### PR TITLE
Add helper classes to clone and read from event data

### DIFF
--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/Event.java
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/Event.java
@@ -11,6 +11,8 @@
 
 package com.adobe.marketing.mobile;
 
+import com.adobe.marketing.mobile.utils.ObjectUtils;
+
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
@@ -27,7 +29,7 @@ public final class Event {
 	private EventType   type;
 	private String      pairID;
 	private String      responsePairID;
-	private EventData   data;
+	private Map<String, Object> data;
 	private long        timestamp;
 	private int         eventNumber;
 	// Specifies the properties in the Event and its data that should be used in the hash for EventHistory storage.
@@ -75,7 +77,6 @@ public final class Event {
 			event.uniqueIdentifier = UUID.randomUUID().toString();
 			event.type = type;
 			event.source = source;
-			event.data = new EventData();
 			event.responsePairID = UUID.randomUUID().toString();
 			event.eventNumber = 0;
 			event.mask = mask;
@@ -134,10 +135,9 @@ public final class Event {
 			throwIfAlreadyBuilt();
 
 			try {
-				event.data = EventData.fromObjectMap(data);
+				event.data = (Map<String, Object>)ObjectUtils.deepClone(data);
 			} catch (final Exception e) {
 				Log.warning("EventBuilder", "Event data couldn't be serialized, empty data was set instead %s", e);
-				event.data = new EventData();
 			}
 
 			return this;
@@ -157,6 +157,10 @@ public final class Event {
 				return null;
 			}
 
+			if (event.data == null) {
+				event.data = new HashMap<>();
+			}
+
 			if (event.timestamp == 0) {
 				event.timestamp = System.currentTimeMillis();
 			}
@@ -173,7 +177,12 @@ public final class Event {
 		 */
 		Builder setData(final EventData data) {
 			throwIfAlreadyBuilt();
-			event.data = data;
+			// Todo - Remove this method once all EventData usage is removed from Core.
+			try {
+				event.data = (Map<String, Object>)ObjectUtils.deepClone(data.toObjectMap());
+			} catch (Exception ex) {
+				Log.error("Error", ex.toString());
+			}
 			return this;
 		}
 
@@ -321,13 +330,13 @@ public final class Event {
 	 */
 	public Map<String, Object> getEventData() {
 		try {
-			return data.toObjectMap();
+			return (Map<String, Object>) ObjectUtils.deepClone(data);
 		} catch (final Exception e) {
 			Log.warning("EventBuilder", "An error occurred while retrieving the event data for %s and %s, %s", type.getName(),
 						source.getName(), e);
 		}
 
-		return null;
+		return new HashMap<>();
 	}
 
 	/**
@@ -354,8 +363,15 @@ public final class Event {
 	/**
 	 * @return event parameters
 	 */
+	@Deprecated
 	EventData getData() {
-		return data;
+		// Todo - Remove this method once all EventData usage is removed from Core.
+		try {
+			return EventData.fromObjectMap((Map<String, Object>)ObjectUtils.deepClone(data));
+		} catch (Exception ex) {
+			Log.error("Error", ex.toString());
+		}
+		return new EventData();
 	}
 
 	/**
@@ -458,9 +474,13 @@ public final class Event {
 		sb.append("    pairId: ").append(pairID).append(COMMA).append(NEWLINE);
 		sb.append("    responsePairId: ").append(responsePairID).append(COMMA).append(NEWLINE);
 		sb.append("    timestamp: ").append(timestamp).append(COMMA).append(NEWLINE);
-		sb.append("    data: ").append(data.prettyString(2)).append(NEWLINE);
-		sb.append("    mask: ").append(Arrays.toString(mask)).append(COMMA).append(NEWLINE);
-		sb.append("    fnv1aHash: ").append(data.toFnv1aHash(mask)).append(NEWLINE);
+		// Todo - Remove this once we completly remove EventData from core.
+		try {
+			EventData data = EventData.fromObjectMap(this.data);
+			sb.append("    data: ").append(data.prettyString(2)).append(NEWLINE);
+			sb.append("    mask: ").append(Arrays.toString(mask)).append(COMMA).append(NEWLINE);
+			sb.append("    fnv1aHash: ").append(data.toFnv1aHash(mask)).append(NEWLINE);
+		} catch (VariantException ex) {}
 		sb.append("}");
 
 		return sb.toString();

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/utils/CloneFailedException.java
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/utils/CloneFailedException.java
@@ -1,0 +1,43 @@
+/*
+  Copyright 2022 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+ */
+
+package com.adobe.marketing.mobile.utils;
+
+/**
+ * Exception thrown by {@link ObjectUtils#deepClone(Object)} to indicate that an
+ * exception occurred during deep clone.
+ */
+public class CloneFailedException extends Exception {
+    /**
+     * Constructor.
+     */
+    public CloneFailedException() {
+        super("Object clone error occurred.");
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param message {@code String} message for the exception
+     */
+    public CloneFailedException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param inner {@code Exception} that caused this exception
+     */
+    public CloneFailedException(final Exception inner) {
+        super(inner);
+    }
+}

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/utils/DataReader.java
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/utils/DataReader.java
@@ -1,0 +1,492 @@
+/*
+  Copyright 2022 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+ */
+
+package com.adobe.marketing.mobile.utils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DataReader {
+
+    private static boolean checkOverflow(Class clazz, Number n) {
+        if (Double.class.equals(clazz)) {
+            return false;
+        } else if (Float.class.equals(clazz)) {
+            if (n instanceof Double) {
+                double valAsDouble = n.doubleValue();
+                return valAsDouble < Float.MIN_VALUE || valAsDouble > Float.MAX_VALUE;
+            }
+            return false;
+        } else if (Long.class.equals(clazz)) {
+            if (n instanceof Double || n instanceof Float) {
+                double valAsDouble = n.doubleValue();
+                return valAsDouble < Long.MIN_VALUE || valAsDouble > Long.MAX_VALUE;
+            }
+            return false;
+        } else if (Integer.class.equals(clazz)) {
+            if (n instanceof Double || n instanceof Float) {
+                double valAsDouble = n.doubleValue();
+                return valAsDouble < Integer.MIN_VALUE || valAsDouble > Integer.MAX_VALUE;
+            } else {
+                long valAsLong = n.longValue();
+                return valAsLong < Integer.MIN_VALUE || valAsLong > Integer.MAX_VALUE;
+            }
+        } else if (Short.class.equals(clazz)) {
+            if (n instanceof Double || n instanceof Float) {
+                double valAsDouble = n.doubleValue();
+                return valAsDouble < Short.MIN_VALUE || valAsDouble > Short.MAX_VALUE;
+            } else {
+                long valAsLong = n.longValue();
+                return valAsLong < Short.MIN_VALUE || valAsLong > Short.MAX_VALUE;
+            }
+        } else if (Byte.class.equals(clazz)) {
+            if (n instanceof Double || n instanceof Float) {
+                double valAsDouble = n.doubleValue();
+                return valAsDouble < Byte.MIN_VALUE || valAsDouble > Byte.MAX_VALUE;
+            } else {
+                long valAsLong = n.longValue();
+                return valAsLong < Byte.MIN_VALUE || valAsLong > Byte.MAX_VALUE;
+            }
+        }
+
+        return false;
+    }
+
+    private static <T> T castObject(Class<T> tClass, Object obj) throws DataReaderException {
+        if (obj == null) {
+            return null;
+        }
+
+        try {
+            if (Number.class.isAssignableFrom(tClass) && obj instanceof Number) {
+                Number objAsNumber = (Number) obj;
+
+                if (DataReader.checkOverflow(tClass, objAsNumber)) {
+                    throw new DataReaderException("Value overflows type "+ tClass);
+                }
+
+                if (Byte.class.equals(tClass)) {
+                    return (T) Byte.valueOf(objAsNumber.byteValue());
+                } else if (Short.class.equals(tClass)) {
+                    return (T) Short.valueOf(objAsNumber.shortValue());
+                } else if (Integer.class.equals(tClass)) {
+                    return (T) Integer.valueOf(objAsNumber.intValue());
+                } else if (Long.class.equals(tClass)) {
+                    return (T) Long.valueOf(objAsNumber.longValue());
+                } else if (Double.class.equals(tClass)) {
+                    return (T) Double.valueOf(objAsNumber.doubleValue());
+                } else if (Float.class.equals(tClass)) {
+                    return (T) Float.valueOf(objAsNumber.floatValue());
+                }
+            } else if (String.class.equals(tClass)) {
+                // Todo :- Check if we should match the behavior with Variant. It has custom logic to
+                //  convert types to string.
+                return (T) obj.toString();
+            } else {
+                return tClass.cast(obj);
+            }
+        } catch (ClassCastException ex) {
+            throw new DataReaderException(ex);
+        }
+
+        return null;
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as a custom object.
+     *
+     * @param <T> Custom type
+     * @param tClass Custom class
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @return {@code T} value associated with {@code key} or null if {@code key} is not present in {@code map}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     * @throws DataReaderException if value is not gettable as a {@code T}
+     */
+    public static <T> T getTypedObject(Class<T> tClass, Map<String, ?> map, String key) throws DataReaderException {
+        if (map == null || key == null) {
+            throw new IllegalArgumentException("Map or key is null");
+        }
+
+        Object value = map.get(key);
+        return castObject(tClass, value);
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as a custom object or returns default value
+     *
+     * @param <T> Custom type
+     * @param tClass Custom class
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @param fallback {@code T} value to return in case of failure. Can be null.
+     * @return {@code T} value associated with {@code key}, or {@code fallback} if value is
+     * not gettable as a {@code T}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     */
+    public static <T> T optTypedObject(Class<T> tClass, Map<String, ?> map, String key, T fallback) {
+        T ret = null;
+        try {
+            ret = getTypedObject(tClass, map, key);
+        } catch (DataReaderException ex) {}
+        return ret != null ? ret : fallback;
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as a {@code Map<String, T>}
+     *
+     * @param <T> Custom type
+     * @param tClass Custom class
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @return {@code Map<String, T>} Map associated with {@code key} or null if {@code key} is not present in {@code map}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     * @throws DataReaderException if value is not gettable as a {@code Map<String,T>}
+     */
+    public static <T> Map<String, T> getTypedMap(Class<T> tClass, Map<String, ?> map, String key) throws DataReaderException {
+        if (map == null || key == null) {
+            throw new IllegalArgumentException("Map or key is null");
+        }
+
+        Object value = map.get(key);
+        if (value == null) {
+            return null;
+        }
+
+        if (!(value instanceof Map)) {
+            throw new DataReaderException("Value is not a map");
+        }
+
+        Map<String, T> ret = new HashMap<>();
+        Map<?, ?> valueAsMap = (Map<?, ?>)value;
+        for (Map.Entry<?, ?> kv : valueAsMap.entrySet()) {
+            String k = kv.getKey().toString();
+            T v = castObject(tClass, kv.getValue());
+            ret.put(k, v);
+        }
+
+        return ret;
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as a {@code Map<String, T>} or returns default value
+     *
+     * @param <T> Custom type
+     * @param tClass Custom class
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @param fallback {@code Map<String, T>} value to return in case of failure. Can be null.
+     * @return {@code Map<String, T>} Map associated with {@code key}, or {@code fallback} if value is
+     * not gettable as a {@code Map<String, T>}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     */
+    public static <T> Map<String, T> optTypedMap(Class<T> tClass, Map<String, ?> map, String key, Map<String, T> fallback) {
+        Map<String, T> ret = null;
+        try {
+            ret = getTypedMap(tClass, map, key);
+        } catch (DataReaderException ex) {}
+        return ret != null ? ret : fallback;
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as a {@code List<T>}
+     *
+     * @param <T> Custom type
+     * @param tClass Custom class
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @return {@code List<T>} List associated with {@code key} or null if {@code key} is not present in {@code map}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     * @throws DataReaderException if value is not gettable as a {@code List<T>}
+     */
+    public static <T> List<T> getTypedList(Class<T> tClass, Map<String, ?> map, String key) throws DataReaderException {
+        if (map == null || key == null) {
+            throw new IllegalArgumentException("Map or key is null");
+        }
+
+        Object value = map.get(key);
+        if (value == null) {
+            return null;
+        }
+
+        if (!(value instanceof Collection)) {
+            throw new DataReaderException("Value is not a collection");
+        }
+
+        Collection<?> valueAsCollection = (Collection<?>) value;
+        List<T> ret = new ArrayList<>();
+        for (Object obj : valueAsCollection) {
+            T objAsT = castObject(tClass, obj);
+            ret.add(objAsT);
+        }
+
+        return ret;
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as a {@code List<T>} or returns default value
+     *
+     * @param <T> Custom type
+     * @param tClass Custom class
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @param fallback {@code List<T>} value to return in case of failure. Can be null.
+     * @return {@code List<T>} List associated with {@code key}, or {@code fallback} if value is
+     * not gettable as a {@code List<T>}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     */
+    public static <T> List<T> optTypedList(Class<T> tClass, Map<String, ?> map, String key, List<T> fallback) {
+        List<T> ret = null;
+        try {
+            ret = getTypedList(tClass, map, key);
+        } catch (DataReaderException ex) {}
+        return ret != null ? ret : fallback;
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as a {@code boolean}
+     *
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @return {@code boolean} value associated with {@code key}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     * @throws DataReaderException if value is not gettable as a {@code boolean} or if {@code key} is not present in {@code map}
+     */
+    public static boolean getBoolean(Map<String, ?> map, String key) throws DataReaderException {
+        Boolean ret = getTypedObject(Boolean.class, map, key);
+        if (ret == null) {
+            throw new DataReaderException("Map contains null value for key");
+        }
+        return ret;
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as a {@code boolean} or returns default value
+     *
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @param fallback {@code boolean} value to return in case of failure. Can be null.
+     * @return {@code boolean} value associated with {@code key}, or {@code fallback} if value is
+     * not gettable as a {@code boolean}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     */
+    public static boolean optBoolean(Map<String, ?> map, String key, boolean fallback) {
+        return optTypedObject(Boolean.class, map, key, fallback);
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as an {@code int}
+     *
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @return {@code int} value associated with {@code key}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     * @throws DataReaderException if value is not gettable as an {@code int} or if {@code key} is not present in {@code map}
+     */
+    public static int getInt(Map<String, ?> map, String key) throws DataReaderException {
+        Integer ret = getTypedObject(Integer.class, map, key);
+        if (ret == null) {
+            throw new DataReaderException("Map contains null value for key");
+        }
+        return ret;
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as an {@code int} or returns default value
+     *
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @param fallback {@code int} value to return in case of failure. Can be null.
+     * @return {@code int} value associated with {@code key}, or {@code fallback} if value is
+     * not gettable as a {@code int}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     */
+    public static int optInt(Map<String, ?> map, String key, int fallback) {
+        return optTypedObject(Integer.class, map, key, fallback);
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as an {@code long}
+     *
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @return {@code long} value associated with {@code key}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     * @throws DataReaderException if value is not gettable as an {@code long} or if {@code key} is not present in {@code map}
+     */
+    public static long getLong(Map<String, ?> map, String key) throws DataReaderException {
+        Long ret = getTypedObject(Long.class, map, key);
+        if (ret == null) {
+            throw new DataReaderException("Map contains null value for key");
+        }
+        return ret;
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as an {@code long} or returns default value
+     *
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @param fallback {@code long} value to return in case of failure. Can be null.
+     * @return {@code long} value associated with {@code key}, or {@code fallback} if value is
+     * not gettable as a {@code long}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     */
+    public static long optLong(Map<String, ?> map, String key, long fallback) {
+        return optTypedObject(Long.class, map, key, fallback);
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as an {@code float}
+     *
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @return {@code float} value associated with {@code key}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     * @throws DataReaderException if value is not gettable as an {@code float} or if {@code key} is not present in {@code map}
+     */
+    public static float getFloat(Map<String, ?> map, String key) throws DataReaderException {
+        Float ret = getTypedObject(Float.class, map, key);
+        if (ret == null) {
+            throw new DataReaderException("Map contains null value for key");
+        }
+        return ret;
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as an {@code float} or returns default value
+     *
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @param fallback {@code float} value to return in case of failure. Can be null.
+     * @return {@code float} value associated with {@code key}, or {@code fallback} if value is
+     * not gettable as a {@code float}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     */
+    public static float optFloat(Map<String, ?> map, String key, float fallback) {
+        return optTypedObject(Float.class, map, key, fallback);
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as an {@code double}
+     *
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @return {@code double} value associated with {@code key}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     * @throws DataReaderException if value is not gettable as an {@code double} or if {@code key} is not present in {@code map}
+     */
+    public static double getDouble(Map<String, ?> map, String key) throws DataReaderException {
+        Double ret = getTypedObject(Double.class, map, key);
+        if (ret == null) {
+            throw new DataReaderException("Map contains null value for key");
+        }
+        return ret;
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as an {@code double} or returns default value
+     *
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @param fallback {@code double} value to return in case of failure. Can be null.
+     * @return {@code double} value associated with {@code key}, or {@code fallback} if value is
+     * not gettable as a {@code double}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     */
+    public static double optDouble(Map<String, ?> map, String key, double fallback) {
+        return optTypedObject(Double.class, map, key, fallback);
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as an {@code String}
+     *
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @return {@code String} value associated with {@code key}  or null if {@code key} is not present in {@code map}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     * @throws DataReaderException if value is not gettable as an {@code String}
+     */
+    public static String getString(Map<String, ?> map, String key) throws DataReaderException {
+        return getTypedObject(String.class, map, key);
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as a {@code String} or returns default value
+     *
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @param fallback {@code String} value to return in case of failure. Can be null.
+     * @return {@code String} value associated with {@code key}, or {@code fallback} if value is
+     * not gettable as a {@code String}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     */
+    public static String optString(Map<String, ?> map, String key, String fallback) {
+        return optTypedObject(String.class, map, key, fallback);
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as a {@code Map<String, String>}
+     *
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @return {@code Map<String, String>} Map associated with {@code key} or null if {@code key} is not present in {@code map}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     * @throws DataReaderException if value is not gettable as a {@code Map<String, String>}
+     */
+    public static Map<String, String> getStringMap(Map<String, ?> map, String key) throws DataReaderException {
+        return getTypedMap(String.class, map, key);
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as a {@code Map<String, String>} or returns default value
+     *
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @param fallback {@code Map<String, String>} value to return in case of failure. Can be null.
+     * @return {@code Map<String, String>} value associated with {@code key}, or {@code fallback} if value is
+     * not gettable as a {@code Map<String, String>}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     */
+    public static Map<String, String> optStringMap(Map<String, ?> map, String key, Map<String, String> fallback) {
+        return optTypedMap(String.class, map, key, fallback);
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as a {@code List<String>}
+     *
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @return {@code List<String>} List associated with {@code key} or null if {@code key} is not present in {@code map}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     * @throws DataReaderException if value is not gettable as a {@code List<String>}
+     */
+    public static List<String> getStringList(Map<String, ?> map, String key) throws DataReaderException {
+        return getTypedList(String.class, map, key);
+    }
+
+    /**
+     * Gets the value for {@code key} from {@code map} as a {@code List<String>} or returns default value
+     *
+     * @param map {@code Map} map to fetch data
+     * @param key {@code String} key to fetch
+     * @param fallback {@code List<String>} value to return in case of failure. Can be null.
+     * @return {@code List<String>} List associated with {@code key}, or {@code fallback} if value is
+     * not gettable as a {@code List<String>}
+     * @throws IllegalArgumentException if {@code map} or {@code key} is null
+     */
+    public static List<String> optStringList(Map<String, ?> map, String key, List<String> fallback) {
+        return optTypedList(String.class, map, key, fallback);
+    }
+}

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/utils/DataReaderException.java
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/utils/DataReaderException.java
@@ -1,0 +1,36 @@
+/*
+  Copyright 2022 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+ */
+
+package com.adobe.marketing.mobile.utils;
+
+/**
+ * Exception thrown by {@link DataReader} to indicate an error occurred
+ * reading object.
+ */
+public class DataReaderException extends Exception {
+    /**
+     * Constructor.
+     *
+     * @param message {@code String} message for the exception
+     */
+    public DataReaderException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param inner {@code Exception} that caused this exception
+     */
+    public DataReaderException(final Exception inner) {
+        super(inner);
+    }
+}

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/utils/ObjectUtils.java
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/utils/ObjectUtils.java
@@ -1,0 +1,98 @@
+/*
+  Copyright 2022 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+ */
+
+package com.adobe.marketing.mobile.utils;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+public class ObjectUtils {
+    private static final int MAX_DEPTH = 256;
+
+    private static final Set<Class<?>> immutableClasses;
+    static {
+        immutableClasses = new HashSet<>();
+        immutableClasses.add(Boolean.class);
+        immutableClasses.add(Byte.class);
+        immutableClasses.add(Short.class);
+        immutableClasses.add(Integer.class);
+        immutableClasses.add(Long.class);
+        immutableClasses.add(Float.class);
+        immutableClasses.add(Double.class);
+        immutableClasses.add(BigDecimal.class);
+        immutableClasses.add(BigInteger.class);
+        immutableClasses.add(Character.class);
+        immutableClasses.add(String.class);
+        immutableClasses.add(UUID.class);
+    }
+
+    /**
+     * Deep clones the object. This method is used for cloning event data and shared states. It
+     * only supports cloning basic types, collections and maps.
+     *
+     * @param obj object to be cloned
+     * @return cloned object
+     * @throws CloneFailedException if object depth exceeds {@value ObjectUtils#MAX_DEPTH} or contains unsupported type.
+     */
+    public static Object deepClone(Object obj) throws CloneFailedException {
+        return deepClone(obj, 0);
+    }
+
+    private static Object deepClone(Object obj, int depth) throws CloneFailedException {
+        if (obj == null) {
+            return null;
+        }
+
+        if (depth > MAX_DEPTH) {
+            throw new CloneFailedException("Max depth reached");
+        }
+
+        if (immutableClasses.contains(obj.getClass())) {
+            return obj;
+        }
+
+        if (obj instanceof Map) {
+            return cloneMap((Map<?, ?>) obj, depth);
+        } else if (obj instanceof Collection) {
+            return cloneCollection((Collection<?>) obj, depth);
+        }else {
+            throw new CloneFailedException("Object is of unsupported type");
+        }
+    }
+
+    private static Map<Object, Object> cloneMap(Map<?, ?> map, int depth) throws CloneFailedException {
+        Map<Object, Object> ret = new HashMap<>();
+        for (Map.Entry<?, ?> kv : map.entrySet()) {
+            Object clonedKey = deepClone(kv.getKey(), depth + 1);
+            Object clonedValue = deepClone(kv.getValue(), depth + 1);
+            if (clonedKey != null) {
+                ret.put(clonedKey, clonedValue);
+            }
+        }
+        return ret;
+    }
+
+    private static Collection<Object> cloneCollection(Collection<?> collection, int depth) throws CloneFailedException {
+        Collection<Object> ret = new ArrayList<>();
+        for (Object element : collection) {
+            Object clonedElement = deepClone(element, depth + 1);
+            ret.add(clonedElement);
+        }
+        return ret;
+    }
+}

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/utils/DataReaderTests.java
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/utils/DataReaderTests.java
@@ -1,0 +1,497 @@
+package com.adobe.marketing.mobile.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+interface CheckedBiConsumer {
+    void accept(Map<String, Object> map, String data) throws Exception;
+}
+
+interface CheckedConsumer {
+    void accept(String data) throws Exception;
+}
+
+
+public class DataReaderTests {
+    final String NULL_KEY_ERROR_MSG = "Map or key is null";
+    final String NULL_VALUE_ERROR_MSG = "Map contains null value for key";
+    final String OVERFLOW_ERROR_MSG = "Value overflows type ";
+    final String MAP_ERROR_MSG = "Value is not a map";
+    final String COLLECTION_ERROR_MSG = "Value is not a collection";
+
+    final double DELTA = 0.000001d;
+
+    Map<String, Object> data = new HashMap<>();{
+        data.put("BOOL_TRUE", Boolean.TRUE);
+        data.put("BOOL_FALSE", Boolean.FALSE);
+
+        data.put("BYTE_MAX", Byte.MAX_VALUE);
+        data.put("BYTE", (byte) 1);
+        data.put("SHORT_MAX", Short.MAX_VALUE);
+        data.put("SHORT", (short) 2);
+        data.put("INT_MAX", Integer.MAX_VALUE);
+        data.put("INT", 3);
+        data.put("LONG_MAX", Long.MAX_VALUE);
+        data.put("LONG", 4L);
+        data.put("FLOAT_MAX", Float.MAX_VALUE);
+        data.put("FLOAT", 5.5F);
+        data.put("DOUBLE_MAX", Double.MAX_VALUE);
+        data.put("DOUBLE", 6.6);
+
+        data.put("STRING", "STRING");
+        data.put("NULL", null);
+        data.put("EMPTY_MAP", new HashMap<>());
+        data.put("EMPTY_LIST", new ArrayList<>());
+
+        data.put("INT_MAP", new HashMap<String, Integer>() {{
+            put("a", 1);
+            put("b", 2);
+        }});
+        data.put("INT_LIST", Arrays.asList(1, 2));
+
+        data.put("STRING_MAP", new HashMap<String, String>() {{
+            put("a", "a");
+            put("b", "b");
+        }});
+        data.put("STRING_LIST", Arrays.asList("a", "b"));
+    }
+
+    void checkIllegalArgumentException(CheckedBiConsumer fn) {
+        Exception ex;
+        ex = assertThrows(IllegalArgumentException.class, () -> fn.accept(null, "key"));
+        assertEquals(NULL_KEY_ERROR_MSG, ex.getMessage());
+
+        ex = assertThrows(IllegalArgumentException.class, () -> fn.accept(data, null));
+        assertEquals(NULL_KEY_ERROR_MSG, ex.getMessage());
+    }
+
+    void checkCastException(CheckedConsumer fn, List<String> keys) {
+        keys.forEach((key) -> {
+            Exception ex = assertThrows(DataReaderException.class, () -> fn.accept(key));
+            if (ex != null && ex.getCause() != null) {
+                assertEquals(ClassCastException.class, ex.getCause().getClass());
+            } else {
+                fail();
+            }
+        });
+    }
+
+    void checkExceptionMessage(CheckedConsumer fn, List<String> keys, String errorMessage) {
+        keys.forEach((key) -> {
+            Exception ex = assertThrows(DataReaderException.class, () -> fn.accept(key));
+            assertEquals(ex.getMessage(), errorMessage);
+        });
+    }
+
+    @Test
+    public void testReadBoolean() throws Exception {
+        assertTrue(DataReader.getBoolean(data, "BOOL_TRUE"));
+        assertFalse(DataReader.getBoolean(data, "BOOL_FALSE"));
+
+        checkIllegalArgumentException(DataReader::getBoolean);
+        checkExceptionMessage((key) -> DataReader.getBoolean(data, key), Arrays.asList("NULL", "INVALID"), NULL_VALUE_ERROR_MSG);
+        checkCastException((key) -> DataReader.getBoolean(data, key), Arrays.asList("FLOAT","BYTE", "INT", "DOUBLE", "LONG", "STRING"));
+    }
+
+    @Test
+    public void testOptBoolean() {
+        assertTrue(DataReader.optBoolean(data, "BOOL_TRUE", false));
+        assertFalse(DataReader.optBoolean(data, "BOOL_FALSE", true));
+
+        checkIllegalArgumentException((m, k) -> DataReader.optBoolean(m, k, true));
+        assertTrue(DataReader.optBoolean(data, "FLOAT", true));
+        assertTrue(DataReader.optBoolean(data, "LONG", true));
+        assertTrue(DataReader.optBoolean(data, "STRING", true));
+        assertTrue(DataReader.optBoolean(data, "NULL", true));
+        assertTrue(DataReader.optBoolean(data, "INVALID", true));
+    }
+
+    @Test
+    public void testReadInt() throws Exception {
+        assertEquals(Integer.MAX_VALUE, DataReader.getInt(data, "INT_MAX"));
+        assertEquals(Short.MAX_VALUE, DataReader.getInt(data, "SHORT_MAX"));
+        assertEquals(Byte.MAX_VALUE, DataReader.getInt(data, "BYTE_MAX"));
+
+        assertEquals(1, DataReader.getInt(data, "BYTE"));
+        assertEquals(2, DataReader.getInt(data, "SHORT"));
+        assertEquals(3, DataReader.getInt(data, "INT"));
+        assertEquals(4, DataReader.getInt(data, "LONG"));
+        assertEquals(5, DataReader.getInt(data, "FLOAT"));
+        assertEquals(6, DataReader.getInt(data, "DOUBLE"));
+
+        checkIllegalArgumentException(DataReader::getInt);
+        checkExceptionMessage((key) -> DataReader.getInt(data, key), Arrays.asList("NULL", "INVALID"), NULL_VALUE_ERROR_MSG);
+
+        String errorMessage = OVERFLOW_ERROR_MSG + Integer.class;
+        checkExceptionMessage((key) -> DataReader.getInt(data, key), Arrays.asList("LONG_MAX", "FLOAT_MAX", "DOUBLE_MAX"), errorMessage);
+
+        checkCastException((key) -> DataReader.getInt(data, key), Arrays.asList("STRING", "STRING_MAP", "STRING_LIST"));
+    }
+
+    @Test
+    public void testOptInt() {
+        assertEquals(Integer.MAX_VALUE, DataReader.optInt(data, "INT_MAX", 123));
+        assertEquals(Short.MAX_VALUE, DataReader.optInt(data, "SHORT_MAX", 123));
+        assertEquals(Byte.MAX_VALUE, DataReader.optInt(data, "BYTE_MAX", 123));
+
+        assertEquals(1, DataReader.optInt(data, "BYTE", 123));
+        assertEquals(2, DataReader.optInt(data, "SHORT", 123));
+        assertEquals(3, DataReader.optInt(data, "INT", 123));
+        assertEquals(4, DataReader.optInt(data, "LONG", 123));
+        assertEquals(5, DataReader.optInt(data, "FLOAT", 123));
+        assertEquals(6, DataReader.optInt(data, "DOUBLE", 123));
+
+        assertEquals(123, DataReader.optInt(data, "LONG_MAX", 123));
+        assertEquals(123, DataReader.optInt(data, "FLOAT_MAX", 123));
+        assertEquals(123, DataReader.optInt(data, "DOUBLE_MAX", 123));
+        assertEquals(123, DataReader.optInt(data, "STRING", 123));
+        assertEquals(123, DataReader.optInt(data, "NULL", 123));
+        assertEquals(123, DataReader.optInt(data, "INVALID", 123));
+
+        checkIllegalArgumentException((m, k) -> DataReader.optInt(m, k, 123));
+    }
+
+    @Test
+    public void testReadLong() throws Exception {
+        assertEquals(Long.MAX_VALUE, DataReader.getLong(data, "LONG_MAX"));
+        assertEquals(Integer.MAX_VALUE, DataReader.getLong(data, "INT_MAX"));
+        assertEquals(Short.MAX_VALUE, DataReader.getLong(data, "SHORT_MAX"));
+        assertEquals(Byte.MAX_VALUE, DataReader.getLong(data, "BYTE_MAX"));
+
+        assertEquals(1, DataReader.getLong(data, "BYTE"));
+        assertEquals(2, DataReader.getLong(data, "SHORT"));
+        assertEquals(3, DataReader.getLong(data, "INT"));
+        assertEquals(4, DataReader.getLong(data, "LONG"));
+        assertEquals(5, DataReader.getLong(data, "FLOAT"));
+        assertEquals(6, DataReader.getLong(data, "DOUBLE"));
+
+        checkIllegalArgumentException(DataReader::getLong);
+        checkExceptionMessage((key) -> DataReader.getLong(data, key), Arrays.asList("NULL", "INVALID"), NULL_VALUE_ERROR_MSG);
+
+        String errorMessage = OVERFLOW_ERROR_MSG + Long.class;
+        checkExceptionMessage((key) -> DataReader.getLong(data, key), Arrays.asList("FLOAT_MAX", "DOUBLE_MAX"), errorMessage);
+
+        checkCastException((key) -> DataReader.getLong(data, key), Arrays.asList("STRING","STRING_MAP", "STRING_LIST"));
+    }
+
+    @Test
+    public void testOptLong() {
+        assertEquals(Long.MAX_VALUE, DataReader.optLong(data, "LONG_MAX", 123));
+        assertEquals(Integer.MAX_VALUE, DataReader.optLong(data, "INT_MAX", 123));
+        assertEquals(Short.MAX_VALUE, DataReader.optLong(data, "SHORT_MAX", 123));
+        assertEquals(Byte.MAX_VALUE, DataReader.optLong(data, "BYTE_MAX", 123));
+
+        assertEquals(1, DataReader.optLong(data, "BYTE", 123));
+        assertEquals(2, DataReader.optLong(data, "SHORT", 123));
+        assertEquals(3, DataReader.optLong(data, "INT", 123));
+        assertEquals(4, DataReader.optLong(data, "LONG", 123));
+        assertEquals(5, DataReader.optLong(data, "FLOAT", 123));
+        assertEquals(6, DataReader.optLong(data, "DOUBLE", 123));
+
+        assertEquals(123, DataReader.optLong(data, "FLOAT_MAX", 123));
+        assertEquals(123, DataReader.optLong(data, "DOUBLE_MAX", 123));
+        assertEquals(123, DataReader.optLong(data, "STRING", 123));
+        assertEquals(123, DataReader.optLong(data, "NULL", 123));
+        assertEquals(123, DataReader.optLong(data, "INVALID", 123));
+
+        checkIllegalArgumentException((m, k) -> DataReader.optLong(m, k, 123));
+    }
+
+    @Test
+    public void testReadFloat() throws Exception {
+        assertEquals(Float.MAX_VALUE, DataReader.getFloat(data, "FLOAT_MAX"), DELTA);
+        assertEquals((float) Long.MAX_VALUE, DataReader.getFloat(data, "LONG_MAX"), DELTA);
+        assertEquals((float) Integer.MAX_VALUE, DataReader.getFloat(data, "INT_MAX"), DELTA);
+        assertEquals((float) Short.MAX_VALUE, DataReader.getFloat(data, "SHORT_MAX"), DELTA);
+        assertEquals((float) Byte.MAX_VALUE, DataReader.getFloat(data, "BYTE_MAX"), DELTA);
+
+        assertEquals(1, DataReader.getFloat(data, "BYTE"), DELTA);
+        assertEquals(2, DataReader.getFloat(data, "SHORT"), DELTA);
+        assertEquals(3, DataReader.getFloat(data, "INT"), DELTA);
+        assertEquals(4, DataReader.getFloat(data, "LONG"), DELTA);
+        assertEquals(5.5, DataReader.getFloat(data, "FLOAT"), DELTA);
+        assertEquals(6.6, DataReader.getFloat(data, "DOUBLE"), DELTA);
+
+        checkIllegalArgumentException(DataReader::getFloat);
+        checkExceptionMessage((key) -> DataReader.getFloat(data, key), Arrays.asList("NULL", "INVALID"), NULL_VALUE_ERROR_MSG);
+
+        String errorMessage = OVERFLOW_ERROR_MSG + Float.class;
+        checkExceptionMessage((key) -> DataReader.getFloat(data, key), Arrays.asList("DOUBLE_MAX"), errorMessage);
+
+        checkCastException((key) -> DataReader.getFloat(data, key), Arrays.asList("STRING","STRING_MAP", "STRING_LIST"));
+    }
+
+    @Test
+    public void testOptFloat() {
+        assertEquals(Float.MAX_VALUE, DataReader.optFloat(data, "FLOAT_MAX", 3.3F), DELTA);
+        assertEquals((float) Long.MAX_VALUE, DataReader.optFloat(data, "LONG_MAX", 3.3F), DELTA);
+        assertEquals((float) Integer.MAX_VALUE, DataReader.optFloat(data, "INT_MAX", 3.3F), DELTA);
+        assertEquals((float) Short.MAX_VALUE, DataReader.optFloat(data, "SHORT_MAX", 3.3F), DELTA);
+        assertEquals((float) Byte.MAX_VALUE, DataReader.optFloat(data, "BYTE_MAX", 3.3F), DELTA);
+
+        assertEquals(1, DataReader.optFloat(data, "BYTE",3.3F), DELTA);
+        assertEquals(2, DataReader.optFloat(data, "SHORT",3.3F), DELTA);
+        assertEquals(3, DataReader.optFloat(data, "INT",3.3F), DELTA);
+        assertEquals(4, DataReader.optFloat(data, "LONG",3.3F), DELTA);
+        assertEquals(5.5, DataReader.optFloat(data, "FLOAT",3.3F), DELTA);
+        assertEquals(6.6, DataReader.optFloat(data, "DOUBLE",3.3F), DELTA);
+
+        assertEquals(3.3, DataReader.optFloat(data, "DOUBLE_MAX",3.3F), DELTA);
+        assertEquals(3.3, DataReader.optFloat(data, "STRING",3.3F), DELTA);
+        assertEquals(3.3, DataReader.optFloat(data, "NULL",3.3F), DELTA);
+        assertEquals(3.3, DataReader.optFloat(data, "INVALID",3.3F), DELTA);
+
+        checkIllegalArgumentException((m, k) -> DataReader.optFloat(m, k, 3.3F));
+    }
+
+    @Test
+    public void testReadDouble() throws Exception {
+        assertEquals(Double.MAX_VALUE, DataReader.getDouble(data, "DOUBLE_MAX"), DELTA);
+        assertEquals(Float.MAX_VALUE, DataReader.getDouble(data, "FLOAT_MAX"), DELTA);
+        assertEquals(Long.MAX_VALUE, DataReader.getDouble(data, "LONG_MAX"), DELTA);
+        assertEquals(Integer.MAX_VALUE, DataReader.getDouble(data, "INT_MAX"), DELTA);
+        assertEquals(Short.MAX_VALUE, DataReader.getDouble(data, "SHORT_MAX"), DELTA);
+        assertEquals(Byte.MAX_VALUE, DataReader.getDouble(data, "BYTE_MAX"), DELTA);
+
+        assertEquals(1, DataReader.getDouble(data, "BYTE"), DELTA);
+        assertEquals(2, DataReader.getDouble(data, "SHORT"), DELTA);
+        assertEquals(3, DataReader.getDouble(data, "INT"), DELTA);
+        assertEquals(4, DataReader.getDouble(data, "LONG"), DELTA);
+        assertEquals(5.5, DataReader.getDouble(data, "FLOAT"), DELTA);
+        assertEquals(6.6, DataReader.getDouble(data, "DOUBLE"), DELTA);
+
+        checkIllegalArgumentException(DataReader::getDouble);
+        checkExceptionMessage((key) -> DataReader.getDouble(data, key), Arrays.asList("NULL", "INVALID"), NULL_VALUE_ERROR_MSG);
+        checkCastException((key) -> DataReader.getDouble(data, key), Arrays.asList("STRING"));
+    }
+
+    @Test
+    public void testOptDouble() {
+        assertEquals(Double.MAX_VALUE, DataReader.optDouble(data, "DOUBLE_MAX", 3.3), DELTA);
+        assertEquals(Float.MAX_VALUE, DataReader.optDouble(data, "FLOAT_MAX", 3.3), DELTA);
+        assertEquals(Long.MAX_VALUE, DataReader.optDouble(data, "LONG_MAX", 3.3), DELTA);
+        assertEquals(Integer.MAX_VALUE, DataReader.optDouble(data, "INT_MAX", 3.3), DELTA);
+        assertEquals(Short.MAX_VALUE, DataReader.optDouble(data, "SHORT_MAX", 3.3), DELTA);
+        assertEquals(Byte.MAX_VALUE, DataReader.optDouble(data, "BYTE_MAX", 3.3), DELTA);
+
+        assertEquals(1, DataReader.optDouble(data, "BYTE", 3.3), DELTA);
+        assertEquals(2, DataReader.optDouble(data, "SHORT", 3.3), DELTA);
+        assertEquals(3, DataReader.optDouble(data, "INT", 3.3), DELTA);
+        assertEquals(4, DataReader.optDouble(data, "LONG", 3.3), DELTA);
+        assertEquals(5.5, DataReader.optDouble(data, "FLOAT", 3.3), DELTA);
+        assertEquals(6.6, DataReader.optDouble(data, "DOUBLE", 3.3), DELTA);
+
+        assertEquals(3.3, DataReader.optDouble(data, "STRING", 3.3), DELTA);
+        assertEquals(3.3, DataReader.optDouble(data, "NULL", 3.3), DELTA);
+        assertEquals(3.3, DataReader.optDouble(data, "INVALID", 3.3), DELTA);
+
+        checkIllegalArgumentException((m, k) -> DataReader.optDouble(m, k, 123));
+    }
+
+    @Test
+    public void testReadString() throws Exception {
+        assertEquals(Long.toString(Long.MAX_VALUE), DataReader.getString(data, "LONG_MAX"));
+        assertEquals(Integer.toString(Integer.MAX_VALUE), DataReader.getString(data, "INT_MAX"));
+        assertEquals(Short.toString(Short.MAX_VALUE), DataReader.getString(data, "SHORT_MAX"));
+        assertEquals(Byte.toString(Byte.MAX_VALUE), DataReader.getString(data, "BYTE_MAX"));
+        assertEquals(Float.toString(Float.MAX_VALUE), DataReader.getString(data, "FLOAT_MAX"));
+        assertEquals(Double.toString(Double.MAX_VALUE), DataReader.getString(data, "DOUBLE_MAX"));
+        assertEquals("STRING", DataReader.getString(data, "STRING"));
+
+        assertEquals("1", DataReader.getString(data, "BYTE"));
+        assertEquals("2", DataReader.getString(data, "SHORT"));
+        assertEquals("3", DataReader.getString(data, "INT"));
+        assertEquals("4", DataReader.getString(data, "LONG"));
+        assertEquals("5.5", DataReader.getString(data, "FLOAT"));
+        assertEquals("6.6", DataReader.getString(data, "DOUBLE"));
+        assertNull(DataReader.getString(data, "NULL"));
+        assertNull(DataReader.getString(data, "INVALID"));
+
+        checkIllegalArgumentException(DataReader::getString);
+    }
+
+    @Test
+    public void testOptString() {
+        assertEquals("1", DataReader.optString(data, "BYTE", "DEFAULT"));
+        assertEquals("2", DataReader.optString(data, "SHORT", "DEFAULT"));
+        assertEquals("3", DataReader.optString(data, "INT", "DEFAULT"));
+        assertEquals("4", DataReader.optString(data, "LONG", "DEFAULT"));
+        assertEquals("5.5", DataReader.optString(data, "FLOAT", "DEFAULT"));
+        assertEquals("6.6", DataReader.optString(data, "DOUBLE", "DEFAULT"));
+        assertEquals("DEFAULT", DataReader.optString(data, "NULL", "DEFAULT"));
+        assertEquals("DEFAULT",DataReader.optString(data, "INVALID", "DEFAULT"));
+
+        checkIllegalArgumentException((m, k) -> DataReader.optString(m, k, "DEFAULT"));
+    }
+
+    @Test
+    public void testGetStringMap() throws Exception {
+        Map<String, String> map;
+        map = DataReader.getStringMap(data, "EMPTY_MAP");
+        assertEquals(map, new HashMap<>());
+
+        map = DataReader.getStringMap(data, "INT_MAP");
+        assertEquals(map,  new HashMap<String, String>() {{
+            put("a", "1");
+            put("b", "2");
+        }});
+
+        map = DataReader.getStringMap(data, "STRING_MAP");
+        assertEquals(map,  new HashMap<String, String>() {{
+            put("a", "a");
+            put("b", "b");
+        }});
+
+        checkExceptionMessage((key) -> DataReader.getStringMap(data, key), Arrays.asList("STRING", "INT", "STRING_LIST"), MAP_ERROR_MSG);
+        checkIllegalArgumentException(DataReader::getStringMap);
+    }
+
+    @Test
+    public void testOptStringMap() {
+        Map<String, String> defaultMap = new HashMap<String, String>() {{
+            put("c", "c");
+            put("d", "d");
+        }};
+
+        Map<String, String> map;
+        map = DataReader.optStringMap(data, "EMPTY_MAP", defaultMap);
+        assertEquals(map, new HashMap<>());
+
+        map = DataReader.optStringMap(data, "INT_MAP", defaultMap);
+        assertEquals(map,  new HashMap<String, String>() {{
+            put("a", "1");
+            put("b", "2");
+        }});
+
+        map = DataReader.optStringMap(data, "STRING_MAP", defaultMap);
+        assertEquals(map,  new HashMap<String, String>() {{
+            put("a", "a");
+            put("b", "b");
+        }});
+
+        map = DataReader.optStringMap(data, "STRING", defaultMap);
+        assertEquals(map, defaultMap);
+        map = DataReader.optStringMap(data, "STRING_LIST", defaultMap);
+        assertEquals(map, defaultMap);
+        checkIllegalArgumentException((m, k) -> DataReader.optStringMap(m, k, defaultMap));
+    }
+
+    @Test
+    public void testGetStringList() throws Exception {
+        List<String> list;
+        list = DataReader.getStringList(data, "EMPTY_LIST");
+        assertEquals(list, new ArrayList<>());
+
+        list = DataReader.getStringList(data, "INT_LIST");
+        assertEquals(list,  Arrays.asList("1", "2"));
+
+        list = DataReader.getStringList(data, "STRING_LIST");
+        assertEquals(list, Arrays.asList("a", "b"));
+
+        checkExceptionMessage((key) -> DataReader.getStringList(data, key), Arrays.asList("STRING", "INT", "STRING_MAP"), COLLECTION_ERROR_MSG);
+        checkIllegalArgumentException(DataReader::getStringList);
+    }
+
+    @Test
+    public void testOptStringList() {
+        List<String> defaultList = Arrays.asList("c", "d");
+        List<String> list;
+        list = DataReader.optStringList(data, "EMPTY_LIST", defaultList);
+        assertEquals(list, new ArrayList<>());
+
+        list = DataReader.optStringList(data, "INT_LIST", defaultList);
+        assertEquals(list,  Arrays.asList("1", "2"));
+
+        list = DataReader.optStringList(data, "STRING_LIST", defaultList);
+        assertEquals(list, Arrays.asList("a", "b"));
+
+        list = DataReader.optStringList(data, "STRING", defaultList);
+        assertEquals(list, defaultList);
+        list = DataReader.optStringList(data, "STRING_MAP", defaultList);
+        assertEquals(list, defaultList);
+
+        checkIllegalArgumentException((m, k) -> DataReader.optStringList(m, k, defaultList));
+    }
+
+    @Test
+    public void testGetTypedMap() throws Exception {
+        Map<String, Integer> map = DataReader.getTypedMap(Integer.class, data, "INT_MAP");
+        assertEquals(map,  new HashMap<String, Integer>() {{
+            put("a", 1);
+            put("b", 2);
+        }});
+
+        checkExceptionMessage((key) -> DataReader.getTypedMap(Integer.class, data, key), Arrays.asList("STRING", "INT", "STRING_LIST"), MAP_ERROR_MSG);
+        checkCastException((key) -> DataReader.getTypedMap(Integer.class, data, key), Arrays.asList("STRING_MAP"));
+        checkIllegalArgumentException((m, k) -> DataReader.getTypedMap(Integer.class, m, k));
+    }
+
+    @Test
+    public void testOptTypedMap() {
+        Map<String, Integer> defaultMap = new HashMap<String, Integer>() {{
+            put("c", 3);
+            put("d", 4);
+        }};
+
+        Map<String, Integer> map = DataReader.optTypedMap(Integer.class, data, "INT_MAP", defaultMap);
+        assertEquals(map,  new HashMap<String, Integer>() {{
+            put("a", 1);
+            put("b", 2);
+        }});
+
+        map = DataReader.optTypedMap(Integer.class, data, "STRING", defaultMap);
+        assertEquals(map, defaultMap);
+        map = DataReader.optTypedMap(Integer.class, data, "STRING_MAP", defaultMap);
+        assertEquals(map, defaultMap);
+
+        checkIllegalArgumentException((m, k) -> DataReader.getTypedMap(Integer.class, m, k));
+    }
+
+    @Test
+    public void testGetTypedList() throws Exception {
+        List<Integer> list = DataReader.getTypedList(Integer.class, data, "INT_LIST");
+        assertEquals(list,  Arrays.asList(1, 2));
+
+        checkExceptionMessage((key) -> DataReader.getTypedList(Integer.class, data, key), Arrays.asList("STRING", "INT", "STRING_MAP"), COLLECTION_ERROR_MSG);
+        checkCastException((key) -> DataReader.getTypedList(Integer.class, data, key), Arrays.asList("STRING_LIST"));
+        checkIllegalArgumentException((m, k) -> DataReader.getTypedList(Integer.class, m, k));
+    }
+
+    @Test
+    public void testOptTypedList() {
+        List<Integer> defaultList = Arrays.asList(3, 4);
+
+        List<Integer> list;
+        list = DataReader.optTypedList(Integer.class, data, "INT_LIST", defaultList);
+        assertEquals(list,  Arrays.asList(1, 2));
+
+        list = DataReader.optTypedList(Integer.class, data, "STRING", defaultList);
+        assertEquals(list,  defaultList);
+        list = DataReader.optTypedList(Integer.class, data, "STRING_LIST", defaultList);
+        assertEquals(list,  defaultList);
+        checkIllegalArgumentException((m, k) -> DataReader.optTypedList(Integer.class, m, k, defaultList));
+    }
+
+    @Test
+    public void testReadNestedValue() throws Exception {
+        Map<String, Integer> map = DataReader.getTypedMap(Integer.class, data, "INT_MAP");
+        int value = DataReader.getInt(map, "a");
+        assertEquals(value, 1);
+
+        Map<String, String> map1 = DataReader.getStringMap(data, "STRING_MAP");
+        String value1 = DataReader.getString(map1, "a");
+        assertEquals(value1, "a");
+    }
+}

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/utils/ObjectUtilsTests.java
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/utils/ObjectUtilsTests.java
@@ -1,0 +1,142 @@
+/*
+  Copyright 2022 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+ */
+
+package com.adobe.marketing.mobile.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.UUID;
+
+public class ObjectUtilsTests {
+    @Test
+    public void testCloneBasicTypes() throws CloneFailedException {
+        Boolean bool = (Boolean) ObjectUtils.deepClone(true);
+        assertTrue(bool);
+
+        byte b = 100;
+        assertEquals(ObjectUtils.deepClone(b), b);
+
+        short s = 1000;
+        assertEquals(ObjectUtils.deepClone(s), s);
+
+        int i = 10000;
+        assertEquals(ObjectUtils.deepClone(i), i);
+
+        long l = 100000L;
+        assertEquals(ObjectUtils.deepClone(l), l);
+
+        float f = 1.1F;
+        assertEquals((float) ObjectUtils.deepClone(f), f, 0.0000001);
+
+        double d = 1.1e10D;
+        assertEquals((double) ObjectUtils.deepClone(d), d, 0.0000001);
+
+        BigDecimal bd = (BigDecimal) ObjectUtils.deepClone((BigDecimal.TEN));
+        assertEquals(bd , BigDecimal.TEN);
+
+        BigInteger bi = (BigInteger) ObjectUtils.deepClone((BigInteger.TEN));
+        assertEquals(bi , BigInteger.TEN);
+
+        char c = 'a';
+        assertEquals(ObjectUtils.deepClone(c), c);
+
+        String str = "hello";
+        assertEquals(ObjectUtils.deepClone(str) , str);
+
+        UUID uuid = UUID.randomUUID();
+        UUID clonedUuid = (UUID) ObjectUtils.deepClone(uuid);
+        assertEquals(uuid , clonedUuid);
+    }
+
+    @Test
+    public void testCloneMap() throws CloneFailedException {
+        Map<String, Object> map = new HashMap<>();
+        map.put("integer", 1);
+        map.put("float", 1f);
+        map.put("double", 1d);
+        map.put("string", "hello");
+
+        Map<?, ?> clonedMap = (Map<?, ?>) ObjectUtils.deepClone(map);
+        assertEquals(map, clonedMap);
+    }
+
+    @Test
+    public void testCloneList() throws CloneFailedException {
+        List<Object> list = new LinkedList<>();
+        list.add(1);
+        list.add(1f);
+        list.add(1d);
+        list.add("hello");
+
+        List<?> clonedList = (List<?>) ObjectUtils.deepClone(list);
+        assertEquals(list, clonedList);
+    }
+
+    @Test
+    public void testCloneNestedObject() throws CloneFailedException {
+        Map<String, Object> map = new TreeMap<>();
+        map.put("integer", 1);
+        map.put("float", 1f);
+        map.put("double", 1d);
+        map.put("string", "hello");
+
+        List<Object> list = new LinkedList<>();
+        list.add(1);
+        list.add(1f);
+        list.add(1d);
+        list.add("hello");
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("map", map);
+        data.put("list", list);
+        data.put("string", "top level");
+        data.put("uuid", UUID.randomUUID());
+        data.put("null", null);
+
+        Map<?,?> clonedData = (Map<?,?>) ObjectUtils.deepClone(data);
+        assertEquals(data, clonedData);
+    }
+
+    @Test
+    public void testCloneFailUnsupportedTypes() {
+        class Data {}
+
+        Exception ex = assertThrows(
+                CloneFailedException.class,
+                () -> ObjectUtils.deepClone(new Data()));
+
+        assertEquals(ex.getMessage(), "Object is of unsupported type");
+    }
+
+    @Test
+    public void testCloneFailCircularReference() {
+        List<Object> list = new ArrayList<>();
+        list.add(list);
+
+        Exception ex = assertThrows(
+                CloneFailedException.class,
+                () -> ObjectUtils.deepClone(list));
+
+        assertEquals(ex.getMessage(), "Max depth reached");
+    }
+}


### PR DESCRIPTION
## Description

- Added ObjectUtils to deep clone object. Core will use this helper to return clone of event data and shared states. 
- Added  DataReader utility class to read values from map in type safe way. 

## Motivation and Context

EventData and Variant classes are currently used by core to clone event data. These classes are not public and are used only by internal extensions. Using these helpers instead will allow us to remove all Variant related classes from Core. 
