### PR TITLE
Add javadoc and lint support for Kotlin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ jobs:
       # Checkout the code as the first step.
       - checkout
       - run:
+          name: check-format
+          command: make check-format
+      - run:
           name: assemble-phone-release
           command: make assemble-phone-release
       - run:

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,12 @@ clean:
 checkstyle:
 		(./code/gradlew -p code/android-core-library checkstyle)
 
+check-format:
+		(./code/gradlew -p code/android-core-library ktlintCheck)
+
+format:
+		(./code/gradlew -p code/android-core-library ktlintFormat)
+
 assemble-phone:
 		(./code/gradlew -p code/android-core-library assemblePhone)
 
@@ -31,7 +37,7 @@ functional-test:
 		(./code/gradlew -p code/android-core-library connectedPhoneDebugAndroidTest)
 
 javadoc:
-		(./code/gradlew -p code/android-core-library Javadoc)
+		(./code/gradlew -p code/android-core-library dokkaJavadoc)
 
 
 build-third-party-extension:

--- a/code/android-core-library/build.gradle
+++ b/code/android-core-library/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'org.jlleitschuh.gradle.ktlint'
+apply plugin: 'org.jetbrains.dokka'
 
 android {
     compileSdkVersion 30

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -11,6 +11,8 @@ buildscript {
         classpath 'com.android.tools.build:gradle:4.0.1'
         classpath "org.jacoco:org.jacoco.core:0.8.7"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:${dokka_version}"
+        classpath "org.jlleitschuh.gradle:ktlint-gradle:9.2.1"
     }
 }
 

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -31,3 +31,4 @@ android.useAndroidX=true
 # incompatible library is used.
 #android.enableJetifier=true
 
+dokka_version = 1.6.20


### PR DESCRIPTION
Added following gradle plugins
dokka - Handles generating Javadocs for mixed Kotlin and Java projects.
ktlint - Kotlin style check. 
