### PR TITLE
Event history database migration

### DIFF
--- a/code/android-core-library/src/androidTest/java/com/adobe/marketing/mobile/internal/eventhub/history/AndroidEventHistoryTests.java
+++ b/code/android-core-library/src/androidTest/java/com/adobe/marketing/mobile/internal/eventhub/history/AndroidEventHistoryTests.java
@@ -15,6 +15,7 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import android.app.Activity;
 import android.content.Context;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -22,8 +23,10 @@ import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.adobe.marketing.mobile.Event;
 import com.adobe.marketing.mobile.TestUtils;
+import com.adobe.marketing.mobile.internal.context.App;
 import com.adobe.marketing.mobile.services.ServiceProvider;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,12 +39,33 @@ import java.util.concurrent.CountDownLatch;
 public class AndroidEventHistoryTests {
     private AndroidEventHistory androidEventHistory;
     private HashMap<String, Object> data;
+    private static final String DATABASE_NAME = "com.adobe.marketing.db.eventhistory";
+
+    private static final AppContextProvider appContextProvider = new AppContextProvider();
+    private static class AppContextProvider implements App.AppContextProvider {
+
+        private Context context;
+
+        public void setContext(Context context) {
+            this.context = context;
+        }
+
+        @Override
+        public Context getAppContext() {
+            return this.context;
+        }
+
+        @Override
+        public Activity getCurrentActivity() {
+            return null;
+        }
+    }
 
     @Before
     public void beforeEach() {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-        ServiceProvider.getInstance().setContext(context);
-        TestUtils.deleteAllFilesInCacheDir(context);
+        appContextProvider.setContext(context);
+        App.getInstance().initializeApp(appContextProvider);
 
         try {
             androidEventHistory = new AndroidEventHistory();
@@ -54,6 +78,11 @@ public class AndroidEventHistoryTests {
                 put("key", "value");
             }
         };
+    }
+
+    @After
+    public void cleanup() {
+        appContextProvider.getAppContext().getDatabasePath(DATABASE_NAME).delete();
     }
 
     @Test

--- a/code/android-core-library/src/androidTest/java/com/adobe/marketing/mobile/internal/utility/SQLiteDatabaseHelperTests.java
+++ b/code/android-core-library/src/androidTest/java/com/adobe/marketing/mobile/internal/utility/SQLiteDatabaseHelperTests.java
@@ -48,7 +48,7 @@ public class SQLiteDatabaseHelperTests {
     @After
     public void dispose() {
         SQLiteDatabaseHelper.clearTable(dbPath, TABLE_NAME);
-        new File(InstrumentationRegistry.getInstrumentation().getContext().getCacheDir(), "test.sqlite");
+        new File(InstrumentationRegistry.getInstrumentation().getContext().getCacheDir(), "test.sqlite").delete();
     }
 
     private void createTable() {

--- a/code/android-core-library/src/androidTest/java/com/adobe/marketing/mobile/services/DataQueueServiceTests.java
+++ b/code/android-core-library/src/androidTest/java/com/adobe/marketing/mobile/services/DataQueueServiceTests.java
@@ -86,7 +86,6 @@ public class DataQueueServiceTests {
 
     @Test
     public void testGetDataQueue_DataQueueExistsInDatabaseDirectory() {
-        new File(context.getCacheDir(), TEST_DATABASE_NAME).delete();
         File databaseFile = context.getDatabasePath(TEST_DATABASE_NAME);
         try {
             databaseFile.createNewFile();

--- a/code/android-core-library/src/androidTest/java/com/adobe/marketing/mobile/utility/FileUtilTests.kt
+++ b/code/android-core-library/src/androidTest/java/com/adobe/marketing/mobile/utility/FileUtilTests.kt
@@ -42,11 +42,6 @@ class FileUtilTests {
     }
 
     @Test
-    fun testRemoveRelativePath_NullPath() {
-        assertNull(FileUtil.removeRelativePath(null))
-    }
-
-    @Test
     fun testRemoveRelativePath_RelativePathBackslashClearnedUp() {
         assertEquals(FileUtil.removeRelativePath("/mydatabase\\..\\..\\database1"), "mydatabase_database1")
     }
@@ -68,7 +63,6 @@ class FileUtilTests {
 
     @Test
     fun testOpenOrMigrateDatabase_DatabaseNameIsNullOrEmpty() {
-        assertNull(FileUtil.openOrMigrateDatabase(null, context))
         assertNull(FileUtil.openOrMigrateDatabase("", context))
     }
 

--- a/code/android-core-library/src/androidTest/java/com/adobe/marketing/mobile/utility/FileUtilTests.kt
+++ b/code/android-core-library/src/androidTest/java/com/adobe/marketing/mobile/utility/FileUtilTests.kt
@@ -62,32 +62,14 @@ class FileUtilTests {
     }
 
     @Test
-    fun testOpenOrMigrateDatabase_DatabaseNameIsNullOrEmpty() {
-        assertNull(FileUtil.openOrMigrateDatabase("", context))
-    }
-
-    @Test
-    fun testOpenOrMigrateDatabase_ContextIsNull() {
-        assertNull(FileUtil.openOrMigrateDatabase(testDatabaseName, null))
+    fun testOpenOrCreateDatabase_DatabaseNameIsNullOrEmpty() {
+        assertNull(FileUtil.openOrCreateDatabase("", context))
     }
 
     @Test
     fun testOpenOrMigrateDatabase_DatabaseDoesNotExist() {
-        assertNotNull(FileUtil.openOrMigrateDatabase(testDatabaseName, context))
+        assertNotNull(FileUtil.openOrCreateDatabase(testDatabaseName, context))
         assertTrue(context.getDatabasePath(testDatabaseName).exists())
-    }
-
-    @Test
-    fun testOpenOrMigrateDatabase_DatabaseFromCacheDir() {
-        val file = File(context.cacheDir, testDatabaseName)
-        try {
-            file.createNewFile()
-            assertTrue(File(context.cacheDir, testDatabaseName).exists())
-            val database = FileUtil.openOrMigrateDatabase(testDatabaseName, context)
-            assertNotNull(database)
-            assertTrue(context.getDatabasePath(testDatabaseName).exists())
-            assertFalse(File(context.cacheDir, testDatabaseName).exists())
-        } catch (e: Exception) {}
     }
 
     @Test
@@ -95,9 +77,24 @@ class FileUtilTests {
         val file = context.getDatabasePath(testDatabaseName)
         try {
             file.createNewFile()
-            val database = FileUtil.openOrMigrateDatabase(testDatabaseName, context)
+            val database = FileUtil.openOrCreateDatabase(testDatabaseName, context)
+            assertNotNull(database)
+        } catch (e: Exception) {}
+    }
+
+    @Test
+    fun testMigrateAndODeleteOldDatabase() {
+        val file = File(context.cacheDir, testDatabaseName)
+        try {
+            file.createNewFile()
+            assertTrue(File(context.cacheDir, testDatabaseName).exists())
+            val database = FileUtil.openOrCreateDatabase(testDatabaseName, context)
+            if (database != null) {
+                FileUtil.migrateAndDeleteOldDatabase(database)
+            }
             assertNotNull(database)
             assertTrue(context.getDatabasePath(testDatabaseName).exists())
+            assertFalse(File(context.cacheDir, testDatabaseName).exists())
         } catch (e: Exception) {}
     }
 }

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/eventhub/history/AndroidEventHistoryDatabase.java
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/eventhub/history/AndroidEventHistoryDatabase.java
@@ -18,8 +18,10 @@ import android.database.sqlite.SQLiteDatabase;
 
 import com.adobe.marketing.mobile.LoggingMode;
 import com.adobe.marketing.mobile.MobileCore;
+import com.adobe.marketing.mobile.internal.context.App;
 import com.adobe.marketing.mobile.internal.utility.SQLiteDatabaseHelper;
 import com.adobe.marketing.mobile.services.ServiceProvider;
+import com.adobe.marketing.mobile.services.utility.FileUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -46,12 +48,8 @@ class AndroidEventHistoryDatabase implements EventHistoryDatabase {
      */
     AndroidEventHistoryDatabase() throws EventHistoryDatabaseCreationException {
         try {
-            //TODO: we will create a utility method: Context.getDatabasePath(), we need to  refactor the following code after that.
-            final File applicationCacheDir = ServiceProvider.getInstance().getDeviceInfoService().getApplicationCacheDir();
-            if (applicationCacheDir != null) {
-                final String cacheDirCanonicalPath = applicationCacheDir.getCanonicalPath();
-                databaseFile = new File(cacheDirCanonicalPath + "/" + DATABASE_NAME);
-            }
+            //TODO: add functional tests for testing DB migration
+            databaseFile = FileUtil.openOrMigrateDatabase(DATABASE_NAME, App.getInstance().getAppContext());
             final String tableCreationQuery = "CREATE TABLE IF NOT EXISTS " + TABLE_NAME +
                     " (eventHash INTEGER, timestamp INTEGER);";
 

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/utility/SQLiteDatabaseHelper.java
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/utility/SQLiteDatabaseHelper.java
@@ -13,7 +13,9 @@ package com.adobe.marketing.mobile.internal.utility;
 
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteDoneException;
 import android.database.sqlite.SQLiteException;
+import android.database.sqlite.SQLiteStatement;
 
 import com.adobe.marketing.mobile.LoggingMode;
 import com.adobe.marketing.mobile.MobileCore;
@@ -59,31 +61,21 @@ public class SQLiteDatabaseHelper {
      * @return number of rows in Table @tableName.
      */
     public static int getTableSize(final String dbPath, final String tableName) {
-        final String tableSizeQuery = "Select Count (*) from " + tableName;
         SQLiteDatabase database = null;
         Cursor cursor = null;
 
         try {
             database = openDatabase(dbPath, DatabaseOpenMode.READ_ONLY);
-            cursor = database.rawQuery(tableSizeQuery, null);
-
-            if (cursor.getCount() > 0 && cursor.moveToFirst()) {
-                return cursor.getInt(0);
-            } else {
-                MobileCore.log(LoggingMode.DEBUG, LOG_PREFIX,
-                        String.format("getTableSize - Error in querying table(%s) size. Returning 0.", tableName));
-                return 0;
-            }
+            SQLiteStatement selectStatement = database.compileStatement(
+                    "Select Count (*) from " + tableName
+            );
+            return (int)selectStatement.simpleQueryForLong();
         } catch (final SQLiteException e) {
             MobileCore.log(LoggingMode.WARNING, LOG_PREFIX,
                     String.format("getTableSize - Error in querying table(%s) size. Returning 0. Error: (%s)", tableName,
                             e.getMessage()));
             return 0;
         } finally {
-            if (cursor != null) {
-                cursor.close();
-            }
-
             closeDatabase(database);
         }
     }

--- a/code/android-core-library/src/phone/java/com/adobe/marketing/mobile/services/DataQueueService.java
+++ b/code/android-core-library/src/phone/java/com/adobe/marketing/mobile/services/DataQueueService.java
@@ -49,7 +49,7 @@ class DataQueueService implements DataQueuing {
 				dataQueue = dataQueueCache.get(databaseName);
 
 				if (dataQueue == null) {
-					final File databaseDirDataQueue = FileUtil.openOrMigrateDatabase(
+					final File databaseDirDataQueue = FileUtil.openOrCreateDatabase(
 							databaseName,
 							ServiceProvider.getInstance().getApplicationContext()
 					);
@@ -57,6 +57,8 @@ class DataQueueService implements DataQueuing {
 					if(databaseDirDataQueue == null){
 						return null;
 					}
+
+					FileUtil.migrateAndDeleteOldDatabase(databaseDirDataQueue);
 					dataQueue = new SQLiteDataQueue(databaseDirDataQueue.getPath());
 					dataQueueCache.put(databaseName, dataQueue);
 				}

--- a/code/android-core-library/src/phone/java/com/adobe/marketing/mobile/services/DataQueueService.java
+++ b/code/android-core-library/src/phone/java/com/adobe/marketing/mobile/services/DataQueueService.java
@@ -50,7 +50,7 @@ class DataQueueService implements DataQueuing {
 
 				if (dataQueue == null) {
 					final File databaseDirDataQueue = FileUtil.openOrMigrateDatabase(
-							null,
+							databaseName,
 							ServiceProvider.getInstance().getApplicationContext()
 					);
 

--- a/code/android-core-library/src/phone/java/com/adobe/marketing/mobile/services/utility/FileUtil.kt
+++ b/code/android-core-library/src/phone/java/com/adobe/marketing/mobile/services/utility/FileUtil.kt
@@ -29,8 +29,8 @@ internal object FileUtil {
      * @return file name without relative path
      */
     @JvmStatic
-    fun removeRelativePath(filePath: String?): String? {
-        return if (filePath.isNullOrBlank()) {
+    fun removeRelativePath(filePath: String): String {
+        return if (filePath.isBlank()) {
             filePath
         } else {
             var result = filePath.replace("\\.[/\\\\]".toRegex(), "\\.")
@@ -50,12 +50,12 @@ internal object FileUtil {
      * @return `File` representing the database in [Context.getDatabasePath]`
      */
     @JvmStatic
-    fun openOrMigrateDatabase(databaseName: String?, appContext: Context?): File? {
-        if (databaseName.isNullOrBlank()) {
+    fun openOrMigrateDatabase(databaseName: String, appContext: Context?): File? {
+        if (databaseName.isBlank()) {
             MobileCore.log(
                 LoggingMode.WARNING,
                 LOG_TAG,
-                "Failed to create database, database name is null"
+                "Failed to create database, database name is empty"
             )
             return null
         }
@@ -71,7 +71,7 @@ internal object FileUtil {
             return null
         }
         val cleanedDatabaseName = removeRelativePath(databaseName)
-        if (cleanedDatabaseName.isNullOrBlank()) {
+        if (cleanedDatabaseName.isBlank()) {
             MobileCore.log(
                 LoggingMode.WARNING,
                 LOG_TAG,


### PR DESCRIPTION
Migrating Android Event History Database to use path returned by `getDatabasePath()` instead of cache directory

## Description
1. Moved database migration function to common `FileUtil` class.
2. Added tests for new utility method
3. Changed table size raw query to prepared statement. It's not recommended to use prepared statement for `SELECT` query which return cursor, retaining it as is.
4. Changed AndroidEventHistoryDatabase to use new utility method to open or mirgate database

## Related Issue

#66 

## Motivation and Context

Database is migrated from cache directory because of Android 12 app hibernation changes which can clear app's cache folder when user doesn't interact with app for few months.

## How Has This Been Tested?

Need to add functional tests for testing `AndroidEventHistoryDatabase` https://github.com/adobe/aepsdk-core-android/issues/100

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
