### PR TITLE
Fix bundled rules extraction logic

### DIFF
--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationRulesManager.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationRulesManager.kt
@@ -44,8 +44,8 @@ internal class ConfigurationRulesManager(
         internal const val RULES_CACHE_FOLDER = "configRules"
         internal const val RULES_JSON_FILE_NAME = "rules.json"
         internal const val BUNDLED_RULES_FILE_NAME = "ADBMobileConfig-rules.zip"
-        internal const val BUNDLED_RULES_DIR = "ADBMobileConfig-rules"
-        private const val ADOBE_CACHE_DIR = "adbdownloadcache"
+        internal const val BUNDLED_RULES_DIR = "bundledRules"
+        internal const val ADOBE_CACHE_DIR = "adbdownloadcache"
     }
 
     private val configDataStore: NamedCollection? =
@@ -151,7 +151,11 @@ internal class ConfigurationRulesManager(
             return false
         }
 
-        val cacheDir = File(applicationCacheDir, ADOBE_CACHE_DIR)
+        // Represents the directory where bundled rules will be cached for reading and extracting.
+        val cacheDir = File(
+            applicationCacheDir,
+            ADOBE_CACHE_DIR + File.separator + RULES_CACHE_FOLDER + File.separator + BUNDLED_RULES_DIR
+        )
 
         MobileCore.log(LoggingMode.VERBOSE, LOG_TAG, "Cache dir is: $cacheDir")
         if (!cacheDir.exists() && !cacheDir.mkdirs()) {
@@ -202,7 +206,7 @@ internal class ConfigurationRulesManager(
             "$LOG_TAG - Applying bundled rules."
         )
 
-        return replaceRules(File(cacheDir.path + File.separator + BUNDLED_RULES_DIR), api)
+        return replaceRules(cacheDir, api)
     }
 
     /**
@@ -218,7 +222,7 @@ internal class ConfigurationRulesManager(
             MobileCore.log(
                 LoggingMode.VERBOSE,
                 ConfigurationExtension.TAG,
-                "$LOG_TAG - Invalid rules directory: $rulesDirectory. Cannot apply cached rules"
+                "$LOG_TAG - Invalid rules directory: $rulesDirectory. Cannot apply rules"
             )
             return false
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

[Problem]
Currently bundled rules are extracted to `adbdownloadcache` but the logic incorectly assumes that they are present in a sub-directory structure `adbdownloadcache/ADB-MobileConfigRules` resuting in the bundled rules application logic to fail.

[Fix]
Fix the directory structure to use the correct location. Use `adbdownloadcache/configRules/bundledRules` to be the location where the bundledRules are extracted. This will ensure consistancy with the location where cached rules are downloaded extracted.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
