### PR TITLE
Bug fix to reprocess events when `readyToProcess` returns false

### DIFF
--- a/code/android-core-library/src/androidTest/java/com/adobe/marketing/mobile/util/SerialWorkDispatcherTests.kt
+++ b/code/android-core-library/src/androidTest/java/com/adobe/marketing/mobile/util/SerialWorkDispatcherTests.kt
@@ -35,6 +35,7 @@ class SerialWorkDispatcherTests {
         Thread.sleep(lag)
         processedItems.add(it)
         workCompletionLatch.countDown()
+        true
     }
 
     private val serialWorkDispatcher: SerialWorkDispatcher<Int> =

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/eventhub/EventHub.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/eventhub/EventHub.kt
@@ -126,6 +126,7 @@ internal class EventHub(val eventHistory: EventHistory?) {
                     }
                 }
             }
+            true
         }
 
     /**

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/eventhub/ExtensionContainer.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/eventhub/ExtensionContainer.kt
@@ -78,7 +78,7 @@ internal class ExtensionContainer constructor(
     private val dispatchJob: SerialWorkDispatcher.WorkHandler<Event> =
         SerialWorkDispatcher.WorkHandler { event ->
             if (extension?.readyForEvent(event) != true) {
-                return@WorkHandler
+                return@WorkHandler false
             }
 
             eventListeners.forEach {
@@ -88,6 +88,7 @@ internal class ExtensionContainer constructor(
             }
 
             lastProcessedEvent = event
+            return@WorkHandler true
         }
 
     val eventProcessor: SerialWorkDispatcher<Event> =

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/SerialWorkDispatcher.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/SerialWorkDispatcher.kt
@@ -66,9 +66,6 @@ open class SerialWorkDispatcher<T>(private val name: String, private val workHan
     /**
      * Represents the functional interface that is responsible for doing the desired work on each item of the [workQueue].
      * [WorkHandler.doWork] is called from the background worker thread that the [SerialWorkDispatcher] maintains.
-     * If [WorkHandler.doWork] returns false after processing an item, the [SerialWorkDispatcher] stops processing the work queue without removing the item. It restarts when
-     * [resume] is called or a new item is enqueued.
-     * If [WorkHandler.doWork] returns true after processing an item, it removes it from work queue and continues processing other queued items.
      */
     fun interface WorkHandler<W> {
         /**
@@ -76,6 +73,9 @@ open class SerialWorkDispatcher<T>(private val name: String, private val workHan
          *
          * @param item  the work item which is dispatched for processing.
          * @return [Boolean] A boolean variable denoting whether the [item] has completed processing.
+         * If [WorkHandler.doWork] returns false after processing an item, the [SerialWorkDispatcher] stops processing the work queue without removing the item. It restarts when
+         * [resume] is called or a new item is enqueued.
+         * If [WorkHandler.doWork] returns true after processing an item, it removes it from work queue and continues processing other queued items.
          */
         fun doWork(item: W): Boolean
     }

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/SerialWorkDispatcher.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/SerialWorkDispatcher.kt
@@ -66,18 +66,22 @@ open class SerialWorkDispatcher<T>(private val name: String, private val workHan
     /**
      * Represents the functional interface that is responsible for doing the desired work on each item of the [workQueue].
      * [WorkHandler.doWork] is called from the background worker thread that the [SerialWorkDispatcher] maintains.
+     * If [WorkHandler.doWork] returns false after processing an item, the [SerialWorkDispatcher] stops processing the work queue without removing the item. It restarts when
+     * [resume] is called or a new item is enqueued.
+     * If [WorkHandler.doWork] returns true after processing an item, it removes it from work queue and continues processing other queued items.
      */
     fun interface WorkHandler<W> {
         /**
          * Handles processing on [item]
          *
-         * @param item  the work item on which is dispatched for processing.
+         * @param item  the work item which is dispatched for processing.
+         * @return [Boolean] A boolean variable denoting whether the [item] has completed processing.
          */
-        fun doWork(item: W)
+        fun doWork(item: W): Boolean
     }
 
     /**
-     * The [Executor] to which work is submitted for sequencing.
+     * The executor to which work is submitted for sequencing.
      */
     private var executorService: ExecutorService = Executors.newSingleThreadExecutor()
 
@@ -111,8 +115,6 @@ open class SerialWorkDispatcher<T>(private val name: String, private val workHan
      */
     private val activenessMutex: Any = Any()
 
-    init {
-    }
     /**
      * Enqueues an item to the end of the [workQueue]. Additionally,
      * resumes the queue processing if the [SerialWorkDispatcher] is active
@@ -264,8 +266,17 @@ open class SerialWorkDispatcher<T>(private val name: String, private val workHan
      *
      * @return the work item at the front (earliest queued) of the [workQueue], null if [workQueue] is empty
      */
-    private fun getWorkItem(): T? {
+    private fun removeWorkItem(): T? {
         return workQueue.poll()
+    }
+
+    /**
+     * Peeks the work item at the front (earliest queued) of the [workQueue]
+     *
+     * @return the work item at the front (earliest queued) of the [workQueue], null if [workQueue] is empty
+     */
+    private fun peekWorkItem(): T? {
+        return workQueue.peek()
     }
 
     /**
@@ -319,8 +330,14 @@ open class SerialWorkDispatcher<T>(private val name: String, private val workHan
             // items in the queue to perform work on.
             while (!Thread.interrupted() && state == State.ACTIVE && canWork() && hasWork()) {
                 try {
-                    val workItem = getWorkItem() ?: return
-                    workHandler.doWork(workItem)
+                    val workItem = peekWorkItem() ?: return
+                    if (workHandler.doWork(workItem)) {
+                        // Handler has successfully processed the work item, remove and try processing the next item
+                        removeWorkItem()
+                    } else {
+                        // Work handler cannot process the work item, wait until next item.
+                        break
+                    }
                 } catch (exception: Exception) {
                     Thread.currentThread().interrupt()
                     Log.warning(

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/URLBuilder.java
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/URLBuilder.java
@@ -20,7 +20,7 @@ import java.util.Map;
 /**
  * A class providing a better way to construct a url.
  */
-class URLBuilder {
+public class URLBuilder {
 
 	public enum EncodeType {
 		NONE(1),

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/internal/eventhub/EventHubTests.kt
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/internal/eventhub/EventHubTests.kt
@@ -1004,6 +1004,9 @@ internal class EventHubTests {
         eventHub.start()
         eventHub.dispatch(event1)
         eventHub.dispatch(event2)
+        // Wait for events to get processed
+        val latch = CountDownLatch(1)
+        latch.await(500, TimeUnit.MILLISECONDS)
 
         val state1: MutableMap<String, Any?> = mutableMapOf("One" to 1)
         eventHub.createSharedState(
@@ -1043,6 +1046,9 @@ internal class EventHubTests {
         eventHub.start()
         eventHub.dispatch(event1)
         eventHub.dispatch(event2)
+        // Wait for events to get processed
+        val latch = CountDownLatch(1)
+        latch.await(500, TimeUnit.MILLISECONDS)
 
         val state1: MutableMap<String, Any?> = mutableMapOf("One" to 1)
         eventHub.createSharedState(
@@ -1083,6 +1089,9 @@ internal class EventHubTests {
         eventHub.dispatch(event1)
         eventHub.dispatch(event2)
         eventHub.dispatch(event3)
+        // Wait for events to get processed
+        val latch = CountDownLatch(1)
+        latch.await(500, TimeUnit.MILLISECONDS)
 
         val state1: MutableMap<String, Any?> = mutableMapOf("One" to 1)
         eventHub.createSharedState(
@@ -1107,7 +1116,7 @@ internal class EventHubTests {
             TestExtension_Barrier.EXTENSION_NAME
         )
 
-        // event2: Returns pending shared state
+        // event2: Returns state set for event1 as shared state for event2 is pending
         verifySharedState(
             SharedStateType.STANDARD,
             event2,
@@ -1138,6 +1147,10 @@ internal class EventHubTests {
         eventHub.dispatch(event1)
         eventHub.dispatch(event2)
         eventHub.dispatch(event3)
+        // Wait for events to get processed
+        val latch = CountDownLatch(1)
+        latch.await(500, TimeUnit.MILLISECONDS)
+
 
         val state1: MutableMap<String, Any?> = mutableMapOf("One" to 1)
         eventHub.createSharedState(
@@ -1162,7 +1175,7 @@ internal class EventHubTests {
             TestExtension_Barrier.EXTENSION_NAME
         )
 
-        // event2: Returns pending shared state
+        // event2: Returns state set for event1 as shared state for event2 is pending
         verifySharedState(
             SharedStateType.STANDARD,
             event2,
@@ -1172,7 +1185,7 @@ internal class EventHubTests {
             TestExtension_Barrier.EXTENSION_NAME
         )
 
-        // event3: Returns pending shared state as the extension has not processed the event
+        // event3: Returns state set for event1 as event3 has not been processed
         verifySharedState(
             SharedStateType.STANDARD,
             event3,

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/internal/eventhub/EventHubTests.kt
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/internal/eventhub/EventHubTests.kt
@@ -1151,7 +1151,6 @@ internal class EventHubTests {
         val latch = CountDownLatch(1)
         latch.await(500, TimeUnit.MILLISECONDS)
 
-
         val state1: MutableMap<String, Any?> = mutableMapOf("One" to 1)
         eventHub.createSharedState(
             SharedStateType.STANDARD,

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/util/SerialWorkDispatcherJavaCompatTests.java
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/util/SerialWorkDispatcherJavaCompatTests.java
@@ -60,8 +60,9 @@ public class SerialWorkDispatcherJavaCompatTests {
 
     private final SerialWorkDispatcher.WorkHandler<Integer> workHandler = new SerialWorkDispatcher.WorkHandler<Integer>() {
         @Override
-        public void doWork(Integer item) {
+        public boolean doWork(Integer item) {
             javaSerialWorkDispatcher.getProcessedItems().add(item);
+            return true;
         }
     };
 

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/util/SerialWorkDispatcherTests.kt
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/util/SerialWorkDispatcherTests.kt
@@ -60,6 +60,7 @@ class SerialWorkDispatcherTests {
     private val workHandler: SerialWorkDispatcher.WorkHandler<Event> =
         SerialWorkDispatcher.WorkHandler {
             serialWorkDispatcher.processedEvents?.add(it)
+            true
         }
 
     @Mock
@@ -283,6 +284,7 @@ class SerialWorkDispatcherTests {
                     latch.countDown()
                 }
                 Thread.sleep(50)
+                true
             }
 
         val serialDispatcher = SerialWorkDispatcher("", workHandler)


### PR DESCRIPTION
Bug fix to reprocess events when `readyToProcess` returns false
Tests to verify `getSharedState` APIs return correct state with barrier. 
Made URLBuilder utility class public