### PR TITLE
Support 1.x MobileCore initialization

### DIFF
--- a/code/android-core-compatiblity/src/main/java/com/adobe/marketing/mobile/InvalidInitException.java
+++ b/code/android-core-compatiblity/src/main/java/com/adobe/marketing/mobile/InvalidInitException.java
@@ -1,4 +1,0 @@
-package com.adobe.marketing.mobile;
-
-public class InvalidInitException extends Exception {
-}

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/InvalidInitException.java
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/InvalidInitException.java
@@ -1,0 +1,13 @@
+/*
+  Copyright 2022 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+ */
+package com.adobe.marketing.mobile;
+
+public class InvalidInitException extends RuntimeException { }

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/eventhub/EventHub.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/eventhub/EventHub.kt
@@ -216,8 +216,14 @@ internal class EventHub(val eventHistory: EventHistory?) {
     /**
      * `EventHub` will begin processing `Event`s when this API is invoked.
      */
+    @JvmOverloads
     fun start(completion: (() -> Unit)? = null) {
         eventHubExecutor.submit {
+            if (hubStartReceived) {
+                Log.debug(CoreConstants.LOG_TAG, LOG_TAG, "Dropping start call as it was already received")
+                return@submit
+            }
+
             this.hubStartReceived = true
             this.hubStartCallback = completion
 

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/eventhub/EventHub.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/eventhub/EventHub.kt
@@ -184,7 +184,6 @@ internal class EventHub(val eventHistory: EventHistory?) {
 
     init {
         registerExtension(EventHubPlaceholderExtension::class.java)
-        registerExtension(ConfigurationExtension::class.java)
     }
 
     private var _wrapperType = WrapperType.NONE
@@ -299,6 +298,7 @@ internal class EventHub(val eventHistory: EventHistory?) {
      * @param extensionClass The class of extension to register
      * @param completion Invoked when the extension has been registered or failed to register
      */
+    @JvmOverloads
     fun registerExtension(
         extensionClass: Class<out Extension>,
         completion: ((error: EventHubError) -> Unit)? = null

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/eventhub/EventHub.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/eventhub/EventHub.kt
@@ -27,7 +27,6 @@ import com.adobe.marketing.mobile.SharedStateResult
 import com.adobe.marketing.mobile.SharedStateStatus
 import com.adobe.marketing.mobile.WrapperType
 import com.adobe.marketing.mobile.internal.CoreConstants
-import com.adobe.marketing.mobile.internal.configuration.ConfigurationExtension
 import com.adobe.marketing.mobile.internal.eventhub.history.AndroidEventHistory
 import com.adobe.marketing.mobile.internal.eventhub.history.EventHistory
 import com.adobe.marketing.mobile.internal.util.prettify

--- a/code/android-core-library/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
+++ b/code/android-core-library/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
@@ -19,6 +19,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import com.adobe.marketing.mobile.internal.CoreConstants;
+import com.adobe.marketing.mobile.internal.configuration.ConfigurationExtension;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.services.ServiceProvider;
 import com.adobe.marketing.mobile.services.internal.context.App;
@@ -100,7 +101,6 @@ final public class MobileCore {
             return;
         }
 
-
         // AMSDK-8502
         // workaround to prevent a crash happening on Android 8.0/8.1 related to TimeZoneNamesImpl
         // https://issuetracker.google.com/issues/110848122
@@ -116,6 +116,9 @@ final public class MobileCore {
 
         V4ToV5Migration migrationTool = new V4ToV5Migration();
         migrationTool.migrate();
+
+        // Register configuration extension
+        EventHub.Companion.getShared().registerExtension(ConfigurationExtension.class);
     }
 
     /**

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/MobileCoreTests.kt
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/MobileCoreTests.kt
@@ -22,6 +22,7 @@ import org.mockito.Mockito.mock
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.collections.HashMap
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -131,7 +132,7 @@ class MobileCoreTests {
         MockExtension.registrationClosure = { latch.countDown() }
 
         MobileCore.setApplication(mock(Application::class.java))
-        MobileCore.registerExtension(MockExtension::class.java) {}
+        MobileCore.registerExtensions(listOf(MockExtension::class.java)) {}
 
         assertTrue { latch.await(1, TimeUnit.SECONDS) }
     }
@@ -142,9 +143,13 @@ class MobileCoreTests {
         MockExtension.registrationClosure = { latch.countDown() }
         MockExtension2.registrationClosure = { latch.countDown() }
 
+        val extensions: List<Class<out Extension>> = listOf(
+            MockExtension::class.java,
+            MockExtension2::class.java
+        )
+
         MobileCore.setApplication(mock(Application::class.java))
-        MobileCore.registerExtension(MockExtension::class.java) {}
-        MobileCore.registerExtension(MockExtension2::class.java) {}
+        MobileCore.registerExtensions(extensions) {}
 
         assertTrue { latch.await(1, TimeUnit.SECONDS) }
     }
@@ -157,10 +162,14 @@ class MobileCoreTests {
 
         MockExtensionWithSlowInit.initWaitTimeMS = 2000
 
+        val extensions: List<Class<out Extension>> = listOf(
+            MockExtensionWithSlowInit::class.java,
+            MockExtension::class.java,
+            MockExtension2::class.java
+        )
+
         MobileCore.setApplication(mock(Application::class.java))
-        MobileCore.registerExtension(MockExtensionWithSlowInit::class.java) {}
-        MobileCore.registerExtension(MockExtension::class.java) {}
-        MobileCore.registerExtension(MockExtension2::class.java) {}
+        MobileCore.registerExtensions(extensions) {}
 
         assertTrue { latch.await(1, TimeUnit.SECONDS) }
     }
@@ -229,7 +238,7 @@ class MobileCoreTests {
 
     @Test
     fun testRegisterMultipleExtensionsDispatchEventBeforeRegister() {
-        val latch = CountDownLatch(2)
+        val latch = CountDownLatch(3)
         MockExtension.eventReceivedClosure = {
             if (it.name == "test-event") {
                 latch.countDown()
@@ -247,9 +256,11 @@ class MobileCoreTests {
         MobileCore.setApplication(mock(Application::class.java))
         MobileCore.registerExtension(MockExtension::class.java) {}
         MobileCore.registerExtension(MockExtension2::class.java) {}
-        MobileCore.start {}
+        MobileCore.start {
+            latch.countDown()
+        }
 
-        assertTrue { latch.await(10, TimeUnit.SECONDS) }
+        assertTrue { latch.await(1000, TimeUnit.SECONDS) }
     }
 
     @Test
@@ -1036,6 +1047,66 @@ class MobileCoreTests {
         val expectedData = mapOf(
             CoreConstants.EventDataKeys.Analytics.TRACK_STATE to state,
             CoreConstants.EventDataKeys.Analytics.CONTEXT_DATA to contextData,
+        )
+        assertEquals(expectedData, capturedEvents[0].eventData)
+    }
+
+    // Lifecycle methods
+    @Test
+    fun testLifecycleStart() {
+        registerExtension(MockExtension::class.java)
+
+        val latch = CountDownLatch(1)
+        val capturedEvents = mutableListOf<Event>()
+        EventHub.shared.getExtensionContainer(MockExtension::class.java)?.registerEventListener(
+            EventType.GENERIC_LIFECYCLE,
+            EventSource.REQUEST_CONTENT
+        ) {
+            capturedEvents.add(it)
+            latch.countDown()
+        }
+        EventHub.shared.start()
+
+        val contextData = mapOf("testKey" to "testVal")
+
+        // test
+        MobileCore.lifecycleStart(contextData)
+        assertTrue {
+            latch.await(1, TimeUnit.SECONDS)
+        }
+
+        val expectedData = mapOf(
+            CoreConstants.EventDataKeys.Lifecycle.LIFECYCLE_ACTION_KEY to CoreConstants.EventDataKeys.Lifecycle.LIFECYCLE_START,
+            CoreConstants.EventDataKeys.Lifecycle.ADDITIONAL_CONTEXT_DATA to contextData,
+        )
+        assertEquals(expectedData, capturedEvents[0].eventData)
+    }
+
+    @Test
+    fun testLifecyclePause() {
+        registerExtension(MockExtension::class.java)
+
+        val latch = CountDownLatch(1)
+        val capturedEvents = mutableListOf<Event>()
+        EventHub.shared.getExtensionContainer(MockExtension::class.java)?.registerEventListener(
+            EventType.GENERIC_LIFECYCLE,
+            EventSource.REQUEST_CONTENT
+        ) {
+            capturedEvents.add(it)
+            latch.countDown()
+        }
+        EventHub.shared.start()
+
+        val contextData = mapOf("testKey" to "testVal")
+
+        // test
+        MobileCore.lifecyclePause()
+        assertTrue {
+            latch.await(1, TimeUnit.SECONDS)
+        }
+
+        val expectedData = mapOf(
+            CoreConstants.EventDataKeys.Lifecycle.LIFECYCLE_ACTION_KEY to CoreConstants.EventDataKeys.Lifecycle.LIFECYCLE_PAUSE,
         )
         assertEquals(expectedData, capturedEvents[0].eventData)
     }


### PR DESCRIPTION
This PR contains changes to support SDK initialization for customers migrating from 1.x SDK with no compilation errors or runtime inconsistencies. 

1.x initialization code
```
   try {
         Analytics.registerExtension();
         Edge.registerExtension();
         Identity.registerExtension();
         Lifecycle.registerExtension();
         Signal.registerExtension();
         MobileCore.start(new AdobeCallback () {
                @Override
                public void call(Object o) {
                    MobileCore.configureWithAppID("launch-EN5640fb1a17ec4f8685142ebb71e9ca3c-development");
                }
         });
   } catch (InvalidInitException ex) {
         ...
   }
```

Background: 
    Core 2.0 added [`MobileCore.registerExtensions`](https://github.com/adobe/aepsdk-core-android/pull/161) API to simplify SDK initialization. EventHub currently initializes extensions in background thread and the caller has to call `EventHub.start()` only after registering all extensions. 

Changes: 

MobileCore 
- The SDK will start processing events after it sees the first `MobileCore.registerExtensions` or `MobileCore.start` call.
- After starting event processing
     - Calls to `MobileCore.start()` will be ignored. 
     - Calls to `MobileCore.registerExtension` or `MobileCore.registerExtensions()` will register extensions and update the eventhub shared state. 

EventHub 
- `EventHub.start()` will start processing events only after all `registerExtension` calls before it completes. 
- `EventHub.registerExtension()` will shutdown the ExtensionContainer in case of failed registration. 
- Dispatch callbacks and response listeners from different thread so that it does not block event hub and event processing. 
- Made `InvaidInitException` an unchecked exception to avoid compilation errors.

