### PR TITLE
Remove eager service allocation in ConfigurationExtension

### DIFF
--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/configuration/AppIdManager.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/configuration/AppIdManager.kt
@@ -11,25 +11,22 @@
 
 package com.adobe.marketing.mobile.internal.configuration
 
-import com.adobe.marketing.mobile.services.DataStoring
-import com.adobe.marketing.mobile.services.DeviceInforming
 import com.adobe.marketing.mobile.services.Log
 import com.adobe.marketing.mobile.services.NamedCollection
+import com.adobe.marketing.mobile.services.ServiceProvider
 
 /**
  * Manages the storage and retrieval of AEP appID from shared preferences and the app manifest.
  */
-internal class AppIdManager(
-    private val dataStoreService: DataStoring,
-    private val deviceInfoService: DeviceInforming
-) {
+internal class AppIdManager {
 
     companion object {
         private const val LOG_TAG = "AppIdManager"
     }
 
     private val configStateStoreCollection: NamedCollection? =
-        dataStoreService.getNamedCollection(ConfigurationStateManager.DATASTORE_KEY)
+        ServiceProvider.getInstance().dataStoreService
+            .getNamedCollection(ConfigurationStateManager.DATASTORE_KEY)
 
     /**
      * Saves the appId provided into shared preferences.
@@ -101,6 +98,7 @@ internal class AppIdManager(
      *         null otherwise.
      */
     private fun getAppIDFromManifest(): String? {
-        return deviceInfoService.getPropertyFromManifest(ConfigurationStateManager.CONFIG_MANIFEST_APPID_KEY)
+        return ServiceProvider.getInstance().deviceInfoService
+            .getPropertyFromManifest(ConfigurationStateManager.CONFIG_MANIFEST_APPID_KEY)
     }
 }

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationDownloader.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationDownloader.kt
@@ -17,7 +17,7 @@ import com.adobe.marketing.mobile.services.HttpMethod
 import com.adobe.marketing.mobile.services.Log
 import com.adobe.marketing.mobile.services.NetworkCallback
 import com.adobe.marketing.mobile.services.NetworkRequest
-import com.adobe.marketing.mobile.services.Networking
+import com.adobe.marketing.mobile.services.ServiceProvider
 import com.adobe.marketing.mobile.services.caching.CacheEntry
 import com.adobe.marketing.mobile.services.caching.CacheExpiry
 import com.adobe.marketing.mobile.services.caching.CacheService
@@ -39,10 +39,7 @@ import java.util.TimeZone
  * Responsible for downloading configuration json file and processing it to provide a
  * usable configuration for the app implementing AEP SDK.
  */
-internal class ConfigurationDownloader(
-    private val networkService: Networking,
-    private val cacheService: CacheService
-) {
+internal class ConfigurationDownloader {
 
     companion object {
         const val LOG_TAG = "ConfigurationDownloader"
@@ -75,7 +72,7 @@ internal class ConfigurationDownloader(
             return
         }
 
-        val cacheResult = cacheService.get(CONFIG_CACHE_NAME, url)
+        val cacheResult = ServiceProvider.getInstance().cacheService.get(CONFIG_CACHE_NAME, url)
 
         // Compute headers
         val headers: MutableMap<String, String> = HashMap()
@@ -116,7 +113,7 @@ internal class ConfigurationDownloader(
             completionCallback.invoke(config)
         }
 
-        networkService.connectAsync(networkRequest, networkCallback)
+        ServiceProvider.getInstance().networkService.connectAsync(networkRequest, networkCallback)
     }
 
     /**
@@ -150,7 +147,7 @@ internal class ConfigurationDownloader(
                     "Configuration from $url has not been modified. Fetching from cache."
                 )
 
-                val cacheResult = cacheService.get(CONFIG_CACHE_NAME, url)
+                val cacheResult = ServiceProvider.getInstance().cacheService.get(CONFIG_CACHE_NAME, url)
                 processDownloadedConfig(url, cacheResult?.data, cacheResult?.metadata)
             }
 
@@ -191,7 +188,7 @@ internal class ConfigurationDownloader(
 
                     // Cache the downloaded configuration before returning
                     val cacheEntry = CacheEntry(content.byteInputStream(), CacheExpiry.never(), metadata)
-                    cacheService.set(CONFIG_CACHE_NAME, url, cacheEntry)
+                    ServiceProvider.getInstance().cacheService.set(CONFIG_CACHE_NAME, url, cacheEntry)
                     configMap
                 } catch (exception: JSONException) {
                     Log.debug(

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtension.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtension.kt
@@ -23,8 +23,6 @@ import com.adobe.marketing.mobile.internal.eventhub.EventHub
 import com.adobe.marketing.mobile.launch.rulesengine.LaunchRulesEngine
 import com.adobe.marketing.mobile.launch.rulesengine.LaunchRulesEvaluator
 import com.adobe.marketing.mobile.services.Log
-import com.adobe.marketing.mobile.services.ServiceProvider
-import com.adobe.marketing.mobile.services.caching.CacheService
 import com.adobe.marketing.mobile.util.DataReader
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
@@ -70,9 +68,7 @@ internal class ConfigurationExtension : Extension {
         REMOTE
     }
 
-    private val serviceProvider: ServiceProvider
     private val appIdManager: AppIdManager
-    private val cacheService: CacheService
     private val launchRulesEvaluator: LaunchRulesEvaluator
     private val configurationStateManager: ConfigurationStateManager
     private val configurationRulesManager: ConfigurationRulesManager
@@ -80,18 +76,9 @@ internal class ConfigurationExtension : Extension {
     private var retryConfigurationCounter: Int = 0
     private var retryConfigTaskHandle: Future<*>? = null
 
-    constructor(extensionApi: ExtensionApi) : this(extensionApi, ServiceProvider.getInstance())
-
-    /**
-     * Exists only for cascading components for dependency injection.
-     */
-    private constructor(
-        extensionApi: ExtensionApi,
-        serviceProvider: ServiceProvider
-    ) : this(
-        extensionApi, serviceProvider,
-        AppIdManager(serviceProvider.dataStoreService, serviceProvider.deviceInfoService),
-        serviceProvider.cacheService,
+    constructor(extensionApi: ExtensionApi) : this(
+        extensionApi,
+        AppIdManager(),
         LaunchRulesEvaluator("Configuration", LaunchRulesEngine(extensionApi), extensionApi),
         Executors.newSingleThreadScheduledExecutor()
     )
@@ -101,47 +88,28 @@ internal class ConfigurationExtension : Extension {
      */
     private constructor(
         extensionApi: ExtensionApi,
-        serviceProvider: ServiceProvider,
         appIdManager: AppIdManager,
-        cacheService: CacheService,
         launchRulesEvaluator: LaunchRulesEvaluator,
         retryWorker: ScheduledExecutorService
     ) : this(
         extensionApi,
-        serviceProvider,
         appIdManager,
-        cacheService,
         launchRulesEvaluator,
         retryWorker,
-        ConfigurationStateManager(
-            appIdManager,
-            cacheService,
-            serviceProvider.networkService,
-            serviceProvider.deviceInfoService,
-            serviceProvider.dataStoreService
-        ),
-        ConfigurationRulesManager(
-            launchRulesEvaluator,
-            serviceProvider.dataStoreService,
-            serviceProvider.deviceInfoService,
-            serviceProvider.networkService,
-        )
+        ConfigurationStateManager(appIdManager),
+        ConfigurationRulesManager(launchRulesEvaluator)
     )
 
     @VisibleForTesting
     internal constructor(
         extensionApi: ExtensionApi,
-        serviceProvider: ServiceProvider,
         appIdManager: AppIdManager,
-        cacheService: CacheService,
         launchRulesEvaluator: LaunchRulesEvaluator,
         retryWorker: ScheduledExecutorService,
         configurationStateManager: ConfigurationStateManager,
         configurationRulesManager: ConfigurationRulesManager
     ) : super(extensionApi) {
-        this.serviceProvider = serviceProvider
         this.appIdManager = appIdManager
-        this.cacheService = cacheService
         this.launchRulesEvaluator = launchRulesEvaluator
         this.retryWorker = retryWorker
         this.configurationStateManager = configurationStateManager
@@ -484,7 +452,10 @@ internal class ConfigurationExtension : Extension {
      * @param eventData the content of the event data for the response event
      * @param triggerEvent the [Event] to which the response is being dispatched
      */
-    private fun dispatchConfigurationResponse(eventData: Map<String, Any?>, triggerEvent: Event? = null) {
+    private fun dispatchConfigurationResponse(
+        eventData: Map<String, Any?>,
+        triggerEvent: Event? = null
+    ) {
         val builder = Event.Builder(
             "Configuration Response Event",
             EventType.CONFIGURATION, EventSource.RESPONSE_CONTENT

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationRulesManager.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationRulesManager.kt
@@ -11,16 +11,15 @@
 
 package com.adobe.marketing.mobile.internal.configuration
 
+import androidx.annotation.VisibleForTesting
 import com.adobe.marketing.mobile.ExtensionApi
 import com.adobe.marketing.mobile.launch.rulesengine.LaunchRulesEvaluator
 import com.adobe.marketing.mobile.launch.rulesengine.download.RulesLoadResult
 import com.adobe.marketing.mobile.launch.rulesengine.download.RulesLoader
 import com.adobe.marketing.mobile.launch.rulesengine.json.JSONRulesParser
-import com.adobe.marketing.mobile.services.DataStoring
-import com.adobe.marketing.mobile.services.DeviceInforming
 import com.adobe.marketing.mobile.services.Log
 import com.adobe.marketing.mobile.services.NamedCollection
-import com.adobe.marketing.mobile.services.Networking
+import com.adobe.marketing.mobile.services.ServiceProvider
 
 /**
  * Facilitates notifying [LaunchRulesEvaluator] about replacing current rules with cached or newly
@@ -36,40 +35,20 @@ internal class ConfigurationRulesManager {
     }
 
     private val launchRulesEvaluator: LaunchRulesEvaluator
-    private val dataStoreService: DataStoring
-    private val deviceInfoService: DeviceInforming
-    private val networkService: Networking
     private val rulesLoader: RulesLoader
     private val configDataStore: NamedCollection?
 
-    constructor(
-        launchRulesEvaluator: LaunchRulesEvaluator,
-        dataStoreService: DataStoring,
-        deviceInfoService: DeviceInforming,
-        networkService: Networking
-    ) : this(
+    constructor(launchRulesEvaluator: LaunchRulesEvaluator) : this(
         launchRulesEvaluator,
-        dataStoreService,
-        deviceInfoService,
-        networkService,
-        RulesLoader(
-            RULES_CACHE_NAME
-        )
+        RulesLoader(RULES_CACHE_NAME)
     )
 
-    constructor(
-        launchRulesEvaluator: LaunchRulesEvaluator,
-        dataStoreService: DataStoring,
-        deviceInfoService: DeviceInforming,
-        networkService: Networking,
-        rulesLoader: RulesLoader
-    ) {
+    @VisibleForTesting
+    constructor(launchRulesEvaluator: LaunchRulesEvaluator, rulesLoader: RulesLoader) {
         this.launchRulesEvaluator = launchRulesEvaluator
-        this.dataStoreService = dataStoreService
-        this.deviceInfoService = deviceInfoService
-        this.networkService = networkService
         this.rulesLoader = rulesLoader
-        configDataStore = dataStoreService.getNamedCollection(ConfigurationExtension.DATASTORE_KEY)
+        configDataStore =
+            ServiceProvider.getInstance().dataStoreService.getNamedCollection(ConfigurationExtension.DATASTORE_KEY)
     }
 
     /**

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtensionTest.kt
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtensionTest.kt
@@ -28,10 +28,13 @@ import com.adobe.marketing.mobile.internal.eventhub.EventHub
 import com.adobe.marketing.mobile.launch.rulesengine.LaunchRulesEvaluator
 import com.adobe.marketing.mobile.services.ServiceProvider
 import com.adobe.marketing.mobile.services.caching.CacheService
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mock
+import org.mockito.MockedStatic
 import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.anyString
@@ -84,11 +87,20 @@ class ConfigurationExtensionTest {
     @Mock
     private lateinit var mockSharedStateResolver: SharedStateResolver
 
+    private lateinit var mockedStaticServiceProvider: MockedStatic<ServiceProvider>
+
     companion object {
         private const val SAMPLE_SERVER = "downloaded_server"
         private const val SAMPLE_RSID = "downloaded_rsid"
         private const val ANALYTICS_SERVER_KEY = "Analytics.server"
         private const val ANALYTICS_RSID_KEY = "Analytics.rsids"
+    }
+
+    @Before
+    fun setup() {
+        mockedStaticServiceProvider = Mockito.mockStatic(ServiceProvider::class.java)
+        mockedStaticServiceProvider.`when`<Any> { ServiceProvider.getInstance() }.thenReturn(mockServiceProvider)
+        `when`(mockServiceProvider.cacheService).thenReturn(mockCacheService)
     }
 
     @Test
@@ -106,9 +118,7 @@ class ConfigurationExtensionTest {
 
         val configurationExtension = ConfigurationExtension(
             mockExtensionApi,
-            mockServiceProvider,
             mockAppIdManager,
-            mockCacheService,
             mockLaunchRulesEvaluator,
             mockExecutorService,
             mockConfigStateManager,
@@ -163,9 +173,7 @@ class ConfigurationExtensionTest {
 
         val configurationExtension = ConfigurationExtension(
             mockExtensionApi,
-            mockServiceProvider,
             mockAppIdManager,
-            mockCacheService,
             mockLaunchRulesEvaluator,
             mockExecutorService,
             mockConfigStateManager,
@@ -195,9 +203,7 @@ class ConfigurationExtensionTest {
 
         val configurationExtension = ConfigurationExtension(
             mockExtensionApi,
-            mockServiceProvider,
             mockAppIdManager,
-            mockCacheService,
             mockLaunchRulesEvaluator,
             mockExecutorService,
             mockConfigStateManager,
@@ -226,9 +232,7 @@ class ConfigurationExtensionTest {
     fun `ConfigurationExtension - registers listener onRegistered`() {
         val configurationExtension = ConfigurationExtension(
             mockExtensionApi,
-            mockServiceProvider,
             mockAppIdManager,
-            mockCacheService,
             mockLaunchRulesEvaluator,
             mockExecutorService,
             mockConfigStateManager,
@@ -248,9 +252,7 @@ class ConfigurationExtensionTest {
     fun `Handle Configuration Request Event - event missing valid key`() {
         val configurationExtension = ConfigurationExtension(
             mockExtensionApi,
-            mockServiceProvider,
             mockAppIdManager,
-            mockCacheService,
             mockLaunchRulesEvaluator,
             mockExecutorService,
             mockConfigStateManager,
@@ -291,9 +293,7 @@ class ConfigurationExtensionTest {
 
         val configurationExtension = ConfigurationExtension(
             mockExtensionApi,
-            mockServiceProvider,
             mockAppIdManager,
-            mockCacheService,
             mockLaunchRulesEvaluator,
             mockExecutorService,
             mockConfigStateManager,
@@ -335,9 +335,12 @@ class ConfigurationExtensionTest {
         `when`(mockConfigStateManager.hasConfigExpired(anyString())).thenReturn(false)
 
         val configurationExtension = ConfigurationExtension(
-            mockExtensionApi, mockServiceProvider,
-            mockAppIdManager, mockCacheService, mockLaunchRulesEvaluator, mockExecutorService,
-            mockConfigStateManager, mockConfigurationRulesManager
+            mockExtensionApi,
+            mockAppIdManager,
+            mockLaunchRulesEvaluator,
+            mockExecutorService,
+            mockConfigStateManager,
+            mockConfigurationRulesManager
         )
 
         val event: Event = Event.Builder(
@@ -377,9 +380,12 @@ class ConfigurationExtensionTest {
         }
 
         val configurationExtension = ConfigurationExtension(
-            mockExtensionApi, mockServiceProvider,
-            mockAppIdManager, mockCacheService, mockLaunchRulesEvaluator, mockExecutorService,
-            mockConfigStateManager, mockConfigurationRulesManager
+            mockExtensionApi,
+            mockAppIdManager,
+            mockLaunchRulesEvaluator,
+            mockExecutorService,
+            mockConfigStateManager,
+            mockConfigurationRulesManager
         )
 
         val event: Event = Event.Builder(
@@ -474,9 +480,7 @@ class ConfigurationExtensionTest {
 
         val configurationExtension = ConfigurationExtension(
             mockExtensionApi,
-            mockServiceProvider,
             mockAppIdManager,
-            mockCacheService,
             mockLaunchRulesEvaluator,
             mockExecutorService,
             mockConfigStateManager,
@@ -561,9 +565,7 @@ class ConfigurationExtensionTest {
 
         val configurationExtension = ConfigurationExtension(
             mockExtensionApi,
-            mockServiceProvider,
             mockAppIdManager,
-            mockCacheService,
             mockLaunchRulesEvaluator,
             mockExecutorService,
             mockConfigStateManager,
@@ -602,9 +604,7 @@ class ConfigurationExtensionTest {
 
         val configurationExtension = ConfigurationExtension(
             mockExtensionApi,
-            mockServiceProvider,
             mockAppIdManager,
-            mockCacheService,
             mockLaunchRulesEvaluator,
             mockExecutorService,
             mockConfigStateManager,
@@ -638,9 +638,7 @@ class ConfigurationExtensionTest {
 
         val configurationExtension = ConfigurationExtension(
             mockExtensionApi,
-            mockServiceProvider,
             mockAppIdManager,
-            mockCacheService,
             mockLaunchRulesEvaluator,
             mockExecutorService,
             mockConfigStateManager,
@@ -674,9 +672,7 @@ class ConfigurationExtensionTest {
 
         val configurationExtension = ConfigurationExtension(
             mockExtensionApi,
-            mockServiceProvider,
             mockAppIdManager,
-            mockCacheService,
             mockLaunchRulesEvaluator,
             mockExecutorService,
             mockConfigStateManager,
@@ -709,9 +705,7 @@ class ConfigurationExtensionTest {
 
         val configurationExtension = ConfigurationExtension(
             mockExtensionApi,
-            mockServiceProvider,
             mockAppIdManager,
-            mockCacheService,
             mockLaunchRulesEvaluator,
             mockExecutorService,
             mockConfigStateManager,
@@ -745,9 +739,7 @@ class ConfigurationExtensionTest {
         val fileAssetName = "/some/asset"
         val configurationExtension = ConfigurationExtension(
             mockExtensionApi,
-            mockServiceProvider,
             mockAppIdManager,
-            mockCacheService,
             mockLaunchRulesEvaluator,
             mockExecutorService,
             mockConfigStateManager,
@@ -790,9 +782,7 @@ class ConfigurationExtensionTest {
 
         val configurationExtension = ConfigurationExtension(
             mockExtensionApi,
-            mockServiceProvider,
             mockAppIdManager,
-            mockCacheService,
             mockLaunchRulesEvaluator,
             mockExecutorService,
             mockConfigStateManager,
@@ -841,9 +831,7 @@ class ConfigurationExtensionTest {
 
         val configurationExtension = ConfigurationExtension(
             mockExtensionApi,
-            mockServiceProvider,
             mockAppIdManager,
-            mockCacheService,
             mockLaunchRulesEvaluator,
             mockExecutorService,
             mockConfigStateManager,
@@ -885,9 +873,7 @@ class ConfigurationExtensionTest {
 
         val configurationExtension = ConfigurationExtension(
             mockExtensionApi,
-            mockServiceProvider,
             mockAppIdManager,
-            mockCacheService,
             mockLaunchRulesEvaluator,
             mockExecutorService,
             mockConfigStateManager,
@@ -924,9 +910,7 @@ class ConfigurationExtensionTest {
 
         val configurationExtension = ConfigurationExtension(
             mockExtensionApi,
-            mockServiceProvider,
             mockAppIdManager,
-            mockCacheService,
             mockLaunchRulesEvaluator,
             mockExecutorService,
             mockConfigStateManager,
@@ -976,9 +960,7 @@ class ConfigurationExtensionTest {
 
         val configurationExtension = ConfigurationExtension(
             mockExtensionApi,
-            mockServiceProvider,
             mockAppIdManager,
-            mockCacheService,
             mockLaunchRulesEvaluator,
             mockExecutorService,
             mockConfigStateManager,
@@ -1006,6 +988,11 @@ class ConfigurationExtensionTest {
             mockBundledConfig,
             event
         )
+    }
+
+    @After
+    fun teardown() {
+        mockedStaticServiceProvider.close()
     }
 
     private fun verifyDispatchedEvent(


### PR DESCRIPTION
## Description
Configuration extension currently passes public service instances into the constructors of internal components primarily to allow dependency injection for tests. This eager allocation prevents the default services to reflect when they are set to a custom implementation.

<!--- Describe your changes in detail -->
Remove eager service allocation in ConfigurationExtension and use ServiceProvider.getInstance().get* where required

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Unit tests
- Manual verification 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
