### PR TITLE
Add functionality to set custom headers when calling RulesLoader.loadFromUrl

### DIFF
--- a/code/android-core-library/api/android-core-library.api
+++ b/code/android-core-library/api/android-core-library.api
@@ -381,7 +381,6 @@ public class com/adobe/marketing/mobile/launch/rulesengine/download/RulesLoader 
 	public fun getCacheName ()Ljava/lang/String;
 	public fun loadFromAsset (Ljava/lang/String;)Lcom/adobe/marketing/mobile/launch/rulesengine/download/RulesLoadResult;
 	public fun loadFromCache (Ljava/lang/String;)Lcom/adobe/marketing/mobile/launch/rulesengine/download/RulesLoadResult;
-	public fun loadFromUrl (Ljava/lang/String;Lcom/adobe/marketing/mobile/AdobeCallback;)V
 	public fun loadFromUrl (Ljava/lang/String;Ljava/util/Map;Lcom/adobe/marketing/mobile/AdobeCallback;)V
 }
 

--- a/code/android-core-library/api/android-core-library.api
+++ b/code/android-core-library/api/android-core-library.api
@@ -382,6 +382,7 @@ public class com/adobe/marketing/mobile/launch/rulesengine/download/RulesLoader 
 	public fun loadFromAsset (Ljava/lang/String;)Lcom/adobe/marketing/mobile/launch/rulesengine/download/RulesLoadResult;
 	public fun loadFromCache (Ljava/lang/String;)Lcom/adobe/marketing/mobile/launch/rulesengine/download/RulesLoadResult;
 	public fun loadFromUrl (Ljava/lang/String;Lcom/adobe/marketing/mobile/AdobeCallback;)V
+	public fun loadFromUrl (Ljava/lang/String;Ljava/util/Map;Lcom/adobe/marketing/mobile/AdobeCallback;)V
 }
 
 public final class com/adobe/marketing/mobile/launch/rulesengine/json/JSONRulesParser {

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationRulesManager.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationRulesManager.kt
@@ -116,7 +116,7 @@ internal class ConfigurationRulesManager {
 
         configDataStore.setString(PERSISTED_RULES_URL, url)
 
-        rulesLoader.loadFromUrl(url) { rulesDownloadResult ->
+        rulesLoader.loadFromUrl(url, null) { rulesDownloadResult ->
             val reason = rulesDownloadResult.reason
             Log.trace(
                 ConfigurationExtension.TAG,

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/download/RulesLoader.java
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/download/RulesLoader.java
@@ -77,19 +77,6 @@ public class RulesLoader {
 
     /**
      * Loads rules from the {@code url} and invokes {@code callback} with the extracted rules.
-     * Additionally, the extracted content is cached in cache bucket with name {@code name} and {@code url} as the key
-     * in {@code CacheService}.
-     *
-     * @param url      the url from which the compressed rules are to be downloaded
-     * @param callback the callback that will be invoked with the result of the download
-     */
-    public void loadFromUrl(@NonNull final String url,
-                            @NonNull final AdobeCallback<RulesLoadResult> callback) {
-        loadFromUrl(url, null, callback);
-    }
-
-    /**
-     * Loads rules from the {@code url} and invokes {@code callback} with the extracted rules.
      * Any provided {@code customHeaders} are merged with the extracted cache headers and used in the rules download request.
      * Additionally, the extracted content is cached in cache bucket with name {@code name} and {@code url} as the key
      * in {@code CacheService}.

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationRulesManagerTest.kt
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationRulesManagerTest.kt
@@ -208,6 +208,7 @@ class ConfigurationRulesManagerTest {
         )
         verify(mockRulesLoader).loadFromUrl(
             eq(urlForRules),
+            eq(null),
             any()
         )
     }
@@ -227,6 +228,7 @@ class ConfigurationRulesManagerTest {
 
         verify(mockRulesLoader).loadFromUrl(
             eq(urlForRules),
+            eq(null),
             callbackCaptor.capture()
         )
 
@@ -259,6 +261,7 @@ class ConfigurationRulesManagerTest {
 
         verify(mockRulesLoader).loadFromUrl(
             eq(urlForRules),
+            eq(null),
             callbackCaptor.capture()
         )
 
@@ -289,6 +292,7 @@ class ConfigurationRulesManagerTest {
 
         verify(mockRulesLoader).loadFromUrl(
             eq(urlForRules),
+            eq(null),
             callbackCaptor.capture()
         )
 

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/download/RulesLoaderTest.java
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/download/RulesLoaderTest.java
@@ -102,7 +102,7 @@ public class RulesLoaderTest {
     public void testLoadFromURL_InvalidURL() {
         final AdobeCallback<RulesLoadResult> mockCallback = mock(AdobeCallback.class);
 
-        rulesLoader.loadFromUrl("not a url", mockCallback);
+        rulesLoader.loadFromUrl("not a url", null, mockCallback);
 
         verifyNoInteractions(mockNetworkService);
         verifyNoInteractions(mockCacheService);
@@ -150,7 +150,7 @@ public class RulesLoaderTest {
         );
 
         // Test
-        rulesLoader.loadFromUrl(VALID_URL, mockCallback);
+        rulesLoader.loadFromUrl(VALID_URL, null, mockCallback);
 
         verify(mockCacheService).get(RULES_TEST_CACHE_NAME, VALID_URL);
         final ArgumentCaptor<NetworkRequest> networkRequestCaptor = ArgumentCaptor.forClass(NetworkRequest.class);
@@ -284,7 +284,7 @@ public class RulesLoaderTest {
         );
 
         // Test
-        rulesLoader.loadFromUrl(VALID_URL, mockCallback);
+        rulesLoader.loadFromUrl(VALID_URL, null, mockCallback);
 
         verify(mockCacheService).get(RULES_TEST_CACHE_NAME, VALID_URL);
         final ArgumentCaptor<NetworkRequest> networkRequestCaptor = ArgumentCaptor.forClass(NetworkRequest.class);
@@ -405,7 +405,7 @@ public class RulesLoaderTest {
                 10000
         );
 
-        rulesLoader.loadFromUrl(VALID_URL, mockCallback);
+        rulesLoader.loadFromUrl(VALID_URL, null, mockCallback);
 
         verify(mockCacheService).get(RULES_TEST_CACHE_NAME, VALID_URL);
         final ArgumentCaptor<NetworkRequest> networkRequestCaptor = ArgumentCaptor.forClass(NetworkRequest.class);
@@ -451,7 +451,7 @@ public class RulesLoaderTest {
                 10000
         );
 
-        rulesLoader.loadFromUrl(VALID_URL, mockCallback);
+        rulesLoader.loadFromUrl(VALID_URL, null, mockCallback);
 
         verify(mockCacheService).get(RULES_TEST_CACHE_NAME, VALID_URL);
         final ArgumentCaptor<NetworkRequest> networkRequestCaptor = ArgumentCaptor.forClass(NetworkRequest.class);
@@ -495,7 +495,7 @@ public class RulesLoaderTest {
                 10000
         );
 
-        rulesLoader.loadFromUrl(VALID_URL, mockCallback);
+        rulesLoader.loadFromUrl(VALID_URL, null, mockCallback);
 
         final ArgumentCaptor<NetworkRequest> networkRequestCaptor = ArgumentCaptor.forClass(NetworkRequest.class);
         verify(mockNetworkService, times(1)).connectAsync(networkRequestCaptor.capture(), any());
@@ -551,7 +551,7 @@ public class RulesLoaderTest {
 
         // Test
         final AdobeCallback<RulesLoadResult> mockCallback = mock(AdobeCallback.class);
-        rulesLoader.loadFromUrl(VALID_URL, mockCallback);
+        rulesLoader.loadFromUrl(VALID_URL, null, mockCallback);
 
         final ArgumentCaptor<NetworkRequest> networkRequestCaptor = ArgumentCaptor.forClass(NetworkRequest.class);
         verify(mockNetworkService, times(1)).connectAsync(networkRequestCaptor.capture(), any());
@@ -592,7 +592,7 @@ public class RulesLoaderTest {
                 10000
         );
 
-        rulesLoader.loadFromUrl(VALID_URL, mockCallback);
+        rulesLoader.loadFromUrl(VALID_URL, null, mockCallback);
 
         verify(mockCacheService).get(RULES_TEST_CACHE_NAME, VALID_URL);
         final ArgumentCaptor<NetworkRequest> networkRequestCaptor = ArgumentCaptor.forClass(NetworkRequest.class);


### PR DESCRIPTION
- Add functionality to set custom headers when calling RulesLoader.loadFromUrl

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/adobe/aepsdk-core-android/issues/248
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
