### PR TITLE
Add Edge Identity EventType and reset complete, update identity EventSources

### DIFF
--- a/code/android-core-library/api/android-core-library.api
+++ b/code/android-core-library/api/android-core-library.api
@@ -63,6 +63,7 @@ public final class com/adobe/marketing/mobile/EventSource {
 	public static final field APPLICATION_CLOSE Ljava/lang/String;
 	public static final field APPLICATION_LAUNCH Ljava/lang/String;
 	public static final field CONSENT_PREFERENCE Ljava/lang/String;
+	public static final field ERROR_RESPONSE_CONTENT Ljava/lang/String;
 	public static final field NONE Ljava/lang/String;
 	public static final field OS Ljava/lang/String;
 	public static final field REQUEST_CONTENT Ljava/lang/String;

--- a/code/android-core-library/api/android-core-library.api
+++ b/code/android-core-library/api/android-core-library.api
@@ -69,11 +69,13 @@ public final class com/adobe/marketing/mobile/EventSource {
 	public static final field REQUEST_IDENTITY Ljava/lang/String;
 	public static final field REQUEST_PROFILE Ljava/lang/String;
 	public static final field REQUEST_RESET Ljava/lang/String;
+	public static final field RESET_COMPLETE Ljava/lang/String;
 	public static final field RESPONSE_CONTENT Ljava/lang/String;
 	public static final field RESPONSE_IDENTITY Ljava/lang/String;
 	public static final field RESPONSE_PROFILE Ljava/lang/String;
 	public static final field SHARED_STATE Ljava/lang/String;
 	public static final field UPDATE_CONSENT Ljava/lang/String;
+	public static final field UPDATE_IDENTITY Ljava/lang/String;
 	public static final field WILDCARD Ljava/lang/String;
 }
 
@@ -87,6 +89,7 @@ public final class com/adobe/marketing/mobile/EventType {
 	public static final field CONSENT Ljava/lang/String;
 	public static final field CUSTOM Ljava/lang/String;
 	public static final field EDGE Ljava/lang/String;
+	public static final field EDGE_IDENTITY Ljava/lang/String;
 	public static final field GENERIC_DATA Ljava/lang/String;
 	public static final field GENERIC_IDENTITY Ljava/lang/String;
 	public static final field GENERIC_LIFECYCLE Ljava/lang/String;

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/EventSource.java
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/EventSource.java
@@ -37,4 +37,6 @@ public final class EventSource {
 	public static final String APPLICATION_CLOSE = "com.adobe.eventSource.applicationClose";
 	public static final String CONSENT_PREFERENCE = "consent:preferences";
 	public static final String UPDATE_CONSENT = "com.adobe.eventSource.updateConsent";
+	public static final String RESET_COMPLETE = "com.adobe.eventSource.resetComplete";
+	public static final String UPDATE_IDENTITY = "com.adobe.eventSource.updateIdentity";
 }

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/EventSource.java
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/EventSource.java
@@ -39,4 +39,5 @@ public final class EventSource {
 	public static final String UPDATE_CONSENT = "com.adobe.eventSource.updateConsent";
 	public static final String RESET_COMPLETE = "com.adobe.eventSource.resetComplete";
 	public static final String UPDATE_IDENTITY = "com.adobe.eventSource.updateIdentity";
+	public static final String ERROR_RESPONSE_CONTENT = "com.adobe.eventSource.errorResponseContent";
 }

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/EventType.java
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/EventType.java
@@ -49,4 +49,6 @@ public final class EventType {
 	public static final String WILDCARD = "com.adobe.eventType._wildcard_";
 	public static final String CONSENT = "com.adobe.eventType.edgeConsent";
 	public static final String EDGE = "com.adobe.eventType.edge";
+	public static final String EDGE_IDENTITY = "com.adobe.eventType.edgeIdentity";
+
 }

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/EventType.java
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/EventType.java
@@ -28,27 +28,26 @@ public final class EventType {
 	public static final String AUDIENCEMANAGER = "com.adobe.eventType.audienceManager";
 	public static final String CAMPAIGN = "com.adobe.eventType.campaign";
 	public static final String CONFIGURATION = "com.adobe.eventType.configuration";
+	public static final String CONSENT = "com.adobe.eventType.edgeConsent";
 	public static final String CUSTOM = "com.adobe.eventType.custom";
+	public static final String EDGE = "com.adobe.eventType.edge";
+	public static final String EDGE_IDENTITY = "com.adobe.eventType.edgeIdentity";
+	public static final String GENERIC_DATA = "com.adobe.eventType.generic.data";
+	public static final String GENERIC_IDENTITY = "com.adobe.eventType.generic.identity";
+	public static final String GENERIC_LIFECYCLE = "com.adobe.eventType.generic.lifecycle";
+	public static final String GENERIC_PII = "com.adobe.eventType.generic.pii";
+	public static final String GENERIC_TRACK = "com.adobe.eventType.generic.track";
 	public static final String HUB = "com.adobe.eventType.hub";
 	public static final String IDENTITY = "com.adobe.eventType.identity";
 	public static final String LIFECYCLE = "com.adobe.eventType.lifecycle";
 	public static final String LOCATION = "com.adobe.eventType.location";
 	public static final String MEDIA = "com.adobe.eventType.media";
 	public static final String PII = "com.adobe.eventType.pii";
+	public static final String PLACES = "com.adobe.eventType.places";
 	public static final String RULES_ENGINE = "com.adobe.eventType.rulesEngine";
 	public static final String SIGNAL = "com.adobe.eventType.signal";
 	public static final String SYSTEM = "com.adobe.eventType.system";
 	public static final String TARGET = "com.adobe.eventType.target";
 	public static final String USERPROFILE = "com.adobe.eventType.userProfile";
-	public static final String PLACES = "com.adobe.eventType.places";
-	public static final String GENERIC_TRACK = "com.adobe.eventType.generic.track";
-	public static final String GENERIC_LIFECYCLE = "com.adobe.eventType.generic.lifecycle";
-	public static final String GENERIC_IDENTITY = "com.adobe.eventType.generic.identity";
-	public static final String GENERIC_PII = "com.adobe.eventType.generic.pii";
-	public static final String GENERIC_DATA = "com.adobe.eventType.generic.data";
 	public static final String WILDCARD = "com.adobe.eventType._wildcard_";
-	public static final String CONSENT = "com.adobe.eventType.edgeConsent";
-	public static final String EDGE = "com.adobe.eventType.edge";
-	public static final String EDGE_IDENTITY = "com.adobe.eventType.edgeIdentity";
-
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding EventType and EventSource used by Edge extensions.

Adds:

- EventType:  `EDGE_IDENTITY = "com.adobe.eventType.edgeIdentity"`
- EventSource: `RESET_COMPLETE = "com.adobe.eventSource.resetComplete"`
- EventSource: `UPDATE_IDENTITY = "com.adobe.eventSource.updateIdentity"`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
