### PR TITLE
Update TimeUtil helper method for ISO 8601 UTC conversion

### DIFF
--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/TimeUtils.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/TimeUtils.kt
@@ -47,15 +47,21 @@ object TimeUtils {
     }
 
     /**
-     * Gets the the ISO 8601 formatted date `String` for the current date.
-     * TimeZone format used is ISO8601 using XXX formatting letters. ex: 9th July 2020 PDT will be formatted as 2020-07-09T15:09:18-07:00.
+     * Gets the the ISO 8601 formatted UTC(Z) millisecond precision date `String` for the provided date.
+     * Date format used is [ISO8601_FORMAT_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND]
+     * ex: Wed Nov 30 11:53:09.497 GMT-07:00 2022 -> 2022-11-30T18:53:09.497Z
+     *
+     * Note that ISO 8601 requires date strings terminating with 'Z' to be in the timezone UTC +0 (no offset).
+     *
      * AMSDK-10273 :: ExEdge requires time zone offset formatted in form [+-]HH:MM.
      *
-     * @return Iso8601 formatted date [String]
+     * @param date the [Date] to apply the formatting to; defaults to the current [Date]
+     * @return date [String] formatted as ISO 8601 timezone UTC(Z) millisecond precision
      */
     @JvmStatic
-    fun getIso8601DateTimeZoneISO8601(): String? {
-        return getIso8601Date(Date(), ISO8601_DATE_FORMATTER_TIMEZONE_UTC, TimeZone.getTimeZone("GMT"))
+    @JvmOverloads
+    fun getIso8601DateTimeZoneISO8601(date: Date? = Date()): String? {
+        return getIso8601Date(date, ISO8601_DATE_FORMATTER_TIMEZONE_UTC, TimeZone.getTimeZone("Etc/UTC"))
     }
 
     /**

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/util/TimeUtilsTests.java
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/util/TimeUtilsTests.java
@@ -14,7 +14,10 @@ package com.adobe.marketing.mobile.util;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import static org.junit.Assert.*;
@@ -81,5 +84,18 @@ public class TimeUtilsTests {
 	public void testGetIso8601Date_TimeZone_ISO8601_returns_milliseconds_and_UTC() {
 		String formattedDate = TimeUtils.getIso8601DateTimeZoneISO8601();
 		assertTrue(formattedDate.matches("[0-9]{4}-[0-9]{2}-[0-9]{2}T([0-9]{2}:){2}[0-9]{2}.[0-9]{3}Z"));
+	}
+
+	@Test
+	public void testGetIso8601Date_TimeZone_UTC_precision_milliseconds_when_ValidDate() throws ParseException {
+		SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", new Locale(Locale.US.getLanguage(), Locale.US.getCountry(), "POSIX"));
+		formatter.setTimeZone(TimeZone.getTimeZone("Etc/UTC"));
+
+		String dateInString = "2022-11-30T13:50:53.945Z";
+		Date testDate = formatter.parse(dateInString);
+
+		String formattedDate = TimeUtils.getIso8601DateTimeZoneISO8601(testDate);
+
+		assertTrue(formattedDate.matches(dateInString));
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR updates the helper method `getIso8601DateTimeZoneISO8601` for ISO 8601 `Date` conversion into UTC +0 timezone, millisecond precision format, allowing it to accept a `Date` arg; this makes is much easier to convert `Date` values into the proper format with the correct timezone set and also preserves the existing functionality of using the current `Date()` as the default value when no arg is passed.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

3rd party extensions need to be able to convert `Date` instances into the ISO 8601 UTC +0 timezone, millisecond precision, and the current method only allows for converting the current `Date()` into this format. The alternative general purpose method can be cumbersome to use, and it would be easier to have the guarantee of setting the correct date format string and timezone using the existing method.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

There is a new unit test case that validates the conversion of a Date instance into the ISO 8601 UTC +0 timezone, millisecond precision format using this method.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
