### PR TITLE
TimeUtils Refactor

### DIFF
--- a/code/android-core-library/api/android-core-library.api
+++ b/code/android-core-library/api/android-core-library.api
@@ -1071,14 +1071,25 @@ public final class com/adobe/marketing/mobile/util/StringUtils {
 
 public final class com/adobe/marketing/mobile/util/TimeUtils {
 	public static final field INSTANCE Lcom/adobe/marketing/mobile/util/TimeUtils;
-	public static final fun getIso8601Date ()Ljava/lang/String;
-	public static final fun getIso8601Date (Ljava/util/Date;Ljava/lang/String;)Ljava/lang/String;
-	public static final fun getIso8601Date (Ljava/util/Date;Ljava/lang/String;Ljava/util/TimeZone;)Ljava/lang/String;
-	public static synthetic fun getIso8601Date$default (Ljava/util/Date;Ljava/lang/String;Ljava/util/TimeZone;ILjava/lang/Object;)Ljava/lang/String;
-	public static final fun getIso8601DateTimeZoneISO8601 ()Ljava/lang/String;
+	public static final fun getISO8601UTCDateWithMilliseconds ()Ljava/lang/String;
+	public static final fun getISO8601UTCDateWithMilliseconds (Ljava/util/Date;)Ljava/lang/String;
+	public static synthetic fun getISO8601UTCDateWithMilliseconds$default (Ljava/util/Date;ILjava/lang/Object;)Ljava/lang/String;
+	public static final fun getIso8601DateTimeZoneRFC822 ()Ljava/lang/String;
+	public static final fun getIso8601DateTimeZoneRFC822 (Ljava/util/Date;)Ljava/lang/String;
+	public static synthetic fun getIso8601DateTimeZoneRFC822$default (Ljava/util/Date;ILjava/lang/Object;)Ljava/lang/String;
 	public static final fun getRFC2822Date (JLjava/util/TimeZone;Ljava/util/Locale;)Ljava/lang/String;
 	public static final fun getUnixTimeInSeconds ()J
 	public static final fun parseRFC2822Date (Ljava/lang/String;Ljava/util/TimeZone;Ljava/util/Locale;)Ljava/util/Date;
+}
+
+public final class com/adobe/marketing/mobile/util/TimeUtils$DatePattern : java/lang/Enum {
+	public static final field ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND Lcom/adobe/marketing/mobile/util/TimeUtils$DatePattern;
+	public static final field ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND Lcom/adobe/marketing/mobile/util/TimeUtils$DatePattern;
+	public static final field ISO8601_TIMEZONE_RFC822_PRECISION_SECOND Lcom/adobe/marketing/mobile/util/TimeUtils$DatePattern;
+	public static final field RFC2822_DATE_PATTERN Lcom/adobe/marketing/mobile/util/TimeUtils$DatePattern;
+	public final fun getPattern ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/adobe/marketing/mobile/util/TimeUtils$DatePattern;
+	public static fun values ()[Lcom/adobe/marketing/mobile/util/TimeUtils$DatePattern;
 }
 
 public class com/adobe/marketing/mobile/util/URLBuilder {

--- a/code/android-core-library/api/android-core-library.api
+++ b/code/android-core-library/api/android-core-library.api
@@ -1071,25 +1071,21 @@ public final class com/adobe/marketing/mobile/util/StringUtils {
 
 public final class com/adobe/marketing/mobile/util/TimeUtils {
 	public static final field INSTANCE Lcom/adobe/marketing/mobile/util/TimeUtils;
+	public static final fun getISO8601Date ()Ljava/lang/String;
+	public static final fun getISO8601Date (Ljava/util/Date;)Ljava/lang/String;
+	public static synthetic fun getISO8601Date$default (Ljava/util/Date;ILjava/lang/Object;)Ljava/lang/String;
+	public static final fun getISO8601DateNoColon ()Ljava/lang/String;
+	public static final fun getISO8601DateNoColon (Ljava/util/Date;)Ljava/lang/String;
+	public static synthetic fun getISO8601DateNoColon$default (Ljava/util/Date;ILjava/lang/Object;)Ljava/lang/String;
+	public static final fun getISO8601FullDate ()Ljava/lang/String;
+	public static final fun getISO8601FullDate (Ljava/util/Date;)Ljava/lang/String;
+	public static synthetic fun getISO8601FullDate$default (Ljava/util/Date;ILjava/lang/Object;)Ljava/lang/String;
 	public static final fun getISO8601UTCDateWithMilliseconds ()Ljava/lang/String;
 	public static final fun getISO8601UTCDateWithMilliseconds (Ljava/util/Date;)Ljava/lang/String;
 	public static synthetic fun getISO8601UTCDateWithMilliseconds$default (Ljava/util/Date;ILjava/lang/Object;)Ljava/lang/String;
-	public static final fun getIso8601DateTimeZoneRFC822 ()Ljava/lang/String;
-	public static final fun getIso8601DateTimeZoneRFC822 (Ljava/util/Date;)Ljava/lang/String;
-	public static synthetic fun getIso8601DateTimeZoneRFC822$default (Ljava/util/Date;ILjava/lang/Object;)Ljava/lang/String;
 	public static final fun getRFC2822Date (JLjava/util/TimeZone;Ljava/util/Locale;)Ljava/lang/String;
 	public static final fun getUnixTimeInSeconds ()J
 	public static final fun parseRFC2822Date (Ljava/lang/String;Ljava/util/TimeZone;Ljava/util/Locale;)Ljava/util/Date;
-}
-
-public final class com/adobe/marketing/mobile/util/TimeUtils$DatePattern : java/lang/Enum {
-	public static final field ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND Lcom/adobe/marketing/mobile/util/TimeUtils$DatePattern;
-	public static final field ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND Lcom/adobe/marketing/mobile/util/TimeUtils$DatePattern;
-	public static final field ISO8601_TIMEZONE_RFC822_PRECISION_SECOND Lcom/adobe/marketing/mobile/util/TimeUtils$DatePattern;
-	public static final field RFC2822_DATE_PATTERN Lcom/adobe/marketing/mobile/util/TimeUtils$DatePattern;
-	public final fun getPattern ()Ljava/lang/String;
-	public static fun valueOf (Ljava/lang/String;)Lcom/adobe/marketing/mobile/util/TimeUtils$DatePattern;
-	public static fun values ()[Lcom/adobe/marketing/mobile/util/TimeUtils$DatePattern;
 }
 
 public class com/adobe/marketing/mobile/util/URLBuilder {

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchTokenFinder.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchTokenFinder.kt
@@ -64,7 +64,7 @@ internal class LaunchTokenFinder(val event: Event, val extensionApi: ExtensionAp
             KEY_EVENT_TYPE -> event.type
             KEY_EVENT_SOURCE -> event.source
             KEY_TIMESTAMP_UNIX -> TimeUtils.getUnixTimeInSeconds().toString()
-            KEY_TIMESTAMP_ISO8601 -> TimeUtils.getIso8601DateTimeZoneRFC822()
+            KEY_TIMESTAMP_ISO8601 -> TimeUtils.getISO8601DateNoColon()
             KEY_TIMESTAMP_PLATFORM -> TimeUtils.getISO8601UTCDateWithMilliseconds()
             KEY_SDK_VERSION -> MobileCore.extensionVersion()
             KEY_CACHEBUST -> SecureRandom().nextInt(RANDOM_INT_BOUNDARY).toString()

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchTokenFinder.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchTokenFinder.kt
@@ -64,8 +64,8 @@ internal class LaunchTokenFinder(val event: Event, val extensionApi: ExtensionAp
             KEY_EVENT_TYPE -> event.type
             KEY_EVENT_SOURCE -> event.source
             KEY_TIMESTAMP_UNIX -> TimeUtils.getUnixTimeInSeconds().toString()
-            KEY_TIMESTAMP_ISO8601 -> TimeUtils.getIso8601Date()
-            KEY_TIMESTAMP_PLATFORM -> TimeUtils.getIso8601DateTimeZoneISO8601()
+            KEY_TIMESTAMP_ISO8601 -> TimeUtils.getIso8601DateTimeZoneRFC822()
+            KEY_TIMESTAMP_PLATFORM -> TimeUtils.getIso8601DateTimeZoneUTC()
             KEY_SDK_VERSION -> MobileCore.extensionVersion()
             KEY_CACHEBUST -> SecureRandom().nextInt(RANDOM_INT_BOUNDARY).toString()
             KEY_ALL_URL -> {

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchTokenFinder.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchTokenFinder.kt
@@ -65,7 +65,7 @@ internal class LaunchTokenFinder(val event: Event, val extensionApi: ExtensionAp
             KEY_EVENT_SOURCE -> event.source
             KEY_TIMESTAMP_UNIX -> TimeUtils.getUnixTimeInSeconds().toString()
             KEY_TIMESTAMP_ISO8601 -> TimeUtils.getIso8601DateTimeZoneRFC822()
-            KEY_TIMESTAMP_PLATFORM -> TimeUtils.getIso8601DateTimeZoneUTC()
+            KEY_TIMESTAMP_PLATFORM -> TimeUtils.getISO8601UTCDateWithMilliseconds()
             KEY_SDK_VERSION -> MobileCore.extensionVersion()
             KEY_CACHEBUST -> SecureRandom().nextInt(RANDOM_INT_BOUNDARY).toString()
             KEY_ALL_URL -> {

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/TimeUtils.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/TimeUtils.kt
@@ -21,7 +21,9 @@ import java.util.TimeZone
 object TimeUtils {
     private const val MILLISECONDS_PER_SECOND = 1000L
     private const val ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
-    private const val ISO8601_TIMEZONE_RFC822_PRECISION_SECOND = "yyyy-MM-dd'T'HH:mm:ssZ"
+    private const val ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND = "yyyy-MM-dd'T'HH:mm:ssXXX"
+    private const val ISO8601_TIMEZONE_ISO8601_2X_PRECISION_SECOND = "yyyy-MM-dd'T'HH:mm:ssXX"
+    private const val ISO8601_FULL_DATE = "yyyy-MM-dd"
     private const val RFC2822_DATE_PATTERN = "EEE, dd MMM yyyy HH:mm:ss z"
 
     /**
@@ -35,24 +37,43 @@ object TimeUtils {
     }
 
     /**
-     * Gets the ISO 8601 formatted with RFC 822 time zone, second precision date `String` for the provided
-     * date using the current device time zone.
-     * Date pattern used is [ISO8601_TIMEZONE_RFC822_PRECISION_SECOND]
-     * which has timezone RFC 822 'Z' pattern, which gives a timezone of ex: "-0700" ("+0000" for UTC +0)
-     * Ex (device in time zone "America/Los_Angeles"): Wed Nov 30 11:53:09.497 GMT-07:00 2022 -> 2022-11-30T11:53:09-0700
+     * Gets the ISO 8601 formatted with colon time zone, second precision date `String`
+     * for the provide date using the system local time zone.
+     *
+     * Date pattern used is [ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND]
+     * which has timezone ISO 8601 'XXX' pattern, which gives a timezone of ex: "-07:00" ("Z" for UTC +0)
+     * Ex: (device in time zone "America/Los_Angeles") Wed Nov 30 11:53:09.497 GMT-07:00 2022 -> 2022-11-30T11:53:09-07:00
      *
      * @param date the [Date] to apply the formatting to; defaults to the current [Date]
-     * @return date [String] formatted as ISO 8601 with RFC 822 time zone, second precision
+     * @return date [String] formatted as ISO 8601 with colon time zone, second precision
      */
     @JvmStatic
     @JvmOverloads
-    fun getIso8601DateTimeZoneRFC822(date: Date = Date()): String {
-        return getFormattedDate(date, ISO8601_TIMEZONE_RFC822_PRECISION_SECOND) ?: ""
+    fun getISO8601Date(date: Date = Date()): String {
+        return getFormattedDate(date, ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND) ?: ""
+    }
+
+    /**
+     * Gets the ISO 8601 formatted with no colon time zone, second precision date `String`
+     * for the provide date using the system local time zone.
+     *
+     * Date pattern used is [ISO8601_TIMEZONE_ISO8601_2X_PRECISION_SECOND]
+     * which has timezone ISO 8601 'XX' pattern, which gives a timezone of ex: "-0700" ("Z" for UTC +0)
+     * Ex: (device in time zone "America/Los_Angeles") Wed Nov 30 11:53:09.497 GMT-07:00 2022 -> 2022-11-30T11:53:09-0700
+     *
+     * @param date the [Date] to apply the formatting to; defaults to the current [Date]
+     * @return date [String] formatted as ISO 8601 with no colon time zone, second precision
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun getISO8601DateNoColon(date: Date = Date()): String {
+        return getFormattedDate(date, ISO8601_TIMEZONE_ISO8601_2X_PRECISION_SECOND) ?: ""
     }
 
     /**
      * Gets the ISO 8601 formatted with UTC(Z) time zone, millisecond precision date `String` for the
      * provided date using the UTC +0 time zone.
+     *
      * Date pattern used is [ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND]
      * which has timezone ISO 8601 'Z' char terminator, which gives a timezone of 'Z'.
      * Ex: Wed Nov 30 11:53:09.497 GMT-07:00 2022 -> 2022-11-30T18:53:09.497Z (notice the hour shift because the date must be evaluated from UTC +0)
@@ -71,14 +92,29 @@ object TimeUtils {
     }
 
     /**
-     * Gets the formatted date `String` for the passed in date; if no date passed in, uses current `Date()`
+     * Gets the ISO 8601 formatted full date `String` for the provided date using the system local time zone.
+     *
+     * Date pattern used is [ISO8601_FULL_DATE]
+     * Ex: Wed Nov 30 11:53:09.497 GMT-07:00 2022 -> 2022-11-30
      *
      * @param date the [Date] to apply the formatting to; defaults to the current [Date]
+     * @return date [String] formatted as ISO 8601 full date, using system local time zone
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun getISO8601FullDate(date: Date = Date()): String {
+        return getFormattedDate(date, ISO8601_FULL_DATE) ?: ""
+    }
+
+    /**
+     * Gets the formatted date `String` for the passed in date; if no date passed in, uses current `Date()`
+     *
+     * @param date the [Date] to apply the formatting to
      * @param pattern the pattern [String] to use to format the date
      * @param timeZone the [TimeZone] to evaluate the formatted date from; defaults to device time zone if not specified
      * @return the formatted date [String], null if formatting fails
      */
-    private fun getFormattedDate(date: Date?, pattern: String, timeZone: TimeZone? = null): String? {
+    private fun getFormattedDate(date: Date, pattern: String, timeZone: TimeZone? = null): String? {
         // AMSDK-8374 -
         // we should explicitly ignore the device's locale when formatting an ISO 8601 timestamp
         val posixLocale = Locale(Locale.US.language, Locale.US.country, "POSIX")
@@ -87,7 +123,7 @@ object TimeUtils {
         if (timeZone != null) {
             dateFormat.timeZone = timeZone
         }
-        return dateFormat.format(date ?: Date())
+        return dateFormat.format(date)
     }
 
     /**
@@ -110,8 +146,8 @@ object TimeUtils {
     }
 
     /**
-     * Converts the epoch into a RFC-2822 date string pattern - [DatePattern.RFC2822_DATE_PATTERN]
-     * @param epoch the epoch that should be converted to Date
+     * Converts the epoch into a RFC-2822 date string pattern - [RFC2822_DATE_PATTERN]
+     * @param epoch the epoch (milliseconds) that should be converted to [Date]
      * @param timeZone the timezone that should be used
      * @param locale the locale whose date format symbols should be used
      * @return a RFC-2822 formatted date string for the epoch provided

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/TimeUtils.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/TimeUtils.kt
@@ -83,9 +83,7 @@ object TimeUtils {
      * @param timeZone the [TimeZone] to evaluate the formatted date from; defaults to device time zone if not specified
      * @return the formatted date [String]
      */
-    @JvmStatic
-    @JvmOverloads
-    fun getFormattedDate(date: Date?, datePattern: DatePattern, timeZone: TimeZone? = null): String? {
+    private fun getFormattedDate(date: Date?, datePattern: DatePattern, timeZone: TimeZone? = null): String? {
         // AMSDK-8374 -
         // we should explicitly ignore the device's locale when formatting an ISO 8601 timestamp
         val posixLocale = Locale(Locale.US.language, Locale.US.country, "POSIX")

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/TimeUtils.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/TimeUtils.kt
@@ -20,10 +20,10 @@ import java.util.TimeZone
 
 object TimeUtils {
     private const val MILLISECONDS_PER_SECOND = 1000L
-    private const val ISO8601_DATE_FORMATTER_TIMEZONE_RFC822 = "yyyy-MM-dd'T'HH:mm:ssZZZ"
-    private const val ISO8601_DATE_FORMATTER_TIMEZONE_ISO8601 = "yyyy-MM-dd'T'HH:mm:ssXXX"
+    private const val ISO8601_FORMAT_TIMEZONE_RFC822_OFFSET_PRECISION_SECOND = "yyyy-MM-dd'T'HH:mm:ssZ"
+    private const val ISO8601_FORMAT_TIMEZONE_ISO8601_OFFSET_PRECISION_SECOND = "yyyy-MM-dd'T'HH:mm:ssXXX"
     private const val RFC2822_DATE_PATTERN = "EEE, dd MMM yyyy HH:mm:ss z"
-    private const val ISO8601_DATE_FORMATTER_TIMEZONE_UTC = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+    private const val ISO8601_FORMAT_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
 
     /**
      * Gets current unix timestamp in seconds.
@@ -37,13 +37,13 @@ object TimeUtils {
 
     /**
      * Gets the the ISO 8601 formatted date `String` for the current date.
-     * TimeZone format used is RFC822 using ZZZ formatting letter. ex: 9th July 2020 PDT will be formatted as 2020-07-09T15:09:18-0700.
+     * Date format used is RFC822 using ZZZ formatting letter. ex: 9th July 2020 PDT will be formatted as 2020-07-09T15:09:18-0700.
      *
      * @return Iso8601 formatted date [String]
      */
     @JvmStatic
     fun getIso8601Date(): String? {
-        return getIso8601Date(Date(), ISO8601_DATE_FORMATTER_TIMEZONE_RFC822)
+        return getIso8601Date(Date(), ISO8601_FORMAT_TIMEZONE_RFC822_OFFSET_PRECISION_SECOND)
     }
 
     /**
@@ -61,7 +61,7 @@ object TimeUtils {
     @JvmStatic
     @JvmOverloads
     fun getIso8601DateTimeZoneISO8601(date: Date? = Date()): String? {
-        return getIso8601Date(date, ISO8601_DATE_FORMATTER_TIMEZONE_UTC, TimeZone.getTimeZone("Etc/UTC"))
+        return getIso8601Date(date, ISO8601_FORMAT_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND, TimeZone.getTimeZone("Etc/UTC"))
     }
 
     /**

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/TimeUtils.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/TimeUtils.kt
@@ -47,15 +47,21 @@ object TimeUtils {
     }
 
     /**
-     * Gets the the ISO 8601 formatted date `String` for the current date.
-     * TimeZone format used is ISO8601 using XXX formatting letters. ex: 9th July 2020 PDT will be formatted as 2020-07-09T15:09:18-07:00.
+     * Gets the the ISO 8601 formatted UTC(Z) millisecond precision date `String` for the provided date.
+     * Date format used is [ISO8601_FORMAT_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND]
+     * ex: Wed Nov 30 11:53:09.497 GMT-07:00 2022 -> 2022-11-30T18:53:09.497Z
+     *
+     * Note that ISO 8601 requires date strings terminating with 'Z' to be in the timezone UTC +0 (no offset).
+     *
      * AMSDK-10273 :: ExEdge requires time zone offset formatted in form [+-]HH:MM.
      *
-     * @return Iso8601 formatted date [String]
+     * @param date the [Date] to apply the formatting to; defaults to the current [Date]
+     * @return date [String] formatted as ISO 8601 timezone UTC(Z) millisecond precision
      */
     @JvmStatic
-    fun getIso8601DateTimeZoneISO8601(): String? {
-        return getIso8601Date(Date(), ISO8601_DATE_FORMATTER_TIMEZONE_UTC, TimeZone.getTimeZone("GMT"))
+    @JvmOverloads
+    fun getIso8601DateTimeZoneISO8601(date: Date? = Date()): String? {
+        return getIso8601Date(date, ISO8601_DATE_FORMATTER_TIMEZONE_UTC, TimeZone.getTimeZone("Etc/UTC"))
     }
 
     /**

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/TimeUtils.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/TimeUtils.kt
@@ -71,8 +71,8 @@ object TimeUtils {
      */
     @JvmStatic
     @JvmOverloads
-    fun getIso8601DateTimeZoneUTC(date: Date? = Date()): String? {
-        return getFormattedDate(date, DatePattern.ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND, TimeZone.getTimeZone("Etc/UTC"))
+    fun getISO8601UTCDateWithMilliseconds(date: Date? = Date()): String? {
+        return getFormattedDate(date, DatePattern.ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND)
     }
 
     /**

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/TimeUtils.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/TimeUtils.kt
@@ -54,7 +54,6 @@ object TimeUtils {
         return getFormattedDate(date, DatePattern.ISO8601_TIMEZONE_RFC822_PRECISION_SECOND)
     }
 
-
     /**
      * Gets the ISO 8601 formatted with UTC(Z) time zone, millisecond precision date `String` for the
      * provided date using the UTC +0 time zone.

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/TimeUtils.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/util/TimeUtils.kt
@@ -20,10 +20,13 @@ import java.util.TimeZone
 
 object TimeUtils {
     private const val MILLISECONDS_PER_SECOND = 1000L
-    private const val ISO8601_FORMAT_TIMEZONE_RFC822_OFFSET_PRECISION_SECOND = "yyyy-MM-dd'T'HH:mm:ssZ"
-    private const val ISO8601_FORMAT_TIMEZONE_ISO8601_OFFSET_PRECISION_SECOND = "yyyy-MM-dd'T'HH:mm:ssXXX"
-    private const val RFC2822_DATE_PATTERN = "EEE, dd MMM yyyy HH:mm:ss z"
-    private const val ISO8601_FORMAT_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+
+    enum class DatePattern(val pattern: String) {
+        ISO8601_TIMEZONE_RFC822_PRECISION_SECOND("yyyy-MM-dd'T'HH:mm:ssZ"),
+        ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND("yyyy-MM-dd'T'HH:mm:ssXXX"),
+        RFC2822_DATE_PATTERN("EEE, dd MMM yyyy HH:mm:ss z"),
+        ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    }
 
     /**
      * Gets current unix timestamp in seconds.
@@ -36,51 +39,69 @@ object TimeUtils {
     }
 
     /**
-     * Gets the the ISO 8601 formatted date `String` for the current date.
-     * Date format used is RFC822 using ZZZ formatting letter. ex: 9th July 2020 PDT will be formatted as 2020-07-09T15:09:18-0700.
+     * Gets the ISO 8601 formatted with RFC 822 time zone, second precision date `String` for the provided
+     * date using the current device time zone.
+     * Date pattern used is [DatePattern.ISO8601_TIMEZONE_RFC822_PRECISION_SECOND]
+     * which has timezone RFC 822 'Z' pattern, which gives a timezone of ex: "-0700" ("+0000" for UTC +0)
+     * Ex (device in time zone "America/Los_Angeles"): Wed Nov 30 11:53:09.497 GMT-07:00 2022 -> 2022-11-30T11:53:09-0700
      *
-     * @return Iso8601 formatted date [String]
+     * @param date the [Date] to apply the formatting to; defaults to the current [Date]
+     * @return date [String] formatted as ISO 8601 with RFC 822 time zone, second precision
      */
     @JvmStatic
-    fun getIso8601Date(): String? {
-        return getIso8601Date(Date(), ISO8601_FORMAT_TIMEZONE_RFC822_OFFSET_PRECISION_SECOND)
+    @JvmOverloads
+    fun getIso8601DateTimeZoneRFC822(date: Date? = Date()): String? {
+        return getFormattedDate(date, DatePattern.ISO8601_TIMEZONE_RFC822_PRECISION_SECOND)
     }
 
+
     /**
-     * Gets the the ISO 8601 formatted UTC(Z) millisecond precision date `String` for the provided date.
-     * Date format used is [ISO8601_FORMAT_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND]
-     * ex: Wed Nov 30 11:53:09.497 GMT-07:00 2022 -> 2022-11-30T18:53:09.497Z
+     * Gets the ISO 8601 formatted with UTC(Z) time zone, millisecond precision date `String` for the
+     * provided date using the UTC +0 time zone.
+     * Date pattern used is [DatePattern.ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND]
+     * which has timezone ISO 8601 'Z' char terminator, which gives a timezone of 'Z'.
+     * Ex: Wed Nov 30 11:53:09.497 GMT-07:00 2022 -> 2022-11-30T18:53:09.497Z (notice the hour shift because the date must be evaluated from UTC +0)
      *
-     * Note that ISO 8601 requires date strings terminating with 'Z' to be in the timezone UTC +0 (no offset).
+     * Note that ISO 8601 requires date strings terminating with the char 'Z' to be in the time zone UTC +0 (no offset).
      *
      * AMSDK-10273 :: ExEdge requires time zone offset formatted in form [+-]HH:MM.
      *
      * @param date the [Date] to apply the formatting to; defaults to the current [Date]
-     * @return date [String] formatted as ISO 8601 timezone UTC(Z) millisecond precision
+     * @return date [String] formatted as ISO 8601 with UTC(Z) time zone, millisecond precision
      */
     @JvmStatic
     @JvmOverloads
-    fun getIso8601DateTimeZoneISO8601(date: Date? = Date()): String? {
-        return getIso8601Date(date, ISO8601_FORMAT_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND, TimeZone.getTimeZone("Etc/UTC"))
+    fun getIso8601DateTimeZoneUTC(date: Date? = Date()): String? {
+        return getFormattedDate(date, DatePattern.ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND, TimeZone.getTimeZone("Etc/UTC"))
     }
 
     /**
-     * Gets the the ISO 8601 formatted date `String` for the passed in date - "yyyy-MM-dd'T'HH:mm:ssZZZ"
+     * Gets the formatted date `String` for the passed in date; if no date passed in, uses current `Date()`
      *
-     * @param date the [Date] to generate the [String] for
-     * @return ISO 8601 formatted date [String]
+     * @param date the [Date] to apply the formatting to; defaults to the current [Date]
+     * @param datePattern the [DatePattern] to use to format the date [String]
+     * @param timeZone the [TimeZone] to evaluate the formatted date from; defaults to device time zone if not specified
+     * @return the formatted date [String]
      */
     @JvmStatic
     @JvmOverloads
-    fun getIso8601Date(date: Date?, format: String?, timeZone: TimeZone? = null): String? {
+    fun getFormattedDate(date: Date?, datePattern: DatePattern, timeZone: TimeZone? = null): String? {
         // AMSDK-8374 -
         // we should explicitly ignore the device's locale when formatting an ISO 8601 timestamp
         val posixLocale = Locale(Locale.US.language, Locale.US.country, "POSIX")
-        val iso8601Format: DateFormat = SimpleDateFormat(format, posixLocale)
-        if (timeZone != null) {
-            iso8601Format.timeZone = timeZone
+        val dateFormat: DateFormat = SimpleDateFormat(datePattern.pattern, posixLocale)
+
+        // Handle special cases/requirements based on DatePattern provided
+        when (datePattern) {
+            // This format hardcodes the terminating 'Z' character, which under ISO 8601 requires timezone UTC +0
+            DatePattern.ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND -> dateFormat.timeZone = TimeZone.getTimeZone("Etc/UTC")
+            else -> {
+                if (timeZone != null) {
+                    dateFormat.timeZone = timeZone
+                }
+            }
         }
-        return iso8601Format.format(date ?: Date())
+        return dateFormat.format(date ?: Date())
     }
 
     /**
@@ -93,7 +114,7 @@ object TimeUtils {
     @JvmStatic
     fun parseRFC2822Date(rfc2822Date: String?, timeZone: TimeZone, locale: Locale): Date? {
         if (rfc2822Date == null) return null
-        val rfc2822formatter: DateFormat = SimpleDateFormat(RFC2822_DATE_PATTERN, locale)
+        val rfc2822formatter: DateFormat = SimpleDateFormat(DatePattern.RFC2822_DATE_PATTERN.pattern, locale)
         rfc2822formatter.timeZone = timeZone
         return try {
             rfc2822formatter.parse(rfc2822Date) ?: Date()
@@ -103,7 +124,7 @@ object TimeUtils {
     }
 
     /**
-     * Converts the epoch into a RFC-2822 date string pattern - [RFC2822_DATE_PATTERN]
+     * Converts the epoch into a RFC-2822 date string pattern - [DatePattern.RFC2822_DATE_PATTERN]
      * @param epoch the epoch that should be converted to Date
      * @param timeZone the timezone that should be used
      * @param locale the locale whose date format symbols should be used
@@ -111,7 +132,7 @@ object TimeUtils {
      */
     @JvmStatic
     fun getRFC2822Date(epoch: Long, timeZone: TimeZone, locale: Locale): String {
-        val rfc2822formatter: DateFormat = SimpleDateFormat(RFC2822_DATE_PATTERN, locale)
+        val rfc2822formatter: DateFormat = SimpleDateFormat(DatePattern.RFC2822_DATE_PATTERN.pattern, locale)
         rfc2822formatter.timeZone = timeZone
         return rfc2822formatter.format(epoch)
     }

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/util/TimeUtilsTests.java
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/util/TimeUtilsTests.java
@@ -11,6 +11,15 @@
 
 package com.adobe.marketing.mobile.util;
 
+import org.junit.Before;
+import org.junit.Test;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
 import static org.junit.Assert.*;
 
 import com.adobe.marketing.mobile.TestHelper;
@@ -71,18 +80,22 @@ public class TimeUtilsTests {
         assertEquals("2018-05-15T10:33:26-07:00", formattedDate);
     }
 
-    @Test
-    public void testGetIso8601Date_TimeZone_ISO8601_when_NullDate() {
-        String formattedDate = TimeUtils.getIso8601Date(null, "yyyy-MM-dd'T'HH:mm:ssXXX");
-        assertNotNull(formattedDate);
-        assertTrue(formattedDate.matches(DATE_REGEX_TIMEZONE_ISO8601));
-    }
+	@Test
+	public void testGetIso8601Date_TimeZone_ISO8601_returns_milliseconds_and_UTC() {
+		String formattedDate = TimeUtils.getIso8601DateTimeZoneISO8601();
+		assertTrue(formattedDate.matches("[0-9]{4}-[0-9]{2}-[0-9]{2}T([0-9]{2}:){2}[0-9]{2}.[0-9]{3}Z"));
+	}
 
-    @Test
-    public void testGetIso8601Date_TimeZone_ISO8601_returns_milliseconds_and_UTC() {
-        String formattedDate = TimeUtils.getIso8601DateTimeZoneISO8601();
-        assertTrue(
-                formattedDate.matches(
-                        "[0-9]{4}-[0-9]{2}-[0-9]{2}T([0-9]{2}:){2}[0-9]{2}.[0-9]{3}Z"));
-    }
+	@Test
+	public void testGetIso8601Date_TimeZone_UTC_precision_milliseconds_when_ValidDate() throws ParseException {
+		SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", new Locale(Locale.US.getLanguage(), Locale.US.getCountry(), "POSIX"));
+		formatter.setTimeZone(TimeZone.getTimeZone("Etc/UTC"));
+
+		String dateInString = "2022-11-30T13:50:53.945Z";
+		Date testDate = formatter.parse(dateInString);
+
+		String formattedDate = TimeUtils.getIso8601DateTimeZoneISO8601(testDate);
+
+		assertTrue(formattedDate.matches(dateInString));
+	}
 }

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/util/TimeUtilsTests.java
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/util/TimeUtilsTests.java
@@ -50,39 +50,37 @@ public class TimeUtilsTests {
         }
     }
 
-    @Test
-    public void testGetUnixTime_returnTimestampInSeconds() {
-        long timestamp = TimeUtils.getUnixTimeInSeconds();
-        long currentTimestamp = System.currentTimeMillis() / 1000;
-        assertTrue(timestamp - currentTimestamp <= 0);
-    }
+	@Test
+	public void testGetIso8601Date_TimeZone_RFC822_when_ValidDate() {
+		long timestamp = 1526405606000L;
+		String formattedDate = TimeUtils.getFormattedDate(new Date(timestamp), TimeUtils.DatePattern.ISO8601_TIMEZONE_RFC822_PRECISION_SECOND);
+		assertEquals("2018-05-15T10:33:26-0700", formattedDate);
+	}
 
-    @Test
-    public void testGetIso8601Date_TimeZone_RFC822_when_ValidDate() {
-        long timestamp = 1526405606000L;
-        String formattedDate =
-                TimeUtils.getIso8601Date(new Date(timestamp), "yyyy-MM-dd'T'HH:mm:ssZZZ");
-        assertEquals("2018-05-15T10:33:26-0700", formattedDate);
-    }
+	@Test
+	public void testGetIso8601Date_TimeZone_RFC822_when_NullDate() {
+		String formattedDate = TimeUtils.getFormattedDate(null, TimeUtils.DatePattern.ISO8601_TIMEZONE_RFC822_PRECISION_SECOND);
+		assertNotNull(formattedDate);
+		assertTrue(formattedDate.matches(DATE_REGEX_TIMEZONE_RFC822));
+	}
 
-    @Test
-    public void testGetIso8601Date_TimeZone_RFC822_when_NullDate() {
-        String formattedDate = TimeUtils.getIso8601Date(null, "yyyy-MM-dd'T'HH:mm:ssZZZ");
-        assertNotNull(formattedDate);
-        assertTrue(formattedDate.matches(DATE_REGEX_TIMEZONE_RFC822));
-    }
+	@Test
+	public void testGetIso8601Date_TimeZone_ISO8601_when_ValidDate() {
+		long timestamp = 1526405606000L;
+		String formattedDate = TimeUtils.getFormattedDate(new Date(timestamp), TimeUtils.DatePattern.ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND);
+		assertEquals("2018-05-15T10:33:26-07:00", formattedDate);
+	}
 
-    @Test
-    public void testGetIso8601Date_TimeZone_ISO8601_when_ValidDate() {
-        long timestamp = 1526405606000L;
-        String formattedDate =
-                TimeUtils.getIso8601Date(new Date(timestamp), "yyyy-MM-dd'T'HH:mm:ssXXX");
-        assertEquals("2018-05-15T10:33:26-07:00", formattedDate);
-    }
+	@Test
+	public void testGetIso8601Date_TimeZone_ISO8601_when_NullDate() {
+		String formattedDate = TimeUtils.getFormattedDate(null, TimeUtils.DatePattern.ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND);
+		assertNotNull(formattedDate);
+		assertTrue(formattedDate.matches(DATE_REGEX_TIMEZONE_ISO8601));
+	}
 
 	@Test
 	public void testGetIso8601Date_TimeZone_ISO8601_returns_milliseconds_and_UTC() {
-		String formattedDate = TimeUtils.getIso8601DateTimeZoneISO8601();
+		String formattedDate = TimeUtils.getIso8601DateTimeZoneUTC();
 		assertTrue(formattedDate.matches("[0-9]{4}-[0-9]{2}-[0-9]{2}T([0-9]{2}:){2}[0-9]{2}.[0-9]{3}Z"));
 	}
 
@@ -94,7 +92,7 @@ public class TimeUtilsTests {
 		String dateInString = "2022-11-30T13:50:53.945Z";
 		Date testDate = formatter.parse(dateInString);
 
-		String formattedDate = TimeUtils.getIso8601DateTimeZoneISO8601(testDate);
+		String formattedDate = TimeUtils.getIso8601DateTimeZoneUTC(testDate);
 
 		assertTrue(formattedDate.matches(dateInString));
 	}

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/util/TimeUtilsTests.java
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/util/TimeUtilsTests.java
@@ -11,71 +11,62 @@
 
 package com.adobe.marketing.mobile.util;
 
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.*;
 
+import com.adobe.marketing.mobile.TestHelper;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
-
-import static org.junit.Assert.*;
-
-import com.adobe.marketing.mobile.TestHelper;
-import java.util.Date;
-import java.util.TimeZone;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TimeUtilsTests {
-	private static final String DATE_REGEX_ISO8601_TIMEZONE_ISO8601_2X_PRECISION_SECOND =
-		"^((19|2[0-9])[0-9]{2})-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T[0-2][0-9]:[0-5][0-9]:[0-5][0-9][-+][0-9]{4}$";
+    private static final String DATE_REGEX_ISO8601_TIMEZONE_ISO8601_2X_PRECISION_SECOND =
+            "^((19|2[0-9])[0-9]{2})-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T[0-2][0-9]:[0-5][0-9]:[0-5][0-9][-+][0-9]{4}$";
 
-	private static final String DATE_REGEX_ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND =
-		"^((19|2[0-9])[0-9]{2})-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T[0-2][0-9]:[0-5][0-9]:[0-5][0-9][-+][0-9]{2}:[0-9]{2}$";
+    private static final String DATE_REGEX_ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND =
+            "^((19|2[0-9])[0-9]{2})-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T[0-2][0-9]:[0-5][0-9]:[0-5][0-9][-+][0-9]{2}:[0-9]{2}$";
 
-	private static final String DATE_REGEX_ISO8601_FULL_DATE =
-			"^[0-9]{4}-[0-9]{2}-[0-9]{2}$";
+    private static final String DATE_REGEX_ISO8601_FULL_DATE = "^[0-9]{4}-[0-9]{2}-[0-9]{2}$";
 
-	private static final String DATE_REGEX_ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND =
-			"^[0-9]{4}-[0-9]{2}-[0-9]{2}T([0-9]{2}:){2}[0-9]{2}.[0-9]{3}Z$";
+    private static final String DATE_REGEX_ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND =
+            "^[0-9]{4}-[0-9]{2}-[0-9]{2}T([0-9]{2}:){2}[0-9]{2}.[0-9]{3}Z$";
 
-	private Date defaultDate;
-	private Date defaultDateNoMilli;
+    private Date defaultDate;
+    private Date defaultDateNoMilli;
 
-	private String expectedString_ISO8601_FULL_DATE;
-	private String expectedString_ISO8601_TIMEZONE_ISO8601_2X_PRECISION_SECOND;
-	private String expectedString_ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND;
-	private String expectedString_ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND;
+    private String expectedString_ISO8601_FULL_DATE;
+    private String expectedString_ISO8601_TIMEZONE_ISO8601_2X_PRECISION_SECOND;
+    private String expectedString_ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND;
+    private String expectedString_ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND;
 
-	private String expectedString_RFC2822_DATE_PATTERN_GMT;
+    private String expectedString_RFC2822_DATE_PATTERN_GMT;
 
-	private Long defaultEpochMilli;
-	private Locale defaultLocale;
-
-	@Before
-	public void setup() throws ParseException {
-		TimeZone.setDefault(TimeZone.getTimeZone("GMT-7"));
-		defaultLocale = new Locale(Locale.US.getLanguage(), Locale.US.getCountry(), "POSIX");
-		// Setup static date whose expected formats are well-known
-		expectedString_ISO8601_FULL_DATE = "2022-11-30";
-		expectedString_ISO8601_TIMEZONE_ISO8601_2X_PRECISION_SECOND = "2022-11-30T06:50:53-0700";
-		expectedString_ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND = "2022-11-30T06:50:53-07:00";
-		expectedString_ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND = "2022-11-30T13:50:53.945Z";
-		expectedString_RFC2822_DATE_PATTERN_GMT = "Wed, 30 Nov 2022 13:50:53 GMT";
-
-		SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", defaultLocale);
-		formatter.setTimeZone(TimeZone.getTimeZone("GMT"));
-		defaultDate = formatter.parse(expectedString_ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND);
-		formatter.applyPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
-		defaultDateNoMilli = formatter.parse("2022-11-30T13:50:53Z");
-		defaultEpochMilli = defaultDate.toInstant().toEpochMilli();
-	}
+    private Long defaultEpochMilli;
+    private Locale defaultLocale;
 
     @Before
-    public void setup() {
+    public void setup() throws ParseException {
         TimeZone.setDefault(TimeZone.getTimeZone("GMT-7"));
+        defaultLocale = new Locale(Locale.US.getLanguage(), Locale.US.getCountry(), "POSIX");
+        // Setup static date whose expected formats are well-known
+        expectedString_ISO8601_FULL_DATE = "2022-11-30";
+        expectedString_ISO8601_TIMEZONE_ISO8601_2X_PRECISION_SECOND = "2022-11-30T06:50:53-0700";
+        expectedString_ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND = "2022-11-30T06:50:53-07:00";
+        expectedString_ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND =
+                "2022-11-30T13:50:53.945Z";
+        expectedString_RFC2822_DATE_PATTERN_GMT = "Wed, 30 Nov 2022 13:50:53 GMT";
+
+        SimpleDateFormat formatter =
+                new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", defaultLocale);
+        formatter.setTimeZone(TimeZone.getTimeZone("GMT"));
+        defaultDate =
+                formatter.parse(expectedString_ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND);
+        formatter.applyPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        defaultDateNoMilli = formatter.parse("2022-11-30T13:50:53Z");
+        defaultEpochMilli = defaultDate.toInstant().toEpochMilli();
     }
 
     @Test
@@ -87,66 +78,74 @@ public class TimeUtilsTests {
         }
     }
 
-	// Testing each API with a well-known date and corresponding formatting result
-	@Test
-	public void testGetISO8601Date_when_validDate() {
-		String formattedDate = TimeUtils.getISO8601Date(defaultDate);
-		assertEquals(expectedString_ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND, formattedDate);
-	}
+    // Testing each API with a well-known date and corresponding formatting result
+    @Test
+    public void testGetISO8601Date_when_validDate() {
+        String formattedDate = TimeUtils.getISO8601Date(defaultDate);
+        assertEquals(expectedString_ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND, formattedDate);
+    }
 
-	@Test
-	public void testGetISO8601DateNoColon_when_validDate() {
-		String formattedDate = TimeUtils.getISO8601DateNoColon(defaultDate);
-		assertEquals(expectedString_ISO8601_TIMEZONE_ISO8601_2X_PRECISION_SECOND, formattedDate);
-	}
+    @Test
+    public void testGetISO8601DateNoColon_when_validDate() {
+        String formattedDate = TimeUtils.getISO8601DateNoColon(defaultDate);
+        assertEquals(expectedString_ISO8601_TIMEZONE_ISO8601_2X_PRECISION_SECOND, formattedDate);
+    }
 
-	@Test
-	public void testGetISO8601UTCDateWithMilliseconds_when_validDate() {
-		String formattedDate = TimeUtils.getISO8601UTCDateWithMilliseconds(defaultDate);
-		assertEquals(expectedString_ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND, formattedDate);
-	}
+    @Test
+    public void testGetISO8601UTCDateWithMilliseconds_when_validDate() {
+        String formattedDate = TimeUtils.getISO8601UTCDateWithMilliseconds(defaultDate);
+        assertEquals(
+                expectedString_ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND, formattedDate);
+    }
 
-	@Test
-	public void testGetISO8601FullDate_when_validDate() {
-		String formattedDate = TimeUtils.getISO8601FullDate(defaultDate);
-		assertEquals(expectedString_ISO8601_FULL_DATE, formattedDate);
-	}
+    @Test
+    public void testGetISO8601FullDate_when_validDate() {
+        String formattedDate = TimeUtils.getISO8601FullDate(defaultDate);
+        assertEquals(expectedString_ISO8601_FULL_DATE, formattedDate);
+    }
 
-	@Test
-	public void testGetRFC2822Date_when_validEpoch_timeZoneGMT_localeUsPosix() {
-		String formattedDate = TimeUtils.getRFC2822Date(defaultEpochMilli, TimeZone.getTimeZone("GMT"), defaultLocale);
-		assertEquals(expectedString_RFC2822_DATE_PATTERN_GMT, formattedDate);
-	}
+    @Test
+    public void testGetRFC2822Date_when_validEpoch_timeZoneGMT_localeUsPosix() {
+        String formattedDate =
+                TimeUtils.getRFC2822Date(
+                        defaultEpochMilli, TimeZone.getTimeZone("GMT"), defaultLocale);
+        assertEquals(expectedString_RFC2822_DATE_PATTERN_GMT, formattedDate);
+    }
 
-	@Test
-	public void testParseRFC2822Date_when_validDateString() {
-		Date parsedDate = TimeUtils.parseRFC2822Date(expectedString_RFC2822_DATE_PATTERN_GMT, TimeZone.getTimeZone("GMT"), defaultLocale);
-		assertEquals(defaultDateNoMilli, parsedDate);
-	}
+    @Test
+    public void testParseRFC2822Date_when_validDateString() {
+        Date parsedDate =
+                TimeUtils.parseRFC2822Date(
+                        expectedString_RFC2822_DATE_PATTERN_GMT,
+                        TimeZone.getTimeZone("GMT"),
+                        defaultLocale);
+        assertEquals(defaultDateNoMilli, parsedDate);
+    }
 
-	// Testing each API with a new Date instance and verifying output using regex
-	@Test
-	public void testGetISO8601Date_returns_correctFormat() {
-		String formattedDate = TimeUtils.getISO8601Date();
-		assertTrue(formattedDate.matches(DATE_REGEX_ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND));
-	}
+    // Testing each API with a new Date instance and verifying output using regex
+    @Test
+    public void testGetISO8601Date_returns_correctFormat() {
+        String formattedDate = TimeUtils.getISO8601Date();
+        assertTrue(formattedDate.matches(DATE_REGEX_ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND));
+    }
 
-	@Test
-	public void testGetISO8601DateNoColon_returns_correctFormat() {
-		String formattedDate = TimeUtils.getISO8601DateNoColon();
-		assertTrue(formattedDate.matches(DATE_REGEX_ISO8601_TIMEZONE_ISO8601_2X_PRECISION_SECOND));
-	}
+    @Test
+    public void testGetISO8601DateNoColon_returns_correctFormat() {
+        String formattedDate = TimeUtils.getISO8601DateNoColon();
+        assertTrue(formattedDate.matches(DATE_REGEX_ISO8601_TIMEZONE_ISO8601_2X_PRECISION_SECOND));
+    }
 
-	@Test
-	public void testGetISO8601FullDate_returns_correctFormat() {
-		String formattedDate = TimeUtils.getISO8601FullDate();
-		assertTrue(formattedDate.matches(DATE_REGEX_ISO8601_FULL_DATE));
-	}
+    @Test
+    public void testGetISO8601FullDate_returns_correctFormat() {
+        String formattedDate = TimeUtils.getISO8601FullDate();
+        assertTrue(formattedDate.matches(DATE_REGEX_ISO8601_FULL_DATE));
+    }
 
-	@Test
-	public void testGetISO8601UTCDateWithMilliseconds_returns_correctFormat() {
-		String formattedDate = TimeUtils.getISO8601UTCDateWithMilliseconds();
-		assertTrue(formattedDate.matches(DATE_REGEX_ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND));
-	}
-
+    @Test
+    public void testGetISO8601UTCDateWithMilliseconds_returns_correctFormat() {
+        String formattedDate = TimeUtils.getISO8601UTCDateWithMilliseconds();
+        assertTrue(
+                formattedDate.matches(
+                        DATE_REGEX_ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND));
+    }
 }

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/util/TimeUtilsTests.java
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/util/TimeUtilsTests.java
@@ -80,7 +80,7 @@ public class TimeUtilsTests {
 
 	@Test
 	public void testGetIso8601Date_TimeZone_ISO8601_returns_milliseconds_and_UTC() {
-		String formattedDate = TimeUtils.getIso8601DateTimeZoneUTC();
+		String formattedDate = TimeUtils.getISO8601UTCDateWithMilliseconds();
 		assertTrue(formattedDate.matches("[0-9]{4}-[0-9]{2}-[0-9]{2}T([0-9]{2}:){2}[0-9]{2}.[0-9]{3}Z"));
 	}
 
@@ -92,7 +92,7 @@ public class TimeUtilsTests {
 		String dateInString = "2022-11-30T13:50:53.945Z";
 		Date testDate = formatter.parse(dateInString);
 
-		String formattedDate = TimeUtils.getIso8601DateTimeZoneUTC(testDate);
+		String formattedDate = TimeUtils.getISO8601UTCDateWithMilliseconds(testDate);
 
 		assertTrue(formattedDate.matches(dateInString));
 	}

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/util/TimeUtilsTests.java
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/util/TimeUtilsTests.java
@@ -29,12 +29,49 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TimeUtilsTests {
+	private static final String DATE_REGEX_ISO8601_TIMEZONE_ISO8601_2X_PRECISION_SECOND =
+		"^((19|2[0-9])[0-9]{2})-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T[0-2][0-9]:[0-5][0-9]:[0-5][0-9][-+][0-9]{4}$";
 
-    private static final String DATE_REGEX_TIMEZONE_RFC822 =
-            "^((19|2[0-9])[0-9]{2})-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T{1}[0-2][0-9]:[0-5][0-9]:[0-5][0-9][-+][0-9]{4}$";
+	private static final String DATE_REGEX_ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND =
+		"^((19|2[0-9])[0-9]{2})-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T[0-2][0-9]:[0-5][0-9]:[0-5][0-9][-+][0-9]{2}:[0-9]{2}$";
 
-    private static final String DATE_REGEX_TIMEZONE_ISO8601 =
-            "^((19|2[0-9])[0-9]{2})-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T{1}[0-2][0-9]:[0-5][0-9]:[0-5][0-9][-+][0-9]{2}:[0-9]{2}$";
+	private static final String DATE_REGEX_ISO8601_FULL_DATE =
+			"^[0-9]{4}-[0-9]{2}-[0-9]{2}$";
+
+	private static final String DATE_REGEX_ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND =
+			"^[0-9]{4}-[0-9]{2}-[0-9]{2}T([0-9]{2}:){2}[0-9]{2}.[0-9]{3}Z$";
+
+	private Date defaultDate;
+	private Date defaultDateNoMilli;
+
+	private String expectedString_ISO8601_FULL_DATE;
+	private String expectedString_ISO8601_TIMEZONE_ISO8601_2X_PRECISION_SECOND;
+	private String expectedString_ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND;
+	private String expectedString_ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND;
+
+	private String expectedString_RFC2822_DATE_PATTERN_GMT;
+
+	private Long defaultEpochMilli;
+	private Locale defaultLocale;
+
+	@Before
+	public void setup() throws ParseException {
+		TimeZone.setDefault(TimeZone.getTimeZone("GMT-7"));
+		defaultLocale = new Locale(Locale.US.getLanguage(), Locale.US.getCountry(), "POSIX");
+		// Setup static date whose expected formats are well-known
+		expectedString_ISO8601_FULL_DATE = "2022-11-30";
+		expectedString_ISO8601_TIMEZONE_ISO8601_2X_PRECISION_SECOND = "2022-11-30T06:50:53-0700";
+		expectedString_ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND = "2022-11-30T06:50:53-07:00";
+		expectedString_ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND = "2022-11-30T13:50:53.945Z";
+		expectedString_RFC2822_DATE_PATTERN_GMT = "Wed, 30 Nov 2022 13:50:53 GMT";
+
+		SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", defaultLocale);
+		formatter.setTimeZone(TimeZone.getTimeZone("GMT"));
+		defaultDate = formatter.parse(expectedString_ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND);
+		formatter.applyPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		defaultDateNoMilli = formatter.parse("2022-11-30T13:50:53Z");
+		defaultEpochMilli = defaultDate.toInstant().toEpochMilli();
+	}
 
     @Before
     public void setup() {
@@ -50,50 +87,66 @@ public class TimeUtilsTests {
         }
     }
 
+	// Testing each API with a well-known date and corresponding formatting result
 	@Test
-	public void testGetIso8601Date_TimeZone_RFC822_when_ValidDate() {
-		long timestamp = 1526405606000L;
-		String formattedDate = TimeUtils.getFormattedDate(new Date(timestamp), TimeUtils.DatePattern.ISO8601_TIMEZONE_RFC822_PRECISION_SECOND);
-		assertEquals("2018-05-15T10:33:26-0700", formattedDate);
+	public void testGetISO8601Date_when_validDate() {
+		String formattedDate = TimeUtils.getISO8601Date(defaultDate);
+		assertEquals(expectedString_ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND, formattedDate);
 	}
 
 	@Test
-	public void testGetIso8601Date_TimeZone_RFC822_when_NullDate() {
-		String formattedDate = TimeUtils.getFormattedDate(null, TimeUtils.DatePattern.ISO8601_TIMEZONE_RFC822_PRECISION_SECOND);
-		assertNotNull(formattedDate);
-		assertTrue(formattedDate.matches(DATE_REGEX_TIMEZONE_RFC822));
+	public void testGetISO8601DateNoColon_when_validDate() {
+		String formattedDate = TimeUtils.getISO8601DateNoColon(defaultDate);
+		assertEquals(expectedString_ISO8601_TIMEZONE_ISO8601_2X_PRECISION_SECOND, formattedDate);
 	}
 
 	@Test
-	public void testGetIso8601Date_TimeZone_ISO8601_when_ValidDate() {
-		long timestamp = 1526405606000L;
-		String formattedDate = TimeUtils.getFormattedDate(new Date(timestamp), TimeUtils.DatePattern.ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND);
-		assertEquals("2018-05-15T10:33:26-07:00", formattedDate);
+	public void testGetISO8601UTCDateWithMilliseconds_when_validDate() {
+		String formattedDate = TimeUtils.getISO8601UTCDateWithMilliseconds(defaultDate);
+		assertEquals(expectedString_ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND, formattedDate);
 	}
 
 	@Test
-	public void testGetIso8601Date_TimeZone_ISO8601_when_NullDate() {
-		String formattedDate = TimeUtils.getFormattedDate(null, TimeUtils.DatePattern.ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND);
-		assertNotNull(formattedDate);
-		assertTrue(formattedDate.matches(DATE_REGEX_TIMEZONE_ISO8601));
+	public void testGetISO8601FullDate_when_validDate() {
+		String formattedDate = TimeUtils.getISO8601FullDate(defaultDate);
+		assertEquals(expectedString_ISO8601_FULL_DATE, formattedDate);
 	}
 
 	@Test
-	public void testGetIso8601Date_TimeZone_ISO8601_returns_milliseconds_and_UTC() {
+	public void testGetRFC2822Date_when_validEpoch_timeZoneGMT_localeUsPosix() {
+		String formattedDate = TimeUtils.getRFC2822Date(defaultEpochMilli, TimeZone.getTimeZone("GMT"), defaultLocale);
+		assertEquals(expectedString_RFC2822_DATE_PATTERN_GMT, formattedDate);
+	}
+
+	@Test
+	public void testParseRFC2822Date_when_validDateString() {
+		Date parsedDate = TimeUtils.parseRFC2822Date(expectedString_RFC2822_DATE_PATTERN_GMT, TimeZone.getTimeZone("GMT"), defaultLocale);
+		assertEquals(defaultDateNoMilli, parsedDate);
+	}
+
+	// Testing each API with a new Date instance and verifying output using regex
+	@Test
+	public void testGetISO8601Date_returns_correctFormat() {
+		String formattedDate = TimeUtils.getISO8601Date();
+		assertTrue(formattedDate.matches(DATE_REGEX_ISO8601_TIMEZONE_ISO8601_3X_PRECISION_SECOND));
+	}
+
+	@Test
+	public void testGetISO8601DateNoColon_returns_correctFormat() {
+		String formattedDate = TimeUtils.getISO8601DateNoColon();
+		assertTrue(formattedDate.matches(DATE_REGEX_ISO8601_TIMEZONE_ISO8601_2X_PRECISION_SECOND));
+	}
+
+	@Test
+	public void testGetISO8601FullDate_returns_correctFormat() {
+		String formattedDate = TimeUtils.getISO8601FullDate();
+		assertTrue(formattedDate.matches(DATE_REGEX_ISO8601_FULL_DATE));
+	}
+
+	@Test
+	public void testGetISO8601UTCDateWithMilliseconds_returns_correctFormat() {
 		String formattedDate = TimeUtils.getISO8601UTCDateWithMilliseconds();
-		assertTrue(formattedDate.matches("[0-9]{4}-[0-9]{2}-[0-9]{2}T([0-9]{2}:){2}[0-9]{2}.[0-9]{3}Z"));
+		assertTrue(formattedDate.matches(DATE_REGEX_ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND));
 	}
 
-	@Test
-	public void testGetIso8601Date_TimeZone_UTC_precision_milliseconds_when_ValidDate() throws ParseException {
-		SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", new Locale(Locale.US.getLanguage(), Locale.US.getCountry(), "POSIX"));
-		formatter.setTimeZone(TimeZone.getTimeZone("Etc/UTC"));
-
-		String dateInString = "2022-11-30T13:50:53.945Z";
-		Date testDate = formatter.parse(dateInString);
-
-		String formattedDate = TimeUtils.getISO8601UTCDateWithMilliseconds(testDate);
-
-		assertTrue(formattedDate.matches(dateInString));
-	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR refactors the existing `TimeUtils` to use a public `enum` system with a set of available date formatting patterns (the current set is pulled from the existing private formatting strings).

Both ISO 8601 helper methods have updated names to better reflect their return values, and both are able to accept an optional `Date` arg to convert using the specified pattern.

`getIso8601Date` -> `getIso8601DateTimeZoneRFC822` 
* There is value in being more specific with the time zone formatting this method uses, as it will reduce potential ambiguity, and this naming convention aligns with the next method:

`getIso8601DateTimeZoneISO8601` -> `getIso8601DateTimeZoneUTC` 
* The "TimeZoneISO8601" is not as clear as "TimeZoneUTC" because ISO 8601 is the general date pattern standard, with many variations possible; UTC makes it more clear that all times will be converted to UTC +0 (with further explanation in the method's docs)

The general purpose date converter `getIso8601Date(date:, format:, timeZone:)` has been updated to accept only non-optional enum values as the date formatting pattern and also renamed:
`getIso8601Date` -> `getFormattedDate` 
* Rationale: since this method handles all date formats, even those not conforming to ISO 8601, its name should reflect that capability; also, even before the enum system was implemented, there was no restriction on the date pattern that could be passed as the arg

The naming convention (generally) for the enum values themselves is as follows:
\<date pattern standard\>\_**TIMEZONE**\_\<time zone format\>\_**PRECISION**\_\<smallest precision unit\>
ISO8601\_**TIMEZONE**\_RFC822\_**PRECISION**\_SECOND
ISO8601\_**TIMEZONE**\_ISO8601\_UTCZ\_**PRECISION**\_MILLISECOND

TimeZone "GMT" has been updated to "Etc/UTC" to move off the [deprecated 3 letter time zones](https://developer.android.com/reference/java/util/TimeZone#three-letter-time-zone-ids), and "Etc/UTC" comes from the canonical value for UTC +0 (zero offset) from the [tzdb](https://en.wikipedia.org/wiki/Tz_database), supported by ICANN.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

This change would make it much easier for 3rd party extensions to get the common date formatting capabilities they need, through both: 
1. Clearly named helper/convenience methods that can convert passed `Date`s or the current `Date()` into commonly needed formats (automatically applying common built-in assumptions about usage; for example, the time zone to use)
    * `getIso8601DateTimeZoneRFC822` -> 2022-11-30T11:53:09-0700
    * `getIso8601DateTimeZoneUTC` -> 2022-11-30T18:53:09.497Z
2. A general purpose date converter that only accepts date patterns defined in the `enum` `TimeUtils.DatePattern`.
    * This allows for easy use of common date formatting patterns that have **guaranteed consistency** (as tested by the TimeUtils test cases, etc.), virtually eliminating potentials for typos, incorrect date formats, etc.

Point 2 also removes the burden of handling every potential date format pattern (that is, basically being a restrictively simple wrapper around `SimpleDateFormat`); it handles all the `enum` cases covered in `DatePattern` gracefully (for example, setting the time zone to the appropriate value automatically for the `ISO8601_TIMEZONE_ISO8601_UTCZ_PRECISION_MILLISECOND` pattern), and if users want their own custom format they can simply use the `SimpleDateFormat` directly.

Also these changes would be most optimal to decide on before the TimeUtils APIs are cemented in a public release.

## How Has This Been Tested?

Unit tests for the TimeUtils have been updated to reflect the new `enum` system, with a new test case for conversion of provided dates into the helper/convenience methods.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
