### PR TITLE
[MOB-17661] Lifecycle v2 set BCP 47 style language tag for XDM field environment._dc.language

### DIFF
--- a/code/android-lifecycle-library/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtil.java
+++ b/code/android-lifecycle-library/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtil.java
@@ -13,9 +13,7 @@ package com.adobe.marketing.mobile.lifecycle;
 
 import android.annotation.SuppressLint;
 import android.os.Build;
-
 import androidx.annotation.VisibleForTesting;
-
 import com.adobe.marketing.mobile.util.StringUtils;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -54,66 +52,66 @@ final class LifecycleUtil {
             return "";
         }
 
-		final String timePattern =
-				StringUtils.isNullOrEmpty(timestampFormat) ? DATE_TIME_FORMAT : timestampFormat;
-		final Locale posixLocale =
-				new Locale(Locale.US.getLanguage(), Locale.US.getCountry(), "POSIX");
-		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(timePattern, posixLocale);
-		simpleDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-		return simpleDateFormat.format(timestamp);
-	}
+        final String timePattern =
+                StringUtils.isNullOrEmpty(timestampFormat) ? DATE_TIME_FORMAT : timestampFormat;
+        final Locale posixLocale =
+                new Locale(Locale.US.getLanguage(), Locale.US.getCountry(), "POSIX");
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(timePattern, posixLocale);
+        simpleDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+        return simpleDateFormat.format(timestamp);
+    }
 
-	/**
-	 * Formats the locale value by replacing '_' with '-'. Uses {@link Locale#toString()} to retrieve
-	 * the language tag.
-	 * <p>
-	 * Note. the use of {@code Locale#toString()} does not return a value formatted to BCP 47.
-	 * For example, script codes are appended to the locale as "-#scriptCode", as in "zh-HK-#Hant",
-	 * where BCP 47 requires the format as "zh-Hant-HK".
-	 *
-	 * @see #formatLocaleXDM(Locale) 
-	 * @param locale active locale value
-	 * @return string representation of the locale
-	 */
-	static String formatLocale(final Locale locale) {
-		return locale == null ? null : locale.toString().replace('_', '-');
-	}
+    /**
+     * Formats the locale value by replacing '_' with '-'. Uses {@link Locale#toString()} to
+     * retrieve the language tag.
+     *
+     * <p>Note. the use of {@code Locale#toString()} does not return a value formatted to BCP 47.
+     * For example, script codes are appended to the locale as "-#scriptCode", as in "zh-HK-#Hant",
+     * where BCP 47 requires the format as "zh-Hant-HK".
+     *
+     * @see #formatLocaleXDM(Locale)
+     * @param locale active locale value
+     * @return string representation of the locale
+     */
+    static String formatLocale(final Locale locale) {
+        return locale == null ? null : locale.toString().replace('_', '-');
+    }
 
-	/**
-	 * Format the locale to the string format used in XDM.
-	 * For Android API version >= Lollipop (21), returns {@link Locale#toLanguageTag()}.
-	 * For Android API version < 21, returns a concatenation of {@link Locale#getLanguage()}
-	 * and {@link Locale#getCountry()}, separated by '-'.
-	 *
-	 * @param locale active Locale value
-	 * @return String representation of the locale
-	 */
-	@SuppressLint("NewApi")
-	static String formatLocaleXDM(final Locale locale) {
-		if (locale == null) {
-			return null;
-		}
+    /**
+     * Format the locale to the string format used in XDM. For Android API version >= Lollipop (21),
+     * returns {@link Locale#toLanguageTag()}. For Android API version < 21, returns a concatenation
+     * of {@link Locale#getLanguage()} and {@link Locale#getCountry()}, separated by '-'.
+     *
+     * @param locale active Locale value
+     * @return String representation of the locale
+     */
+    @SuppressLint("NewApi")
+    static String formatLocaleXDM(final Locale locale) {
+        if (locale == null) {
+            return null;
+        }
 
-		if (isLollipopOrGreater.check()) {
-			return locale.toLanguageTag();
-		} else {
-			String language = locale.getLanguage();
-			String region = locale.getCountry();
+        if (isLollipopOrGreater.check()) {
+            return locale.toLanguageTag();
+        } else {
+            String language = locale.getLanguage();
+            String region = locale.getCountry();
 
-			if (!StringUtils.isNullOrEmpty(language)) {
-					return !StringUtils.isNullOrEmpty(region) ? String.format("%s-%s", language, region) : language;
-			}
+            if (!StringUtils.isNullOrEmpty(language)) {
+                return !StringUtils.isNullOrEmpty(region)
+                        ? String.format("%s-%s", language, region)
+                        : language;
+            }
 
-			return null;
-		}
-	}
+            return null;
+        }
+    }
 
-	interface BuildVersionCheck {
-		boolean check();
-	}
+    interface BuildVersionCheck {
+        boolean check();
+    }
 
-	@VisibleForTesting
-	static BuildVersionCheck isLollipopOrGreater = () ->
-			Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
-
+    @VisibleForTesting
+    static BuildVersionCheck isLollipopOrGreater =
+            () -> Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
 }

--- a/code/android-lifecycle-library/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtil.java
+++ b/code/android-lifecycle-library/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtil.java
@@ -62,8 +62,14 @@ final class LifecycleUtil {
 	}
 
 	/**
-	 * Formats the locale value from SystemInfoService and replaces '_' with '-'
+	 * Formats the locale value by replacing '_' with '-'. Uses {@link Locale#toString()} to retrieve
+	 * the language tag.
+	 * <p>
+	 * Note. the use of {@code Locale#toString()} does not return a value formatted to BCP 47.
+	 * For example, script codes are appended to the locale as "-#scriptCode", as in "zh-HK-#Hant",
+	 * where BCP 47 requires the format as "zh-Hant-HK".
 	 *
+	 * @see #formatLocaleXDM(Locale) 
 	 * @param locale active locale value
 	 * @return string representation of the locale
 	 */
@@ -74,7 +80,7 @@ final class LifecycleUtil {
 	/**
 	 * Format the locale to the string format used in XDM.
 	 * For Android API version >= Lollipop (21), returns {@link Locale#toLanguageTag()}.
-	 * For Android API version <= KitKat (19), returns a concatenation of {@link Locale#getLanguage()}
+	 * For Android API version < 21, returns a concatenation of {@link Locale#getLanguage()}
 	 * and {@link Locale#getCountry()}, separated by '-'.
 	 *
 	 * @param locale active Locale value

--- a/code/android-lifecycle-library/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtil.java
+++ b/code/android-lifecycle-library/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtil.java
@@ -91,14 +91,15 @@ final class LifecycleUtil {
 		} else {
 			String language = locale.getLanguage();
 			String region = locale.getCountry();
-			if (StringUtils.isNullOrEmpty(language)) {
-				return null;
+
+			if (!StringUtils.isNullOrEmpty(language)) {
+				if (!StringUtils.isNullOrEmpty(region)) {
+					return String.format("%s-%s", language, region);
+				}
+					return language;
 			}
-			else if (!StringUtils.isNullOrEmpty(region)) {
-				return String.format("%s-%s", language, region);
-			} else {
-				return language;
-			}
+
+			return null;
 		}
 	}
 

--- a/code/android-lifecycle-library/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtil.java
+++ b/code/android-lifecycle-library/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtil.java
@@ -11,6 +11,11 @@
 
 package com.adobe.marketing.mobile.lifecycle;
 
+import android.annotation.SuppressLint;
+import android.os.Build;
+
+import androidx.annotation.VisibleForTesting;
+
 import com.adobe.marketing.mobile.util.StringUtils;
 
 import java.text.SimpleDateFormat;
@@ -65,5 +70,44 @@ final class LifecycleUtil {
 	static String formatLocale(final Locale locale) {
 		return locale == null ? null : locale.toString().replace('_', '-');
 	}
+
+	/**
+	 * Format the locale to the string format used in XDM.
+	 * For Android API version >= Lollipop (21), returns {@link Locale#toLanguageTag()}.
+	 * For Android API version <= KitKat (19), returns a concatenation of {@link Locale#getLanguage()}
+	 * and {@link Locale#getCountry()}, separated by '-'.
+	 *
+	 * @param locale active Locale value
+	 * @return String representation of the locale
+	 */
+	@SuppressLint("NewApi")
+	static String formatLocaleXDM(final Locale locale) {
+		if (locale == null) {
+			return null;
+		}
+
+		if (isLollipopOrGreater.check()) {
+			return locale.toLanguageTag();
+		} else {
+			String language = locale.getLanguage();
+			String region = locale.getCountry();
+			if (StringUtils.isNullOrEmpty(language)) {
+				return null;
+			}
+			else if (!StringUtils.isNullOrEmpty(region)) {
+				return String.format("%s-%s", language, region);
+			} else {
+				return language;
+			}
+		}
+	}
+
+	interface BuildVersionCheck {
+		boolean check();
+	}
+
+	@VisibleForTesting
+	static BuildVersionCheck isLollipopOrGreater = () ->
+			Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
 
 }

--- a/code/android-lifecycle-library/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtil.java
+++ b/code/android-lifecycle-library/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtil.java
@@ -93,18 +93,18 @@ final class LifecycleUtil {
 
         if (isLollipopOrGreater.check()) {
             return locale.toLanguageTag();
-        } else {
-            String language = locale.getLanguage();
-            String region = locale.getCountry();
+        }
 
-            if (!StringUtils.isNullOrEmpty(language)) {
-                return !StringUtils.isNullOrEmpty(region)
-                        ? String.format("%s-%s", language, region)
-                        : language;
-            }
+        String language = locale.getLanguage();
+        String region = locale.getCountry();
 
+        if (StringUtils.isNullOrEmpty(language)) {
             return null;
         }
+
+        return StringUtils.isNullOrEmpty(region)
+                ? language
+                : String.format("%s-%s", language, region);
     }
 
     interface BuildVersionCheck {

--- a/code/android-lifecycle-library/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtil.java
+++ b/code/android-lifecycle-library/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtil.java
@@ -99,10 +99,7 @@ final class LifecycleUtil {
 			String region = locale.getCountry();
 
 			if (!StringUtils.isNullOrEmpty(language)) {
-				if (!StringUtils.isNullOrEmpty(region)) {
-					return String.format("%s-%s", language, region);
-				}
-					return language;
+					return !StringUtils.isNullOrEmpty(region) ? String.format("%s-%s", language, region) : language;
 			}
 
 			return null;

--- a/code/android-lifecycle-library/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2MetricsBuilder.java
+++ b/code/android-lifecycle-library/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2MetricsBuilder.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
  * </ul>
  */
 class LifecycleV2MetricsBuilder {
-	private static final String SELF_LOG_TAG = "LifecycleV2MetricsBuilder";
+    private static final String SELF_LOG_TAG = "LifecycleV2MetricsBuilder";
     private final DeviceInforming deviceInfoService;
     private XDMLifecycleDevice xdmDeviceInfo;
     private XDMLifecycleEnvironment xdmEnvironmentInfo;

--- a/code/android-lifecycle-library/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2MetricsBuilder.java
+++ b/code/android-lifecycle-library/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2MetricsBuilder.java
@@ -175,7 +175,7 @@ class LifecycleV2MetricsBuilder {
 		xdmEnvironmentInfo.setType(LifecycleV2DataConverter.toEnvironmentTypeEnum(deviceInfoService.getRunMode()));
 		xdmEnvironmentInfo.setOperatingSystem(deviceInfoService.getOperatingSystemName());
 		xdmEnvironmentInfo.setOperatingSystemVersion(deviceInfoService.getOperatingSystemVersion());
-		xdmEnvironmentInfo.setLanguage(LifecycleUtil.formatLocale(deviceInfoService.getActiveLocale()));
+		xdmEnvironmentInfo.setLanguage(LifecycleUtil.formatLocaleXDM(deviceInfoService.getActiveLocale()));
 
 		return xdmEnvironmentInfo;
 	}

--- a/code/android-lifecycle-library/src/main/java/com/adobe/marketing/mobile/lifecycle/XDMLifecycleEnvironment.java
+++ b/code/android-lifecycle-library/src/main/java/com/adobe/marketing/mobile/lifecycle/XDMLifecycleEnvironment.java
@@ -12,12 +12,10 @@
 package com.adobe.marketing.mobile.lifecycle;
 
 import androidx.annotation.NonNull;
-
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.StringUtils;
-
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 /**
@@ -27,15 +25,15 @@ import java.util.regex.Pattern;
  */
 @SuppressWarnings("unused")
 class XDMLifecycleEnvironment {
-	private final String LOG_SOURCE = "XDMLifecycleEnvironment";
+    private final String LOG_SOURCE = "XDMLifecycleEnvironment";
     private String carrier;
     private String language;
     private String operatingSystem;
     private String operatingSystemVersion;
     private XDMLifecycleEnvironmentTypeEnum type;
-	private final String languageRegex =
-			"^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$";
-	private final Pattern languagePattern = Pattern.compile(languageRegex);
+    private final String languageRegex =
+            "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$";
+    private final Pattern languagePattern = Pattern.compile(languageRegex);
 
     XDMLifecycleEnvironment() {}
 
@@ -46,16 +44,20 @@ class XDMLifecycleEnvironment {
             map.put("carrier", this.carrier);
         }
 
-		if (!StringUtils.isNullOrEmpty(this.language)) {
-			if (isValidLanguageTag(this.language)) {
-				Map<String, Object> dublinCoreLanguage = new HashMap<String, Object>();
-				dublinCoreLanguage.put("language", this.language);
-				map.put("_dc", dublinCoreLanguage);
-			} else {
-				Log.warning(LifecycleConstants.LOG_TAG, LOG_SOURCE, "Language tag '%s' failed validation and will be dropped. Values for XDM field 'environment._dc.language' must conform to BCP 47.",
-						this.language);
-			}
-		}
+        if (!StringUtils.isNullOrEmpty(this.language)) {
+            if (isValidLanguageTag(this.language)) {
+                Map<String, Object> dublinCoreLanguage = new HashMap<String, Object>();
+                dublinCoreLanguage.put("language", this.language);
+                map.put("_dc", dublinCoreLanguage);
+            } else {
+                Log.warning(
+                        LifecycleConstants.LOG_TAG,
+                        LOG_SOURCE,
+                        "Language tag '%s' failed validation and will be dropped. Values for XDM"
+                                + " field 'environment._dc.language' must conform to BCP 47.",
+                        this.language);
+            }
+        }
 
         if (this.operatingSystem != null) {
             map.put("operatingSystem", this.operatingSystem);
@@ -179,12 +181,13 @@ class XDMLifecycleEnvironment {
         this.type = newValue;
     }
 
-	/**
-	 * Validate the language tag is formatted per the XDM Environment Schema required pattern.
-	 * @param tag the language tag to validate
-	 * @return true if the language tag matches the pattern.
-	 */
-	private boolean isValidLanguageTag(@NonNull final String tag) {
-		return languagePattern.matcher(tag).matches();
-	}
+    /**
+     * Validate the language tag is formatted per the XDM Environment Schema required pattern.
+     *
+     * @param tag the language tag to validate
+     * @return true if the language tag matches the pattern.
+     */
+    private boolean isValidLanguageTag(@NonNull final String tag) {
+        return languagePattern.matcher(tag).matches();
+    }
 }

--- a/code/android-lifecycle-library/src/main/java/com/adobe/marketing/mobile/lifecycle/XDMLifecycleEnvironment.java
+++ b/code/android-lifecycle-library/src/main/java/com/adobe/marketing/mobile/lifecycle/XDMLifecycleEnvironment.java
@@ -11,8 +11,14 @@
 
 package com.adobe.marketing.mobile.lifecycle;
 
+import androidx.annotation.NonNull;
+
+import com.adobe.marketing.mobile.services.Log;
+import com.adobe.marketing.mobile.util.StringUtils;
+
 import java.util.Map;
 import java.util.HashMap;
+import java.util.regex.Pattern;
 
 /**
  * Class {@code Environment} representing a subset of the XDM Environment data type fields.
@@ -21,11 +27,15 @@ import java.util.HashMap;
  */
 @SuppressWarnings("unused")
 class XDMLifecycleEnvironment {
+	private final String LOG_SOURCE = "XDMLifecycleEnvironment";
 	private String carrier;
 	private String language;
 	private String operatingSystem;
 	private String operatingSystemVersion;
 	private XDMLifecycleEnvironmentTypeEnum type;
+	private final String languageRegex =
+			"^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$";
+	private final Pattern languagePattern = Pattern.compile(languageRegex);
 
 	XDMLifecycleEnvironment() {}
 
@@ -36,10 +46,15 @@ class XDMLifecycleEnvironment {
 			map.put("carrier", this.carrier);
 		}
 
-		if (this.language != null) {
-			Map<String, Object> dublinCoreLanguage = new HashMap<String, Object>();
-			dublinCoreLanguage.put("language", this.language);
-			map.put("_dc", dublinCoreLanguage);
+		if (!StringUtils.isNullOrEmpty(this.language)) {
+			if (isValidLanguageTag(this.language)) {
+				Map<String, Object> dublinCoreLanguage = new HashMap<String, Object>();
+				dublinCoreLanguage.put("language", this.language);
+				map.put("_dc", dublinCoreLanguage);
+			} else {
+				Log.warning(LifecycleConstants.LOG_TAG, LOG_SOURCE, "Language tag '%s' failed validation and will be dropped. Values for XDM field 'environment._dc.language' must conform to BCP 47.",
+						this.language);
+			}
 		}
 
 		if (this.operatingSystem != null) {
@@ -153,5 +168,14 @@ class XDMLifecycleEnvironment {
 	 */
 	void setType(final XDMLifecycleEnvironmentTypeEnum newValue) {
 		this.type = newValue;
+	}
+
+	/**
+	 * Validate the language tag is formatted per the XDM Environment Schema required pattern.
+	 * @param tag the language tag to validate
+	 * @return true if the language tag matches the pattern.
+	 */
+	private boolean isValidLanguageTag(@NonNull final String tag) {
+		return languagePattern.matcher(tag).matches();
 	}
 }

--- a/code/android-lifecycle-library/src/test/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtilLocaleTest.java
+++ b/code/android-lifecycle-library/src/test/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtilLocaleTest.java
@@ -19,18 +19,13 @@ import org.junit.runners.Parameterized;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
-import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import android.os.Build;
 
 @RunWith(Parameterized.class)
 public class LifecycleUtilLocaleTest {
-    // Pattern used in XDM Environment._dc.language to validate language code
-    private final String languagePattern = "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$";
 
     @After
     public void teardown() {
@@ -57,6 +52,14 @@ public class LifecycleUtilLocaleTest {
                 {
                         // Variant only
                         "Variant only", null, "und-POSIX", new Locale.Builder().setVariant("POSIX").build()
+                },
+                {
+                        // Undefined
+                        "Undefined Locale", null, "und", new Locale.Builder().build()
+                },
+                {
+                        // Null
+                        "Null Locale", null, null, null
                 },
                 {
                         // Language + Region
@@ -122,7 +125,6 @@ public class LifecycleUtilLocaleTest {
                         // English US with Buddhist Calendar
                         "en-US-ca-buddhist", "en-US", "en-US", Locale.forLanguageTag("en-US-ca-buddhist")
                 }
-
         });
     }
 
@@ -150,24 +152,5 @@ public class LifecycleUtilLocaleTest {
         LifecycleUtil.isLollipopOrGreater = () -> false;
         String result = LifecycleUtil.formatLocaleXDM(testLocale);
         assertEquals(expectedKitKat, result);
-    }
-
-    @Test
-    public void testFormattedLocaleConformsToXDMPatternLollipopSDK() {
-        LifecycleUtil.isLollipopOrGreater = () -> true;
-        String result = LifecycleUtil.formatLocaleXDM(testLocale);
-        assertTrue("Locale does not match pattern: " + result, Pattern.matches(languagePattern, result));
-    }
-
-    @Test
-    public void testFormattedLocaleConformsToXDMPatternKitKatSDKSDK() {
-        LifecycleUtil.isLollipopOrGreater = () -> false;
-        String result = LifecycleUtil.formatLocaleXDM(testLocale);
-        if (expectedKitKat == null) {
-            // If formatted result is null, then value is not added to XDM
-            assertNull(result);
-        } else {
-            assertTrue("Locale does not match pattern: " + result, Pattern.matches(languagePattern, result));
-        }
     }
 }

--- a/code/android-lifecycle-library/src/test/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtilLocaleTest.java
+++ b/code/android-lifecycle-library/src/test/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtilLocaleTest.java
@@ -7,22 +7,20 @@
   the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
   OF ANY KIND, either express or implied. See the License for the specific language
   governing permissions and limitations under the License.
- */
+*/
 
 package com.adobe.marketing.mobile.lifecycle;
-
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 
 import android.os.Build;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Locale;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
 public class LifecycleUtilLocaleTest {
@@ -30,102 +28,166 @@ public class LifecycleUtilLocaleTest {
     @After
     public void teardown() {
         // Reset build check version for tests outside this class
-        LifecycleUtil.isLollipopOrGreater = () -> Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
+        LifecycleUtil.isLollipopOrGreater =
+                () -> Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
     }
 
-    @Parameterized.Parameters( name = "{index}: {0}")
+    @Parameterized.Parameters(name = "{index}: {0}")
     public static Collection<Object[]> data() {
-        // 0: test name,  1: expected result for Android KitKat, 2: expected result for Android Lollipop, 3: Locale object to test with
-        return Arrays.asList(new Object[][] {
-                {
+        // 0: test name,  1: expected result for Android KitKat, 2: expected result for Android
+        // Lollipop, 3: Locale object to test with
+        return Arrays.asList(
+                new Object[][] {
+                    {
                         // Language only
                         "Language only", "en", "en", new Locale.Builder().setLanguage("en").build()
-                },
-                {
+                    },
+                    {
                         // Region only
                         "Region only", null, "und-US", new Locale.Builder().setRegion("US").build()
-                },
-                {
+                    },
+                    {
                         // Script only
-                        "Script only", null, "und-Hant", new Locale.Builder().setScript("Hant").build()
-                },
-                {
+                        "Script only",
+                        null,
+                        "und-Hant",
+                        new Locale.Builder().setScript("Hant").build()
+                    },
+                    {
                         // Variant only
-                        "Variant only", null, "und-POSIX", new Locale.Builder().setVariant("POSIX").build()
-                },
-                {
+                        "Variant only",
+                        null,
+                        "und-POSIX",
+                        new Locale.Builder().setVariant("POSIX").build()
+                    },
+                    {
                         // Undefined
                         "Undefined Locale", null, "und", new Locale.Builder().build()
-                },
-                {
+                    },
+                    {
                         // Null
                         "Null Locale", null, null, null
-                },
-                {
+                    },
+                    {
                         // Language + Region
-                        "Language + Region", "es-US", "es-US", new Locale.Builder().setLanguage("es").setRegion("US").build()
-                },
-                {
+                        "Language + Region",
+                        "es-US",
+                        "es-US",
+                        new Locale.Builder().setLanguage("es").setRegion("US").build()
+                    },
+                    {
                         // Language + Region + Variant
-                        "Language + Region + Variant", "de-DE", "de-DE-POSIX", new Locale("DE", "DE", "POSIX")
-                },
-                {
+                        "Language + Region + Variant",
+                        "de-DE",
+                        "de-DE-POSIX",
+                        new Locale("DE", "DE", "POSIX")
+                    },
+                    {
                         // Language + Variant
-                        "Language + Variant", "de", "de-POSIX", new Locale.Builder().setLanguage("de").setVariant("POSIX").build()
-                },
-                {
+                        "Language + Variant",
+                        "de",
+                        "de-POSIX",
+                        new Locale.Builder().setLanguage("de").setVariant("POSIX").build()
+                    },
+                    {
                         // Language + Script + Region + Variant
-                        "Language + Script + Region + Variant", "de-DE", "de-Latn-DE-POSIX", new Locale.Builder().setLanguage("de").setRegion("DE").setScript("Latn").setVariant("POSIX").build()
-                },
-                {
+                        "Language + Script + Region + Variant",
+                        "de-DE",
+                        "de-Latn-DE-POSIX",
+                        new Locale.Builder()
+                                .setLanguage("de")
+                                .setRegion("DE")
+                                .setScript("Latn")
+                                .setVariant("POSIX")
+                                .build()
+                    },
+                    {
                         // Language + Script + Region
-                        "Chinese Hong Kong", "zh-HK", "zh-Hant-HK", new Locale.Builder().setLanguage("zh").setRegion("HK").setScript("Hant").build()
-                },
-                {
+                        "Chinese Hong Kong",
+                        "zh-HK",
+                        "zh-Hant-HK",
+                        new Locale.Builder()
+                                .setLanguage("zh")
+                                .setRegion("HK")
+                                .setScript("Hant")
+                                .build()
+                    },
+                    {
                         // Language + Script + Region
-                        "Chinese China", "zh-CN", "zh-Hans-CN", new Locale.Builder().setLanguage("zh").setRegion("CN").setScript("Hans").build()
-                },
-                {
+                        "Chinese China",
+                        "zh-CN",
+                        "zh-Hans-CN",
+                        new Locale.Builder()
+                                .setLanguage("zh")
+                                .setRegion("CN")
+                                .setScript("Hans")
+                                .build()
+                    },
+                    {
                         // Language + Script
-                        "Language + Script", "it", "it-Latn", new Locale.Builder().setLanguage("it").setScript("Latn").build()
-                },
-                {
+                        "Language + Script",
+                        "it",
+                        "it-Latn",
+                        new Locale.Builder().setLanguage("it").setScript("Latn").build()
+                    },
+                    {
                         // Serbian Montenegro
-                        "Serbian Montenegro", "sr-ME", "sr-ME-x-lvariant-Latn", new Locale("sr", "ME", "Latn")
-                },
-                {
+                        "Serbian Montenegro",
+                        "sr-ME",
+                        "sr-ME-x-lvariant-Latn",
+                        new Locale("sr", "ME", "Latn")
+                    },
+                    {
                         // "no" is treated as Norwegian Nynorsk (nn)
                         "Norwegian Nynorsk", "no-NO", "nn-NO", new Locale("no", "NO", "NY")
-                },
-                {
+                    },
+                    {
                         // Special case for Japanese Calendar
-                        "ja-JP-u-ca-japanese", "ja-JP", "ja-JP-u-ca-japanese", Locale.forLanguageTag("ja-JP-u-ca-japanese")
-                },
-                {
+                        "ja-JP-u-ca-japanese",
+                        "ja-JP",
+                        "ja-JP-u-ca-japanese",
+                        Locale.forLanguageTag("ja-JP-u-ca-japanese")
+                    },
+                    {
                         // Special case for Japanese Calendar
-                        "Special case: ja_JP_JP", "ja-JP", "ja-JP-u-ca-japanese-x-lvariant-JP", new Locale("JA", "JP", "JP")
-                },
-                {
+                        "Special case: ja_JP_JP",
+                        "ja-JP",
+                        "ja-JP-u-ca-japanese-x-lvariant-JP",
+                        new Locale("JA", "JP", "JP")
+                    },
+                    {
                         // Special case for Thai Buddhist Calendar
-                        "Special case: th_TH_TH", "th-TH", "th-TH-u-nu-thai-x-lvariant-TH", new Locale("TH", "TH", "TH")
-                },
-                {
+                        "Special case: th_TH_TH",
+                        "th-TH",
+                        "th-TH-u-nu-thai-x-lvariant-TH",
+                        new Locale("TH", "TH", "TH")
+                    },
+                    {
                         // Special case for Thai Buddhist Calendar
-                        "th-TH-u-ca-buddhist", "th-TH", "th-TH-u-ca-buddhist", Locale.forLanguageTag("th-TH-u-ca-buddhist")
-                },
-                {
+                        "th-TH-u-ca-buddhist",
+                        "th-TH",
+                        "th-TH-u-ca-buddhist",
+                        Locale.forLanguageTag("th-TH-u-ca-buddhist")
+                    },
+                    {
                         // Special case for Thai Buddhist Calendar
-                        "th-TH-u-ca-buddhist-nu-thai", "th-TH", "th-TH-u-ca-buddhist-nu-thai", Locale.forLanguageTag("th-TH-u-ca-buddhist-nu-thai")
-                },
-                {
+                        "th-TH-u-ca-buddhist-nu-thai",
+                        "th-TH",
+                        "th-TH-u-ca-buddhist-nu-thai",
+                        Locale.forLanguageTag("th-TH-u-ca-buddhist-nu-thai")
+                    },
+                    {
                         // Grandfathered locale
                         "Grandfathered i-klingon", "tlh", "tlh", Locale.forLanguageTag("i-klingon")
-                },
-                {
+                    },
+                    {
                         // English US with Buddhist Calendar
-                        "en-US-ca-buddhist", "en-US", "en-US", Locale.forLanguageTag("en-US-ca-buddhist")
-                }
-        });
+                        "en-US-ca-buddhist",
+                        "en-US",
+                        "en-US",
+                        Locale.forLanguageTag("en-US-ca-buddhist")
+                    }
+                });
     }
 
     @Parameterized.Parameter(0)

--- a/code/android-lifecycle-library/src/test/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtilLocaleTest.java
+++ b/code/android-lifecycle-library/src/test/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtilLocaleTest.java
@@ -1,0 +1,173 @@
+/*
+  Copyright 2022 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+ */
+
+package com.adobe.marketing.mobile.lifecycle;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import android.os.Build;
+
+@RunWith(Parameterized.class)
+public class LifecycleUtilLocaleTest {
+    // Pattern used in XDM Environment._dc.language to validate language code
+    private final String languagePattern = "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$";
+
+    @After
+    public void teardown() {
+        // Reset build check version for tests outside this class
+        LifecycleUtil.isLollipopOrGreater = () -> Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
+    }
+
+    @Parameterized.Parameters( name = "{index}: {0}")
+    public static Collection<Object[]> data() {
+        // 0: test name,  1: expected result for Android KitKat, 2: expected result for Android Lollipop, 3: Locale object to test with
+        return Arrays.asList(new Object[][] {
+                {
+                        // Language only
+                        "Language only", "en", "en", new Locale.Builder().setLanguage("en").build()
+                },
+                {
+                        // Region only
+                        "Region only", null, "und-US", new Locale.Builder().setRegion("US").build()
+                },
+                {
+                        // Script only
+                        "Script only", null, "und-Hant", new Locale.Builder().setScript("Hant").build()
+                },
+                {
+                        // Variant only
+                        "Variant only", null, "und-POSIX", new Locale.Builder().setVariant("POSIX").build()
+                },
+                {
+                        // Language + Region
+                        "Language + Region", "es-US", "es-US", new Locale.Builder().setLanguage("es").setRegion("US").build()
+                },
+                {
+                        // Language + Region + Variant
+                        "Language + Region + Variant", "de-DE", "de-DE-POSIX", new Locale("DE", "DE", "POSIX")
+                },
+                {
+                        // Language + Variant
+                        "Language + Variant", "de", "de-POSIX", new Locale.Builder().setLanguage("de").setVariant("POSIX").build()
+                },
+                {
+                        // Language + Script + Region + Variant
+                        "Language + Script + Region + Variant", "de-DE", "de-Latn-DE-POSIX", new Locale.Builder().setLanguage("de").setRegion("DE").setScript("Latn").setVariant("POSIX").build()
+                },
+                {
+                        // Language + Script + Region
+                        "Chinese Hong Kong", "zh-HK", "zh-Hant-HK", new Locale.Builder().setLanguage("zh").setRegion("HK").setScript("Hant").build()
+                },
+                {
+                        // Language + Script + Region
+                        "Chinese China", "zh-CN", "zh-Hans-CN", new Locale.Builder().setLanguage("zh").setRegion("CN").setScript("Hans").build()
+                },
+                {
+                        // Language + Script
+                        "Language + Script", "it", "it-Latn", new Locale.Builder().setLanguage("it").setScript("Latn").build()
+                },
+                {
+                        // Serbian Montenegro
+                        "Serbian Montenegro", "sr-ME", "sr-ME-x-lvariant-Latn", new Locale("sr", "ME", "Latn")
+                },
+                {
+                        // "no" is treated as Norwegian Nynorsk (nn)
+                        "Norwegian Nynorsk", "no-NO", "nn-NO", new Locale("no", "NO", "NY")
+                },
+                {
+                        // Special case for Japanese Calendar
+                        "ja-JP-u-ca-japanese", "ja-JP", "ja-JP-u-ca-japanese", Locale.forLanguageTag("ja-JP-u-ca-japanese")
+                },
+                {
+                        // Special case for Japanese Calendar
+                        "Special case: ja_JP_JP", "ja-JP", "ja-JP-u-ca-japanese-x-lvariant-JP", new Locale("JA", "JP", "JP")
+                },
+                {
+                        // Special case for Thai Buddhist Calendar
+                        "Special case: th_TH_TH", "th-TH", "th-TH-u-nu-thai-x-lvariant-TH", new Locale("TH", "TH", "TH")
+                },
+                {
+                        // Special case for Thai Buddhist Calendar
+                        "th-TH-u-ca-buddhist", "th-TH", "th-TH-u-ca-buddhist", Locale.forLanguageTag("th-TH-u-ca-buddhist")
+                },
+                {
+                        // Special case for Thai Buddhist Calendar
+                        "th-TH-u-ca-buddhist-nu-thai", "th-TH", "th-TH-u-ca-buddhist-nu-thai", Locale.forLanguageTag("th-TH-u-ca-buddhist-nu-thai")
+                },
+                {
+                        // Grandfathered locale
+                        "Grandfathered i-klingon", "tlh", "tlh", Locale.forLanguageTag("i-klingon")
+                },
+                {
+                        // English US with Buddhist Calendar
+                        "en-US-ca-buddhist", "en-US", "en-US", Locale.forLanguageTag("en-US-ca-buddhist")
+                }
+
+        });
+    }
+
+    @Parameterized.Parameter(0)
+    public String testName;
+
+    @Parameterized.Parameter(1)
+    public String expectedKitKat;
+
+    @Parameterized.Parameter(2)
+    public String expectedLollipop;
+
+    @Parameterized.Parameter(3)
+    public Locale testLocale;
+
+    @Test
+    public void testFormatLocaleXDM_usingLollipopSDK() {
+        LifecycleUtil.isLollipopOrGreater = () -> true;
+        String result = LifecycleUtil.formatLocaleXDM(testLocale);
+        assertEquals(expectedLollipop, result);
+    }
+
+    @Test
+    public void testFormatLocaleXDM_usingKitKatSDK() {
+        LifecycleUtil.isLollipopOrGreater = () -> false;
+        String result = LifecycleUtil.formatLocaleXDM(testLocale);
+        assertEquals(expectedKitKat, result);
+    }
+
+    @Test
+    public void testFormattedLocaleConformsToXDMPatternLollipopSDK() {
+        LifecycleUtil.isLollipopOrGreater = () -> true;
+        String result = LifecycleUtil.formatLocaleXDM(testLocale);
+        assertTrue("Locale does not match pattern: " + result, Pattern.matches(languagePattern, result));
+    }
+
+    @Test
+    public void testFormattedLocaleConformsToXDMPatternKitKatSDKSDK() {
+        LifecycleUtil.isLollipopOrGreater = () -> false;
+        String result = LifecycleUtil.formatLocaleXDM(testLocale);
+        if (expectedKitKat == null) {
+            // If formatted result is null, then value is not added to XDM
+            assertNull(result);
+        } else {
+            assertTrue("Locale does not match pattern: " + result, Pattern.matches(languagePattern, result));
+        }
+    }
+}

--- a/code/android-lifecycle-library/src/test/java/com/adobe/marketing/mobile/lifecycle/XDMLifecycleEnvironmentLanguageTest.java
+++ b/code/android-lifecycle-library/src/test/java/com/adobe/marketing/mobile/lifecycle/XDMLifecycleEnvironmentLanguageTest.java
@@ -17,9 +17,13 @@ import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+
+import com.adobe.marketing.mobile.util.DataReader;
+import com.adobe.marketing.mobile.util.DataReaderException;
 
 @RunWith(Parameterized.class)
 public class XDMLifecycleEnvironmentLanguageTest {
@@ -132,14 +136,15 @@ public class XDMLifecycleEnvironmentLanguageTest {
 
     // Test various language tag strings and verify only valid language tags are returned in XDM mapping.
     @Test
-    public void testSerializeToXDM_and_isValidLanguageTag() {
+    public void testSerializeToXDM_and_isValidLanguageTag() throws DataReaderException {
         final XDMLifecycleEnvironment environment = new XDMLifecycleEnvironment();
         environment.setLanguage(languageTag);
         final Map<String, Object> result = environment.serializeToXdm();
 
         if (expected != null) {
             assertEquals(1, result.size());
-            assertEquals(expected, ((Map<String, Object>) result.get("_dc")).get("language"));
+            Map<String, Object> dublinCore = DataReader.getTypedMap(Object.class, result, "_dc");
+            assertEquals(expected, DataReader.getString(dublinCore, "language"));
         } else {
             assertEquals(0, result.size());
         }

--- a/code/android-lifecycle-library/src/test/java/com/adobe/marketing/mobile/lifecycle/XDMLifecycleEnvironmentLanguageTest.java
+++ b/code/android-lifecycle-library/src/test/java/com/adobe/marketing/mobile/lifecycle/XDMLifecycleEnvironmentLanguageTest.java
@@ -7,126 +7,129 @@
   the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
   OF ANY KIND, either express or implied. See the License for the specific language
   governing permissions and limitations under the License.
- */
+*/
 
 package com.adobe.marketing.mobile.lifecycle;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.DataReaderException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
 public class XDMLifecycleEnvironmentLanguageTest {
 
     @Parameterized.Parameters(name = "{index}: {0} ({2})")
     public static Collection<Object[]> data() {
-        // List of various language tags, some use BCP 47 formatting while others use Locale.toString formatting
-        // LifecycleUtil.formatLocaleXDM trims the language tag so not all these values are seen in end-to-end scenarios.
+        // List of various language tags, some use BCP 47 formatting while others use
+        // Locale.toString formatting
+        // LifecycleUtil.formatLocaleXDM trims the language tag so not all these values are seen in
+        // end-to-end scenarios.
         // 0: test name, 1: expected result 2: language tag to test
-        return Arrays.asList(new Object[][] {
-                {
+        return Arrays.asList(
+                new Object[][] {
+                    {
                         // Language only
                         "Language only", "en", "en"
-                },
-                {
+                    },
+                    {
                         // Language + Region
                         "Language + Region", "es-US", "es-US"
-                },
-                {
+                    },
+                    {
                         // Language + Region + Script
                         "Language + Script + Region", "zh-Hant-HK", "zh-Hant-HK"
-                },
-                {
+                    },
+                    {
                         // Language + Region + Variant
                         "Language + Region + Variant", "de-DE-POSIX", "de-DE-POSIX"
-                },
-                {
+                    },
+                    {
                         // Language + Region + Script + Variant
-                        "Language + Script + Region + Variant", "de-Latn-DE-POSIX", "de-Latn-DE-POSIX"
-                },
-                {
+                        "Language + Script + Region + Variant",
+                        "de-Latn-DE-POSIX",
+                        "de-Latn-DE-POSIX"
+                    },
+                    {
                         // Undefined Language + Region
                         "Undefined Language + Region", "und-US", "und-US"
-                },
-                {
+                    },
+                    {
                         // Undefined Language + Script
                         "Undefined Language + Script", "und-Hant", "und-Hant"
-                },
-                {
+                    },
+                    {
                         // Undefined Language + Variant
                         "Undefined Language + Variant", "und-POSIX", "und-POSIX"
-                },
-                {
+                    },
+                    {
                         // Japanese Calendar - for compatibility
                         "Japanese Calendar", "ja-JP-x-lvariant-JP", "ja-JP-x-lvariant-JP"
-                },
-                {
+                    },
+                    {
                         // Japanese Calendar
                         "Japanese Calendar", "ja-JP-u-ca-japanese", "ja-JP-u-ca-japanese"
-                },
-                {
+                    },
+                    {
                         // Thai Buddhist Calendar
-                        "Thai Buddhist Calendar", "th-TH-u-ca-buddhist-nu-thai", "th-TH-u-ca-buddhist-nu-thai"
-                },
-                {
+                        "Thai Buddhist Calendar",
+                        "th-TH-u-ca-buddhist-nu-thai",
+                        "th-TH-u-ca-buddhist-nu-thai"
+                    },
+                    {
                         // Serbian Montenegro - for compatibility
                         "Serbian Montenegro", "sr-ME-x-lvariant-Latn", "sr-ME-x-lvariant-Latn"
-                },
-                {
+                    },
+                    {
                         // Grandfathered
                         "Grandfather Klingon", "i-klingon", "i-klingon"
-                },
-                {
+                    },
+                    {
                         // Null Locale
                         "Null locale", null, null
-                },
-                {
+                    },
+                    {
                         // Empty Locale
                         "Empty locale", null, ""
-                },
-                {
+                    },
+                    {
                         // Non BCP 47 tag - pound sign
                         "Invalid script format '-#'", null, "zh-HK-#Hant"
-                },
-                {
+                    },
+                    {
                         // Non BCP 47 tag - ampersand
                         "Invalid calendar format '@'", null, "en-US@calendar=buddhist"
-                },
-                {
+                    },
+                    {
                         // Non BCP 47 tag - double hyphen
                         "Invalid language + variant '--'", null, "de--POSIX"
-                },
-                {
+                    },
+                    {
                         // Non BCP 47 tag - leading hyphen
                         "Invalid country only '-'", null, "-US"
-                },
-                {
+                    },
+                    {
                         // Non BCP 47 tag - pound sign
                         "Invalid script + extension '#'", null, "zh-TW-#Hant-x-java"
-                },
-                {
+                    },
+                    {
                         // Non BCP 47 tag - underscore instead of hyphen
                         "Invalid underscore", null, "en_US"
-                },
-                {
+                    },
+                    {
                         // Non BCP 47 tag - Thai special case
                         "Invalid Thai special case", null, "th-TH-TH-#u-nu-thai"
-                },
-        });
+                    },
+                });
     }
 
-    @Parameterized.Parameter()
-    public String testName;
+    @Parameterized.Parameter() public String testName;
 
     @Parameterized.Parameter(1)
     public String expected;
@@ -134,7 +137,8 @@ public class XDMLifecycleEnvironmentLanguageTest {
     @Parameterized.Parameter(2)
     public String languageTag;
 
-    // Test various language tag strings and verify only valid language tags are returned in XDM mapping.
+    // Test various language tag strings and verify only valid language tags are returned in XDM
+    // mapping.
     @Test
     public void testSerializeToXDM_and_isValidLanguageTag() throws DataReaderException {
         final XDMLifecycleEnvironment environment = new XDMLifecycleEnvironment();

--- a/code/android-lifecycle-library/src/test/java/com/adobe/marketing/mobile/lifecycle/XDMLifecycleEnvironmentLanguageTest.java
+++ b/code/android-lifecycle-library/src/test/java/com/adobe/marketing/mobile/lifecycle/XDMLifecycleEnvironmentLanguageTest.java
@@ -1,0 +1,147 @@
+/*
+  Copyright 2022 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+ */
+
+package com.adobe.marketing.mobile.lifecycle;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class XDMLifecycleEnvironmentLanguageTest {
+
+    @Parameterized.Parameters(name = "{index}: {0} ({2})")
+    public static Collection<Object[]> data() {
+        // List of various language tags, some use BCP 47 formatting while others use Locale.toString formatting
+        // LifecycleUtil.formatLocaleXDM trims the language tag so not all these values are seen in end-to-end scenarios.
+        // 0: test name, 1: expected result 2: language tag to test
+        return Arrays.asList(new Object[][] {
+                {
+                        // Language only
+                        "Language only", "en", "en"
+                },
+                {
+                        // Language + Region
+                        "Language + Region", "es-US", "es-US"
+                },
+                {
+                        // Language + Region + Script
+                        "Language + Script + Region", "zh-Hant-HK", "zh-Hant-HK"
+                },
+                {
+                        // Language + Region + Variant
+                        "Language + Region + Variant", "de-DE-POSIX", "de-DE-POSIX"
+                },
+                {
+                        // Language + Region + Script + Variant
+                        "Language + Script + Region + Variant", "de-Latn-DE-POSIX", "de-Latn-DE-POSIX"
+                },
+                {
+                        // Undefined Language + Region
+                        "Undefined Language + Region", "und-US", "und-US"
+                },
+                {
+                        // Undefined Language + Script
+                        "Undefined Language + Script", "und-Hant", "und-Hant"
+                },
+                {
+                        // Undefined Language + Variant
+                        "Undefined Language + Variant", "und-POSIX", "und-POSIX"
+                },
+                {
+                        // Japanese Calendar - for compatibility
+                        "Japanese Calendar", "ja-JP-x-lvariant-JP", "ja-JP-x-lvariant-JP"
+                },
+                {
+                        // Japanese Calendar
+                        "Japanese Calendar", "ja-JP-u-ca-japanese", "ja-JP-u-ca-japanese"
+                },
+                {
+                        // Thai Buddhist Calendar
+                        "Thai Buddhist Calendar", "th-TH-u-ca-buddhist-nu-thai", "th-TH-u-ca-buddhist-nu-thai"
+                },
+                {
+                        // Serbian Montenegro - for compatibility
+                        "Serbian Montenegro", "sr-ME-x-lvariant-Latn", "sr-ME-x-lvariant-Latn"
+                },
+                {
+                        // Grandfathered
+                        "Grandfather Klingon", "i-klingon", "i-klingon"
+                },
+                {
+                        // Null Locale
+                        "Null locale", null, null
+                },
+                {
+                        // Empty Locale
+                        "Empty locale", null, ""
+                },
+                {
+                        // Non BCP 47 tag - pound sign
+                        "Invalid script format '-#'", null, "zh-HK-#Hant"
+                },
+                {
+                        // Non BCP 47 tag - ampersand
+                        "Invalid calendar format '@'", null, "en-US@calendar=buddhist"
+                },
+                {
+                        // Non BCP 47 tag - double hyphen
+                        "Invalid language + variant '--'", null, "de--POSIX"
+                },
+                {
+                        // Non BCP 47 tag - leading hyphen
+                        "Invalid country only '-'", null, "-US"
+                },
+                {
+                        // Non BCP 47 tag - pound sign
+                        "Invalid script + extension '#'", null, "zh-TW-#Hant-x-java"
+                },
+                {
+                        // Non BCP 47 tag - underscore instead of hyphen
+                        "Invalid underscore", null, "en_US"
+                },
+                {
+                        // Non BCP 47 tag - Thai special case
+                        "Invalid Thai special case", null, "th-TH-TH-#u-nu-thai"
+                },
+        });
+    }
+
+    @Parameterized.Parameter()
+    public String testName;
+
+    @Parameterized.Parameter(1)
+    public String expected;
+
+    @Parameterized.Parameter(2)
+    public String languageTag;
+
+    // Test various language tag strings and verify only valid language tags are returned in XDM mapping.
+    @Test
+    public void testSerializeToXDM_and_isValidLanguageTag() {
+        final XDMLifecycleEnvironment environment = new XDMLifecycleEnvironment();
+        environment.setLanguage(languageTag);
+        final Map<String, Object> result = environment.serializeToXdm();
+
+        if (expected != null) {
+            assertEquals(1, result.size());
+            assertEquals(expected, ((Map<String, Object>) result.get("_dc")).get("language"));
+        } else {
+            assertEquals(0, result.size());
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Format the value set in the XDM field environment._dc.language to a BCP 47 style language tag.
The XDM schema for Environment requires the _dc.language field be formatted to BCP 47. The existing format used in the v2 metrics builder did not use a valid format when the locale contained script, variant, or extension codes. 
Fixes the issue by:

- When using Android API 21+, use Locale.toLanguageTag() which returns a valid BCP 47 style tag
- When using lower Android APIs, formats the language tag by using _languageCode_-_countryCode_
- Adds a validation step in XDMLifecycleEnvironment as a failsafe so only valid language tags are added to environment._dc.language.

This PR does not change the locale format in any other uses than defined above.

## Related Issue
https://github.com/adobe/aepsdk-core-android/issues/92
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
