### PR TITLE
Fix the version of Signal library artifact

### DIFF
--- a/code/android-signal-library/build.gradle
+++ b/code/android-signal-library/build.gradle
@@ -74,7 +74,7 @@ publishing {
         release(MavenPublication) {
             groupId = groupIdForPublish
             artifactId = rootProject.signalExtensionName
-            version = rootProject.signalExtensionVersion
+            version = version
             artifact("$buildDir/outputs/aar/${rootProject.signalExtensionAARName}")
 
             pom {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Signal library should use the publish version based on the type of the build. Fix the publish based on `isReleaseBuild()`
