### PR TITLE
Shutdown PersistentHitQueue ScheduledExecutorService on close()

### DIFF
--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/services/PersistentHitQueue.java
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/services/PersistentHitQueue.java
@@ -11,6 +11,7 @@
 
 package com.adobe.marketing.mobile.services;
 
+import androidx.annotation.VisibleForTesting;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -25,8 +26,7 @@ public class PersistentHitQueue extends HitQueuing {
     private final DataQueue queue;
     private final HitProcessing processor;
     private AtomicBoolean suspended = new AtomicBoolean(true);
-    private final ScheduledExecutorService scheduledExecutorService =
-            Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService scheduledExecutorService;
     private final AtomicBoolean isTaskScheduled = new AtomicBoolean(false);
 
     /**
@@ -38,6 +38,14 @@ public class PersistentHitQueue extends HitQueuing {
      */
     public PersistentHitQueue(final DataQueue queue, final HitProcessing processor)
             throws IllegalArgumentException {
+        this(queue, processor, Executors.newSingleThreadScheduledExecutor());
+    }
+
+    @VisibleForTesting
+    PersistentHitQueue(
+            final DataQueue queue,
+            final HitProcessing processor,
+            final ScheduledExecutorService executorService) {
         if (queue == null || processor == null) {
             throw new IllegalArgumentException(
                     "Null value is not allowed in PersistentHitQueue Constructor.");
@@ -45,6 +53,7 @@ public class PersistentHitQueue extends HitQueuing {
 
         this.queue = queue;
         this.processor = processor;
+        this.scheduledExecutorService = executorService;
     }
 
     @Override
@@ -79,6 +88,7 @@ public class PersistentHitQueue extends HitQueuing {
     public void close() {
         suspend();
         queue.close();
+        scheduledExecutorService.shutdown();
     }
 
     /**

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/services/PersistentHitQueueTests.java
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/services/PersistentHitQueueTests.java
@@ -40,7 +40,7 @@ public class PersistentHitQueueTests {
     @Mock ScheduledExecutorService scheduledExecutorService;
 
     @Test
-    public void testIllegalArguementExceptionIsThrownWhenPassNullToConstructor() {
+    public void testIllegalArgumentExceptionIsThrownWhenPassNullToConstructor() {
         // Setup
         boolean isExceptionThrown = false;
 

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/services/PersistentHitQueueTests.java
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/services/PersistentHitQueueTests.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.verify;
 import com.adobe.marketing.mobile.MobilePrivacyStatus;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Assert;
 import org.junit.Test;
@@ -35,6 +36,8 @@ public class PersistentHitQueueTests {
     @Mock DataQueue dataQueue;
 
     @Mock HitProcessing processor;
+
+    @Mock ScheduledExecutorService scheduledExecutorService;
 
     @Test
     public void testIllegalArguementExceptionIsThrownWhenPassNullToConstructor() {
@@ -94,15 +97,17 @@ public class PersistentHitQueueTests {
     }
 
     @Test
-    public void testCloseShouldCallDataQueueClose() {
+    public void testCloseShouldCallDataQueueCloseAndShutdownExecutor() {
         // Setup
-        PersistentHitQueue persistentHitQueue = new PersistentHitQueue(dataQueue, processor);
+        PersistentHitQueue persistentHitQueue =
+                new PersistentHitQueue(dataQueue, processor, scheduledExecutorService);
 
         // Action
         persistentHitQueue.close();
 
         // Assert
         Mockito.verify(dataQueue, Mockito.times(1)).close();
+        Mockito.verify(scheduledExecutorService, Mockito.times(1)).shutdown();
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
All threads and executors maintained by core should be relinquished when not in use. Shutdown PersistentHitQueue ScheduledExecutorService on close(). 
<!--- Describe your changes in detail -->

## Related Issue
#321 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->