### PR TITLE
Fix delay values in config extension

### DIFF
--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtension.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtension.kt
@@ -53,7 +53,7 @@ internal class ConfigurationExtension : Extension {
             "config.isinternalevent"
         internal const val DATASTORE_KEY = "AdobeMobile_ConfigState"
         internal const val RULES_CONFIG_URL = "rules.url"
-        internal const val CONFIG_DOWNLOAD_RETRY_ATTEMPT_DELAY_MS = 5L
+        internal const val CONFIG_DOWNLOAD_RETRY_ATTEMPT_DELAY_MS = 5000L
         internal const val CONFIGURATION_RESPONSE_IDENTITY_ALL_IDENTIFIERS = "config.allIdentifiers"
         internal const val EVENT_STATE_OWNER = "stateowner"
         internal const val GLOBAL_CONFIG_PRIVACY = "global.privacy"

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationStateManager.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationStateManager.kt
@@ -33,7 +33,7 @@ import java.util.Date
 internal class ConfigurationStateManager {
     companion object {
         private const val LOG_TAG = "ConfigurationStateManager"
-        private const val CONFIGURATION_TTL = 15L
+        private const val CONFIGURATION_TTL = 15000L
         private const val BUILD_ENVIRONMENT = "build.environment"
         private const val ENVIRONMENT_PREFIX_DELIMITER = "__"
         private const val CONFIGURATION_URL_BASE = "https://assets.adobedtm.com/%s.json"

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationStateManager.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationStateManager.kt
@@ -33,7 +33,7 @@ import java.util.Date
 internal class ConfigurationStateManager {
     companion object {
         private const val LOG_TAG = "ConfigurationStateManager"
-        private const val CONFIGURATION_TTL = 15000L
+        private const val CONFIGURATION_TTL_MS = 15000L
         private const val BUILD_ENVIRONMENT = "build.environment"
         private const val ENVIRONMENT_PREFIX_DELIMITER = "__"
         private const val CONFIGURATION_URL_BASE = "https://assets.adobedtm.com/%s.json"
@@ -456,7 +456,7 @@ internal class ConfigurationStateManager {
      */
     internal fun hasConfigExpired(appId: String): Boolean {
         val latestDownloadDate: Date? = configDownloadMap[appId]
-        return latestDownloadDate == null || Date(latestDownloadDate.time + CONFIGURATION_TTL) < Date()
+        return latestDownloadDate == null || Date(latestDownloadDate.time + CONFIGURATION_TTL_MS) < Date()
     }
 
     /**

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtensionTest.kt
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtensionTest.kt
@@ -517,7 +517,7 @@ class ConfigurationExtensionTest {
         val completionCallbackCaptor: KArgumentCaptor<(Map<String, Any?>?) -> Unit> =
             argumentCaptor()
 
-        // Should invoke update on state manager 2 times for retry and 3 time for success
+        // Should invoke update on state manager 2 times for retry and 3rd time for success
         verify(mockConfigStateManager, times(3)).updateConfigWithAppId(
             appIdCaptor.capture(),
             completionCallbackCaptor.capture()
@@ -526,14 +526,14 @@ class ConfigurationExtensionTest {
         // Verify first retry scheduling
         verify(mockExecutorService).schedule(
             Mockito.any(Runnable::class.java),
-            eq(5L),
+            eq(500L),
             eq(TimeUnit.SECONDS)
         )
 
         // Verify second retry scheduling
         verify(mockExecutorService).schedule(
             Mockito.any(Runnable::class.java),
-            eq(10L),
+            eq(1000L),
             eq(TimeUnit.SECONDS)
         )
 

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtensionTest.kt
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtensionTest.kt
@@ -526,14 +526,14 @@ class ConfigurationExtensionTest {
         // Verify first retry scheduling
         verify(mockExecutorService).schedule(
             Mockito.any(Runnable::class.java),
-            eq(500L),
+            eq(5000L),
             eq(TimeUnit.SECONDS)
         )
 
         // Verify second retry scheduling
         verify(mockExecutorService).schedule(
             Mockito.any(Runnable::class.java),
-            eq(1000L),
+            eq(10000L),
             eq(TimeUnit.SECONDS)
         )
 


### PR DESCRIPTION
Configuration extension erroneously uses a shorter time delays i.e milliseconds when seconds should be used so the wait times end up being 15 milliseconds and 5 milliseconds when they actually should be 15 seconds and 5 seconds.