### PR TITLE
Make EventPreprocessor non public

### DIFF
--- a/code/android-core-library/api/android-core-library.api
+++ b/code/android-core-library/api/android-core-library.api
@@ -55,10 +55,6 @@ public abstract interface class com/adobe/marketing/mobile/EventHistoryResultHan
 	public abstract fun call (Ljava/lang/Object;)V
 }
 
-public abstract interface class com/adobe/marketing/mobile/EventPreprocessor {
-	public abstract fun process (Lcom/adobe/marketing/mobile/Event;)Lcom/adobe/marketing/mobile/Event;
-}
-
 public final class com/adobe/marketing/mobile/EventSource {
 	public static final field APPLICATION_CLOSE Ljava/lang/String;
 	public static final field APPLICATION_LAUNCH Ljava/lang/String;
@@ -170,7 +166,6 @@ public abstract interface class com/adobe/marketing/mobile/ExtensionEventListene
 }
 
 public class com/adobe/marketing/mobile/ExtensionHelper {
-	public fun <init> ()V
 	public static fun getFriendlyName (Lcom/adobe/marketing/mobile/Extension;)Ljava/lang/String;
 	public static fun getMetadata (Lcom/adobe/marketing/mobile/Extension;)Ljava/util/Map;
 	public static fun getName (Lcom/adobe/marketing/mobile/Extension;)Ljava/lang/String;

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/ExtensionHelper.java
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/ExtensionHelper.java
@@ -18,6 +18,8 @@ import java.util.Map;
 /** Helper methods to access protected Extension methods from different packages */
 public class ExtensionHelper {
 
+    private ExtensionHelper() {}
+
     public static @Nullable String getName(@NonNull final Extension extension) {
         try {
             return extension.getName();

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/eventhub/EventHub.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/eventhub/EventHub.kt
@@ -16,7 +16,6 @@ import com.adobe.marketing.mobile.AdobeCallback
 import com.adobe.marketing.mobile.AdobeCallbackWithError
 import com.adobe.marketing.mobile.AdobeError
 import com.adobe.marketing.mobile.Event
-import com.adobe.marketing.mobile.EventPreprocessor
 import com.adobe.marketing.mobile.EventSource
 import com.adobe.marketing.mobile.EventType
 import com.adobe.marketing.mobile.Extension

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/eventhub/EventPreprocessor.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/eventhub/EventPreprocessor.kt
@@ -9,11 +9,10 @@
   governing permissions and limitations under the License.
 */
 
-package com.adobe.marketing.mobile;
+package com.adobe.marketing.mobile.internal.eventhub
 
-import androidx.annotation.NonNull;
+import com.adobe.marketing.mobile.Event
 
-@FunctionalInterface
-public interface EventPreprocessor {
-    @NonNull Event process(@NonNull final Event event);
+fun interface EventPreprocessor {
+    fun process(event: Event): Event
 }

--- a/code/android-core-library/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesEvaluator.kt
+++ b/code/android-core-library/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesEvaluator.kt
@@ -13,10 +13,10 @@ package com.adobe.marketing.mobile.launch.rulesengine
 
 import androidx.annotation.VisibleForTesting
 import com.adobe.marketing.mobile.Event
-import com.adobe.marketing.mobile.EventPreprocessor
 import com.adobe.marketing.mobile.EventSource
 import com.adobe.marketing.mobile.EventType
 import com.adobe.marketing.mobile.ExtensionApi
+import com.adobe.marketing.mobile.internal.eventhub.EventPreprocessor
 
 internal class LaunchRulesEvaluator(
     private val name: String,

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtensionTest.kt
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtensionTest.kt
@@ -12,7 +12,6 @@
 package com.adobe.marketing.mobile.internal.configuration
 
 import com.adobe.marketing.mobile.Event
-import com.adobe.marketing.mobile.EventPreprocessor
 import com.adobe.marketing.mobile.EventSource
 import com.adobe.marketing.mobile.EventType
 import com.adobe.marketing.mobile.ExtensionApi
@@ -25,6 +24,7 @@ import com.adobe.marketing.mobile.internal.configuration.ConfigurationExtension.
 import com.adobe.marketing.mobile.internal.configuration.ConfigurationExtension.Companion.CONFIGURATION_REQUEST_CONTENT_RETRIEVE_CONFIG
 import com.adobe.marketing.mobile.internal.configuration.ConfigurationExtension.Companion.CONFIGURATION_REQUEST_CONTENT_UPDATE_CONFIG
 import com.adobe.marketing.mobile.internal.eventhub.EventHub
+import com.adobe.marketing.mobile.internal.eventhub.EventPreprocessor
 import com.adobe.marketing.mobile.launch.rulesengine.LaunchRulesEvaluator
 import com.adobe.marketing.mobile.services.ServiceProvider
 import com.adobe.marketing.mobile.services.caching.CacheService

--- a/code/android-core-library/src/test/java/com/adobe/marketing/mobile/internal/eventhub/EventHubTests.kt
+++ b/code/android-core-library/src/test/java/com/adobe/marketing/mobile/internal/eventhub/EventHubTests.kt
@@ -14,7 +14,6 @@ package com.adobe.marketing.mobile.internal.eventhub
 import com.adobe.marketing.mobile.AdobeCallbackWithError
 import com.adobe.marketing.mobile.AdobeError
 import com.adobe.marketing.mobile.Event
-import com.adobe.marketing.mobile.EventPreprocessor
 import com.adobe.marketing.mobile.EventSource
 import com.adobe.marketing.mobile.EventType
 import com.adobe.marketing.mobile.Extension
@@ -1903,7 +1902,8 @@ internal class EventHubTests {
         val event = Event.Builder("evt1", "type", "source").build()
         val processedEvent = Event.Builder("evt2", "processedtype", "processedsource").build()
 
-        val processor = object : EventPreprocessor {
+        val processor = object :
+            EventPreprocessor {
             override fun process(it: Event): Event {
                 if (it == event) {
                     return processedEvent
@@ -1941,7 +1941,8 @@ internal class EventHubTests {
         val processedEvent1 = Event.Builder("evt2", "processedtype", "processedsource").build()
         val processedEvent2 = Event.Builder("evt3", "processedtype2", "processedsource2").build()
 
-        val processor1 = object : EventPreprocessor {
+        val processor1 = object :
+            EventPreprocessor {
             override fun process(it: Event): Event {
                 if (it == event) {
                     return processedEvent1
@@ -1951,7 +1952,8 @@ internal class EventHubTests {
             }
         }
 
-        val processor2 = object : EventPreprocessor {
+        val processor2 = object :
+            EventPreprocessor {
             override fun process(it: Event): Event {
                 if (it == processedEvent1) {
                     return processedEvent2
@@ -1987,7 +1989,8 @@ internal class EventHubTests {
         val processedEvent1 = Event.Builder("evt1", "processedtype", "processedsource").build()
         val processedEvent2 = Event.Builder("evt2", "processedtype2", "processedsource2").build()
 
-        val processor = object : EventPreprocessor {
+        val processor = object :
+            EventPreprocessor {
             override fun process(it: Event): Event {
                 if (it == event) {
                     return processedEvent1


### PR DESCRIPTION
Making `EventPreprocessor` non public as we don't expose API for extensions to set preprocessor. We can explore later around exposing preprocessor logic. 