### PR TITLE
Ensure initial shared state is created once and sync new ECID immediately after reset

### DIFF
--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -154,7 +154,7 @@ public final class IdentityExtension extends Extension {
         getApi().registerEventListener(
                         EventType.GENERIC_IDENTITY,
                         EventSource.REQUEST_RESET,
-                        this::processIdentityRequest);
+                        this::handleIdentityRequestReset);
         // listen to Analytics response
         getApi().registerEventListener(
                         EventType.ANALYTICS,
@@ -467,16 +467,7 @@ public final class IdentityExtension extends Extension {
      *
      * @param event the request request {@link Event}
      */
-    void handleIdentityRequestReset(final Event event) {
-        if (event == null) {
-            Log.debug(
-                    IdentityConstants.LOG_TAG,
-                    LOG_SOURCE,
-                    LOG_SOURCE,
-                    "handleIdentityRequestReset: Ignoring null event");
-            return;
-        }
-
+    void handleIdentityRequestReset(@NonNull final Event event) {
         if (privacyStatus == MobilePrivacyStatus.OPT_OUT) {
             Log.debug(
                     IdentityConstants.LOG_TAG,
@@ -763,9 +754,7 @@ public final class IdentityExtension extends Extension {
                 "processEvent : Processing the Identity event: %s",
                 event);
 
-        if (isResetIdentityEvent(event)) {
-            handleIdentityRequestReset(event);
-        } else if (isSyncEvent(event) || event.getType().equals(EventType.GENERIC_IDENTITY)) {
+         if (isSyncEvent(event) || event.getType().equals(EventType.GENERIC_IDENTITY)) {
             if (handleSyncIdentifiers(event, configSharedState, false)) {
                 getApi().createSharedState(packageEventData(), event);
             }

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -502,7 +502,7 @@ public final class IdentityExtension extends Extension {
             configSharedState.getConfigurationProperties(configState.getValue());
         }
 
-        if (handleSyncIdentifiers(event, configSharedState, true)) {
+        if (handleSyncIdentifiers(event, configSharedState, false)) {
             getApi().createSharedState(packageEventData(), event);
         }
     }
@@ -1894,7 +1894,7 @@ public final class IdentityExtension extends Extension {
                 configSharedState.getConfigurationProperties(configState.getValue());
             }
 
-            if (handleSyncIdentifiers(event, configSharedState, true)) {
+            if (handleSyncIdentifiers(event, configSharedState, false)) {
                 getApi().createSharedState(packageEventData(), event);
             }
         }

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -261,7 +261,8 @@ public final class IdentityExtension extends Extension {
         }
 
         // Get privacy status from configuration, set global "privacyStatus" variable, update hit queue
-        loadPrivacyStatusIfConfigurationStateValid(event);
+        loadPrivacyStatusFromConfigurationState(configState.getValue());
+        hitQueue.handlePrivacyChange(privacyStatus);
 
         Map<String, Object> configuration = configState.getValue();
 
@@ -2474,23 +2475,9 @@ public final class IdentityExtension extends Extension {
      * the {@code Configuration} shared state for the given {@code event}. This method should be
      * called during the extension's boot process.
      *
-     * @param event the {@link Event} used to retrieve the {@code Configuration} state
+     * @param configState the Configuration shared state
      */
-    private void loadPrivacyStatusIfConfigurationStateValid(final Event event) {
-        SharedStateResult result =
-                getApi().getSharedState(
-                                IdentityConstants.EventDataKeys.Configuration.MODULE_NAME,
-                                event,
-                                false,
-                                SharedStateResolution.LAST_SET);
-        if (result == null) {
-            return;
-        }
-        Map<String, Object> configState = result.getValue();
-        if (configState == null) {
-            return;
-        }
-
+    private void loadPrivacyStatusFromConfigurationState(final Map<String, Object> configState) {
         String privacyString =
                 DataReader.optString(
                         configState,
@@ -2498,12 +2485,6 @@ public final class IdentityExtension extends Extension {
                         Defaults.DEFAULT_MOBILE_PRIVACY.getValue());
 
         privacyStatus = MobilePrivacyStatus.fromString(privacyString);
-
-        hitQueue.handlePrivacyChange(privacyStatus);
-        Log.trace(
-                LOG_SOURCE,
-                "loadPrivacyStatus : Updated the database with the current privacy status: %s.",
-                privacyString);
     }
 
     @VisibleForTesting

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -897,17 +897,6 @@ public final class IdentityExtension extends Extension {
                     currentEventValidConfig.marketingCloudServer);
         }
 
-        // AMSDK-6861
-        // When updating the push identifier, if the value changes from empty to set or vice versa,
-        // an Analytics Request Content event is dispatched to track the enable/disable of the push
-        // ID.
-        // This happens before the Identity shared state is created. However, Analytics doesn't
-        // (currently)
-        // read the push ID from the Identity shared state when processing the event. If Analytics
-        // changes
-        // to read the push ID, then the code here will need to change to dispatch the event after
-        // creating the shared state.
-
         final Map<String, Object> eventData = event.getEventData();
 
         // Extract dpId's

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -248,10 +248,10 @@ public final class IdentityExtension extends Extension {
 
         SharedStateResult configState =
                 getApi().getSharedState(
-                        IdentityConstants.EventDataKeys.Configuration.MODULE_NAME,
-                        null,
-                        false,
-                        SharedStateResolution.LAST_SET);
+                                IdentityConstants.EventDataKeys.Configuration.MODULE_NAME,
+                                null,
+                                false,
+                                SharedStateResolution.LAST_SET);
         if (configState == null || configState.getStatus() != SharedStateStatus.SET) {
             return false;
         }
@@ -260,7 +260,8 @@ public final class IdentityExtension extends Extension {
             return false;
         }
 
-        // Get privacy status from configuration, set global "privacyStatus" variable, update hit queue
+        // Get privacy status from configuration, set global "privacyStatus" variable, update hit
+        // queue
         loadPrivacyStatusIfConfigurationStateValid(event);
 
         Map<String, Object> configuration = configState.getValue();
@@ -268,7 +269,9 @@ public final class IdentityExtension extends Extension {
         ConfigurationSharedStateIdentity configSharedState = new ConfigurationSharedStateIdentity();
         configSharedState.getConfigurationProperties(configuration);
 
-        hasSynced = handleSyncIdentifiers(event, configSharedState, true) || MobilePrivacyStatus.OPT_OUT.equals(privacyStatus);
+        hasSynced =
+                handleSyncIdentifiers(event, configSharedState, true)
+                        || MobilePrivacyStatus.OPT_OUT.equals(privacyStatus);
 
         if (hasSynced && !didCreateInitialSharedState) {
             getApi().createSharedState(packageEventData(), event);
@@ -498,10 +501,10 @@ public final class IdentityExtension extends Extension {
 
         SharedStateResult configState =
                 getApi().getSharedState(
-                        IdentityConstants.EventDataKeys.Configuration.MODULE_NAME,
-                        event,
-                        false,
-                        SharedStateResolution.LAST_SET);
+                                IdentityConstants.EventDataKeys.Configuration.MODULE_NAME,
+                                event,
+                                false,
+                                SharedStateResolution.LAST_SET);
         if (configState != null) {
             configSharedState.getConfigurationProperties(configState.getValue());
         }
@@ -817,12 +820,14 @@ public final class IdentityExtension extends Extension {
      * @param event {@code Event} containing identifiers that need to be synced
      * @param configSharedState {@code ConfigurationSharedStateIdentity} valid for this event
      * @param forceSync
-     * @return true if the identifiers were successfully processed and a shared state needs
-     * to be created, false if the identifiers could not be processed at this time.
+     * @return true if the identifiers were successfully processed and a shared state needs to be
+     *     created, false if the identifiers could not be processed at this time.
      */
     @VisibleForTesting
     boolean handleSyncIdentifiers(
-            final Event event, final ConfigurationSharedStateIdentity configSharedState, boolean forceSync) {
+            final Event event,
+            final ConfigurationSharedStateIdentity configSharedState,
+            boolean forceSync) {
         if (configSharedState == null) {
             // sanity check, should never get here
             Log.debug(
@@ -914,9 +919,12 @@ public final class IdentityExtension extends Extension {
                                 0));
 
         // Extract isForceSync
-        final boolean shouldForceSync = forceSync ||
-                DataReader.optBoolean(
-                        eventData, IdentityConstants.EventDataKeys.Identity.FORCE_SYNC, false);
+        final boolean shouldForceSync =
+                forceSync
+                        || DataReader.optBoolean(
+                                eventData,
+                                IdentityConstants.EventDataKeys.Identity.FORCE_SYNC,
+                                false);
 
         List<VisitorID> currentCustomerIds = generateCustomerIds(identifiers, idState);
 
@@ -1120,8 +1128,8 @@ public final class IdentityExtension extends Extension {
                     IdentityConstants.LOG_TAG,
                     LOG_SOURCE,
                     "updatePushIdentifier : Ignored a push token (%s) as it matches with an"
-                        + " existing token, and the push notification status will not be re-sent"
-                        + " to Analytics.",
+                        + " existing token, and the push notification status will not be re-sent to"
+                        + " Analytics.",
                     pushId);
             return;
         }
@@ -1816,7 +1824,9 @@ public final class IdentityExtension extends Extension {
                 newEvent.toString());
     }
 
-    /** @param eventData to be used to create the event object to be dispatched. */
+    /**
+     * @param eventData to be used to create the event object to be dispatched.
+     */
     @VisibleForTesting
     void handleIdentityConfigurationUpdateEvent(final Map<String, Object> eventData) {
         final Event event =
@@ -1889,14 +1899,15 @@ public final class IdentityExtension extends Extension {
             getApi().createSharedState(packageEventData(), event);
         } else if (StringUtils.isNullOrEmpty(mid)) {
             // Need to generate new Experience Cloud ID for the user
-            ConfigurationSharedStateIdentity configSharedState = new ConfigurationSharedStateIdentity();
+            ConfigurationSharedStateIdentity configSharedState =
+                    new ConfigurationSharedStateIdentity();
 
             SharedStateResult configState =
                     getApi().getSharedState(
-                            IdentityConstants.EventDataKeys.Configuration.MODULE_NAME,
-                            event,
-                            false,
-                            SharedStateResolution.LAST_SET);
+                                    IdentityConstants.EventDataKeys.Configuration.MODULE_NAME,
+                                    event,
+                                    false,
+                                    SharedStateResolution.LAST_SET);
             if (configState != null) {
                 configSharedState.getConfigurationProperties(configState.getValue());
             }

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -822,7 +822,7 @@ public final class IdentityExtension extends Extension {
     boolean handleSyncIdentifiers(
             final Event event,
             final ConfigurationSharedStateIdentity configSharedState,
-            boolean forceSync) {
+            final boolean forceSync) {
         if (configSharedState == null) {
             // sanity check, should never get here
             Log.debug(

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -256,7 +256,7 @@ public final class IdentityExtension extends Extension {
 
     @VisibleForTesting
     void forceSyncIdentifiers(@NonNull final Event event) {
-        loadPrivacyStatusIfConfigurationSateValid(event);
+        loadPrivacyStatusIfConfigurationStateValid(event);
 
         final Event forcedSyncEvent = createForcedSyncEvent();
         processIdentityRequest(forcedSyncEvent);
@@ -2461,7 +2461,7 @@ public final class IdentityExtension extends Extension {
      *
      * @param event the {@link Event} used to retrieve the {@code Configuration} state
      */
-    private void loadPrivacyStatusIfConfigurationSateValid(final Event event) {
+    private void loadPrivacyStatusIfConfigurationStateValid(final Event event) {
         SharedStateResult result =
                 getApi().getSharedState(
                                 IdentityConstants.EventDataKeys.Configuration.MODULE_NAME,

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -249,10 +249,10 @@ public final class IdentityExtension extends Extension {
 
         SharedStateResult configState =
                 getApi().getSharedState(
-                        IdentityConstants.EventDataKeys.Configuration.MODULE_NAME,
-                        null,
-                        false,
-                        SharedStateResolution.LAST_SET);
+                                IdentityConstants.EventDataKeys.Configuration.MODULE_NAME,
+                                null,
+                                false,
+                                SharedStateResolution.LAST_SET);
         if (configState == null || configState.getStatus() != SharedStateStatus.SET) {
             return false;
         }
@@ -261,7 +261,8 @@ public final class IdentityExtension extends Extension {
             return false;
         }
 
-        // Get privacy status from configuration, set global "privacyStatus" variable, update hit queue
+        // Get privacy status from configuration, set global "privacyStatus" variable, update hit
+        // queue
         loadPrivacyStatusFromConfigurationState(configState.getValue());
         hitQueue.handlePrivacyChange(privacyStatus);
 
@@ -270,11 +271,14 @@ public final class IdentityExtension extends Extension {
         ConfigurationSharedStateIdentity configSharedState = new ConfigurationSharedStateIdentity();
         configSharedState.getConfigurationProperties(configuration);
 
-        hasSynced = handleSyncIdentifiers(event, configSharedState, true) || MobilePrivacyStatus.OPT_OUT.equals(privacyStatus);
+        hasSynced =
+                handleSyncIdentifiers(event, configSharedState, true)
+                        || MobilePrivacyStatus.OPT_OUT.equals(privacyStatus);
 
         // Identity should always share its state
         // However, don't create a shared state twice, which will log an error
-        // If the sync was successful and there is no initial shared state available, post a shared state update
+        // If the sync was successful and there is no initial shared state available, post a shared
+        // state update
         if (hasSynced && !didCreateInitialSharedState) {
             getApi().createSharedState(packageEventData(), event);
             didCreateInitialSharedState = true;
@@ -494,10 +498,10 @@ public final class IdentityExtension extends Extension {
 
         SharedStateResult configState =
                 getApi().getSharedState(
-                        IdentityConstants.EventDataKeys.Configuration.MODULE_NAME,
-                        event,
-                        false,
-                        SharedStateResolution.LAST_SET);
+                                IdentityConstants.EventDataKeys.Configuration.MODULE_NAME,
+                                event,
+                                false,
+                                SharedStateResolution.LAST_SET);
         if (configState != null) {
             configSharedState.getConfigurationProperties(configState.getValue());
         }
@@ -754,7 +758,7 @@ public final class IdentityExtension extends Extension {
                 "processEvent : Processing the Identity event: %s",
                 event);
 
-         if (isSyncEvent(event) || event.getType().equals(EventType.GENERIC_IDENTITY)) {
+        if (isSyncEvent(event) || event.getType().equals(EventType.GENERIC_IDENTITY)) {
             if (handleSyncIdentifiers(event, configSharedState, false)) {
                 getApi().createSharedState(packageEventData(), event);
             }
@@ -811,12 +815,14 @@ public final class IdentityExtension extends Extension {
      * @param event {@code Event} containing identifiers that need to be synced
      * @param configSharedState {@code ConfigurationSharedStateIdentity} valid for this event
      * @param forceSync
-     * @return true if the identifiers were successfully processed and a shared state needs
-     * to be created, false if the identifiers could not be processed at this time.
+     * @return true if the identifiers were successfully processed and a shared state needs to be
+     *     created, false if the identifiers could not be processed at this time.
      */
     @VisibleForTesting
     boolean handleSyncIdentifiers(
-            final Event event, final ConfigurationSharedStateIdentity configSharedState, boolean forceSync) {
+            final Event event,
+            final ConfigurationSharedStateIdentity configSharedState,
+            boolean forceSync) {
         if (configSharedState == null) {
             // sanity check, should never get here
             Log.debug(
@@ -907,9 +913,12 @@ public final class IdentityExtension extends Extension {
                                 0));
 
         // Extract isForceSync
-        final boolean shouldForceSync = forceSync ||
-                DataReader.optBoolean(
-                        eventData, IdentityConstants.EventDataKeys.Identity.FORCE_SYNC, false);
+        final boolean shouldForceSync =
+                forceSync
+                        || DataReader.optBoolean(
+                                eventData,
+                                IdentityConstants.EventDataKeys.Identity.FORCE_SYNC,
+                                false);
 
         List<VisitorID> currentCustomerIds = generateCustomerIds(identifiers, idState);
 
@@ -1882,14 +1891,15 @@ public final class IdentityExtension extends Extension {
             getApi().createSharedState(packageEventData(), event);
         } else if (StringUtils.isNullOrEmpty(mid)) {
             // Need to generate new Experience Cloud ID for the user
-            ConfigurationSharedStateIdentity configSharedState = new ConfigurationSharedStateIdentity();
+            ConfigurationSharedStateIdentity configSharedState =
+                    new ConfigurationSharedStateIdentity();
 
             SharedStateResult configState =
                     getApi().getSharedState(
-                            IdentityConstants.EventDataKeys.Configuration.MODULE_NAME,
-                            event,
-                            false,
-                            SharedStateResolution.LAST_SET);
+                                    IdentityConstants.EventDataKeys.Configuration.MODULE_NAME,
+                                    event,
+                                    false,
+                                    SharedStateResolution.LAST_SET);
             if (configState != null) {
                 configSharedState.getConfigurationProperties(configState.getValue());
             }

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -38,6 +38,7 @@ import com.adobe.marketing.mobile.services.Networking;
 import com.adobe.marketing.mobile.services.PersistentHitQueue;
 import com.adobe.marketing.mobile.services.ServiceProvider;
 import com.adobe.marketing.mobile.util.DataReader;
+import com.adobe.marketing.mobile.util.MapUtils;
 import com.adobe.marketing.mobile.util.SQLiteUtils;
 import com.adobe.marketing.mobile.util.StringUtils;
 import com.adobe.marketing.mobile.util.TimeUtils;
@@ -271,6 +272,9 @@ public final class IdentityExtension extends Extension {
 
         hasSynced = handleSyncIdentifiers(event, configSharedState, true) || MobilePrivacyStatus.OPT_OUT.equals(privacyStatus);
 
+        // Identity should always share its state
+        // However, don't create a shared state twice, which will log an error
+        // If the sync was successful and there is no initial shared state available, post a shared state update
         if (hasSynced && !didCreateInitialSharedState) {
             getApi().createSharedState(packageEventData(), event);
             didCreateInitialSharedState = true;
@@ -287,7 +291,7 @@ public final class IdentityExtension extends Extension {
             return false;
         }
         Map<String, Object> sharedStateValue = sharedStateResult.getValue();
-        return sharedStateValue != null && !sharedStateValue.isEmpty();
+        return !MapUtils.isNullOrEmpty(sharedStateValue);
     }
 
     private void boot() {
@@ -841,7 +845,6 @@ public final class IdentityExtension extends Extension {
                     LOG_SOURCE,
                     "handleSyncIdentifiers : Ignoring the Sync Identifiers call because the"
                             + " privacy status was opt-out.");
-            // did process this event but can't sync the call. Hence return true.
             return false;
         }
 
@@ -2114,7 +2117,7 @@ public final class IdentityExtension extends Extension {
      * @return {@link String} representing valid query parameters for a URL.
      */
     String generateInternalIdString(final Map<String, String> dpids) {
-        if (dpids == null || dpids.isEmpty()) {
+        if (MapUtils.isNullOrEmpty(dpids)) {
             return "";
         }
 

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -244,14 +244,14 @@ public final class IdentityExtension extends Extension {
     }
 
     private boolean hasValidSharedState(final String extensionName, final Event event) {
-        SharedStateResult result =
+        SharedStateResult sharedStateResult =
                 getApi().getSharedState(
                                 extensionName, event, false, SharedStateResolution.LAST_SET);
-        if (result == null) {
+        if (sharedStateResult == null || sharedStateResult.getStatus() != SharedStateStatus.SET) {
             return false;
         }
-        Map<String, Object> configuration = result.getValue();
-        return configuration != null && !configuration.isEmpty();
+        Map<String, Object> sharedStateValue = sharedStateResult.getValue();
+        return sharedStateValue != null && !sharedStateValue.isEmpty();
     }
 
     @VisibleForTesting

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -758,7 +758,7 @@ public final class IdentityExtension extends Extension {
                 "processEvent : Processing the Identity event: %s",
                 event);
 
-        if (isSyncEvent(event) || event.getType().equals(EventType.GENERIC_IDENTITY)) {
+        if (isSyncEvent(event) || EventType.GENERIC_IDENTITY.equals(event.getType())) {
             if (handleSyncIdentifiers(event, configSharedState, false)) {
                 getApi().createSharedState(packageEventData(), event);
             }

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -248,10 +248,10 @@ public final class IdentityExtension extends Extension {
 
         SharedStateResult configState =
                 getApi().getSharedState(
-                                IdentityConstants.EventDataKeys.Configuration.MODULE_NAME,
-                                null,
-                                false,
-                                SharedStateResolution.LAST_SET);
+                        IdentityConstants.EventDataKeys.Configuration.MODULE_NAME,
+                        null,
+                        false,
+                        SharedStateResolution.LAST_SET);
         if (configState == null || configState.getStatus() != SharedStateStatus.SET) {
             return false;
         }
@@ -260,8 +260,7 @@ public final class IdentityExtension extends Extension {
             return false;
         }
 
-        // Get privacy status from configuration, set global "privacyStatus" variable, update hit
-        // queue
+        // Get privacy status from configuration, set global "privacyStatus" variable, update hit queue
         loadPrivacyStatusIfConfigurationStateValid(event);
 
         Map<String, Object> configuration = configState.getValue();
@@ -269,9 +268,7 @@ public final class IdentityExtension extends Extension {
         ConfigurationSharedStateIdentity configSharedState = new ConfigurationSharedStateIdentity();
         configSharedState.getConfigurationProperties(configuration);
 
-        hasSynced =
-                handleSyncIdentifiers(event, configSharedState, true)
-                        || MobilePrivacyStatus.OPT_OUT.equals(privacyStatus);
+        hasSynced = handleSyncIdentifiers(event, configSharedState, true) || MobilePrivacyStatus.OPT_OUT.equals(privacyStatus);
 
         if (hasSynced && !didCreateInitialSharedState) {
             getApi().createSharedState(packageEventData(), event);
@@ -501,10 +498,10 @@ public final class IdentityExtension extends Extension {
 
         SharedStateResult configState =
                 getApi().getSharedState(
-                                IdentityConstants.EventDataKeys.Configuration.MODULE_NAME,
-                                event,
-                                false,
-                                SharedStateResolution.LAST_SET);
+                        IdentityConstants.EventDataKeys.Configuration.MODULE_NAME,
+                        event,
+                        false,
+                        SharedStateResolution.LAST_SET);
         if (configState != null) {
             configSharedState.getConfigurationProperties(configState.getValue());
         }
@@ -820,14 +817,12 @@ public final class IdentityExtension extends Extension {
      * @param event {@code Event} containing identifiers that need to be synced
      * @param configSharedState {@code ConfigurationSharedStateIdentity} valid for this event
      * @param forceSync
-     * @return true if the identifiers were successfully processed and a shared state needs to be
-     *     created, false if the identifiers could not be processed at this time.
+     * @return true if the identifiers were successfully processed and a shared state needs
+     * to be created, false if the identifiers could not be processed at this time.
      */
     @VisibleForTesting
     boolean handleSyncIdentifiers(
-            final Event event,
-            final ConfigurationSharedStateIdentity configSharedState,
-            boolean forceSync) {
+            final Event event, final ConfigurationSharedStateIdentity configSharedState, boolean forceSync) {
         if (configSharedState == null) {
             // sanity check, should never get here
             Log.debug(
@@ -919,12 +914,9 @@ public final class IdentityExtension extends Extension {
                                 0));
 
         // Extract isForceSync
-        final boolean shouldForceSync =
-                forceSync
-                        || DataReader.optBoolean(
-                                eventData,
-                                IdentityConstants.EventDataKeys.Identity.FORCE_SYNC,
-                                false);
+        final boolean shouldForceSync = forceSync ||
+                DataReader.optBoolean(
+                        eventData, IdentityConstants.EventDataKeys.Identity.FORCE_SYNC, false);
 
         List<VisitorID> currentCustomerIds = generateCustomerIds(identifiers, idState);
 
@@ -1128,8 +1120,8 @@ public final class IdentityExtension extends Extension {
                     IdentityConstants.LOG_TAG,
                     LOG_SOURCE,
                     "updatePushIdentifier : Ignored a push token (%s) as it matches with an"
-                        + " existing token, and the push notification status will not be re-sent to"
-                        + " Analytics.",
+                        + " existing token, and the push notification status will not be re-sent"
+                        + " to Analytics.",
                     pushId);
             return;
         }
@@ -1824,9 +1816,7 @@ public final class IdentityExtension extends Extension {
                 newEvent.toString());
     }
 
-    /**
-     * @param eventData to be used to create the event object to be dispatched.
-     */
+    /** @param eventData to be used to create the event object to be dispatched. */
     @VisibleForTesting
     void handleIdentityConfigurationUpdateEvent(final Map<String, Object> eventData) {
         final Event event =
@@ -1899,15 +1889,14 @@ public final class IdentityExtension extends Extension {
             getApi().createSharedState(packageEventData(), event);
         } else if (StringUtils.isNullOrEmpty(mid)) {
             // Need to generate new Experience Cloud ID for the user
-            ConfigurationSharedStateIdentity configSharedState =
-                    new ConfigurationSharedStateIdentity();
+            ConfigurationSharedStateIdentity configSharedState = new ConfigurationSharedStateIdentity();
 
             SharedStateResult configState =
                     getApi().getSharedState(
-                                    IdentityConstants.EventDataKeys.Configuration.MODULE_NAME,
-                                    event,
-                                    false,
-                                    SharedStateResolution.LAST_SET);
+                            IdentityConstants.EventDataKeys.Configuration.MODULE_NAME,
+                            event,
+                            false,
+                            SharedStateResolution.LAST_SET);
             if (configState != null) {
                 configSharedState.getConfigurationProperties(configState.getValue());
             }

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityHitsProcessing.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityHitsProcessing.java
@@ -145,10 +145,9 @@ class IdentityHitsProcessing implements HitProcessing {
                                 Log.debug(
                                         IdentityConstants.LOG_TAG,
                                         LOG_SOURCE,
-                                        "IdentityHitsDatabase.process : A recoverable network"
-                                            + " error occurred with response code %d while"
-                                            + " processing ECID Service requests.  Will retry in"
-                                            + " 30 seconds.",
+                                        "IdentityHitsDatabase.process : A recoverable network error"
+                                            + " occurred with response code %d while processing"
+                                            + " ECID Service requests.  Will retry in 30 seconds.",
                                         connection.getResponseCode());
                                 processingResult.complete(false);
                             }

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityHitsProcessing.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityHitsProcessing.java
@@ -145,9 +145,10 @@ class IdentityHitsProcessing implements HitProcessing {
                                 Log.debug(
                                         IdentityConstants.LOG_TAG,
                                         LOG_SOURCE,
-                                        "IdentityHitsDatabase.process : A recoverable network error"
-                                            + " occurred with response code %d while processing"
-                                            + " ECID Service requests.  Will retry in 30 seconds.",
+                                        "IdentityHitsDatabase.process : A recoverable network"
+                                            + " error occurred with response code %d while"
+                                            + " processing ECID Service requests.  Will retry in"
+                                            + " 30 seconds.",
                                         connection.getResponseCode());
                                 processingResult.complete(false);
                             }

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
@@ -157,7 +157,7 @@ class IdentityExtensionTests {
     fun `readyForEvent() - handle getExperienceCloudId or getIdentifiers event without valid configuration`() {
         val identityExtension = initializeSpiedIdentityExtension()
         identityExtension.onRegistered()
-        identityExtension.setHasSynced(true)
+        identityExtension.setHasSynced(true);
 
         Mockito.`when`(
             mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
@@ -179,7 +179,7 @@ class IdentityExtensionTests {
     fun `readyForEvent() should return false for appendUrl and urlVars events if Analytics extension is not registered`() {
         val identityExtension = initializeSpiedIdentityExtension()
         identityExtension.onRegistered()
-        identityExtension.setHasSynced(true)
+        identityExtension.setHasSynced(true);
 
         val countDownLatch = CountDownLatch(2)
         Mockito.`when`(
@@ -254,15 +254,15 @@ class IdentityExtensionTests {
     fun `forceSyncIdentifiers() should return true on valid Configuration state `() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
         Mockito.`when`(
-            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
+                mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
                 return@thenAnswer SharedStateResult(
-                    SharedStateStatus.SET,
-                    mapOf(
-                        "experienceCloud.org" to "orgid"
-                    )
+                        SharedStateStatus.SET,
+                        mapOf(
+                                "experienceCloud.org" to "orgid"
+                        )
                 )
             }
             return@thenAnswer null
@@ -279,15 +279,15 @@ class IdentityExtensionTests {
     fun `forceSyncIdentifiers() should return false on Configuration state without orgId `() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
         Mockito.`when`(
-            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
+                mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
                 return@thenAnswer SharedStateResult(
-                    SharedStateStatus.SET,
-                    mapOf(
-                        "no.server.config" to "orgid"
-                    )
+                        SharedStateStatus.SET,
+                        mapOf(
+                                "no.server.config" to "orgid"
+                        )
                 )
             }
             return@thenAnswer null
@@ -305,15 +305,15 @@ class IdentityExtensionTests {
     fun `forceSyncIdentifiers() should still create a shared state if OPTED_OUT`() {
         val identityExtension = initializeSpiedIdentityExtension()
         Mockito.`when`(
-            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
+                mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
                 return@thenAnswer SharedStateResult(
-                    SharedStateStatus.SET,
-                    mapOf(
-                        "experienceCloud.org" to "orgid"
-                    )
+                        SharedStateStatus.SET,
+                        mapOf(
+                                "experienceCloud.org" to "orgid"
+                        )
                 )
             }
             return@thenAnswer null
@@ -391,7 +391,7 @@ class IdentityExtensionTests {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
 
         spiedIdentityExtension.onRegistered()
-        spiedIdentityExtension.setHasSynced(true)
+        spiedIdentityExtension.setHasSynced(true);
 
         Mockito.`when`(
             mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
@@ -429,7 +429,7 @@ class IdentityExtensionTests {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
 
         spiedIdentityExtension.onRegistered()
-        spiedIdentityExtension.setHasSynced(true)
+        spiedIdentityExtension.setHasSynced(true);
 
         Mockito.`when`(
             mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
@@ -459,7 +459,7 @@ class IdentityExtensionTests {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
 
         spiedIdentityExtension.onRegistered()
-        spiedIdentityExtension.setHasSynced(true)
+        spiedIdentityExtension.setHasSynced(true);
 
         Mockito.`when`(
             mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
@@ -497,7 +497,7 @@ class IdentityExtensionTests {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
 
         spiedIdentityExtension.onRegistered()
-        spiedIdentityExtension.setHasSynced(true)
+        spiedIdentityExtension.setHasSynced(true);
 
         Mockito.`when`(
             mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
@@ -942,9 +942,9 @@ class IdentityExtensionTests {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
         assertFalse(
             spiedIdentityExtension.handleSyncIdentifiers(
-                Event.Builder("event", "type", "source").build(),
-                null,
-                false
+                    Event.Builder("event", "type", "source").build(),
+                    null,
+                    false
             )
         )
         verify(spiedIdentityExtension, never()).extractIdentifiers(any())
@@ -957,9 +957,9 @@ class IdentityExtensionTests {
         val state = ConfigurationSharedStateIdentity()
         assertFalse(
             spiedIdentityExtension.handleSyncIdentifiers(
-                Event.Builder("event", "type", "source").build(),
-                state,
-                false
+                    Event.Builder("event", "type", "source").build(),
+                    state,
+                    false
             )
         )
 
@@ -979,9 +979,9 @@ class IdentityExtensionTests {
         )
         assertFalse(
             spiedIdentityExtension.handleSyncIdentifiers(
-                Event.Builder("event", "type", "source").build(),
-                state,
-                false
+                    Event.Builder("event", "type", "source").build(),
+                    state,
+                    false
             )
         )
 

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
@@ -157,7 +157,7 @@ class IdentityExtensionTests {
     fun `readyForEvent() - handle getExperienceCloudId or getIdentifiers event without valid configuration`() {
         val identityExtension = initializeSpiedIdentityExtension()
         identityExtension.onRegistered()
-        identityExtension.setHasSynced(true);
+        identityExtension.setHasSynced(true)
 
         Mockito.`when`(
             mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
@@ -179,7 +179,7 @@ class IdentityExtensionTests {
     fun `readyForEvent() should return false for appendUrl and urlVars events if Analytics extension is not registered`() {
         val identityExtension = initializeSpiedIdentityExtension()
         identityExtension.onRegistered()
-        identityExtension.setHasSynced(true);
+        identityExtension.setHasSynced(true)
 
         val countDownLatch = CountDownLatch(2)
         Mockito.`when`(
@@ -254,15 +254,15 @@ class IdentityExtensionTests {
     fun `forceSyncIdentifiers() should return true on valid Configuration state `() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
         Mockito.`when`(
-                mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
                 return@thenAnswer SharedStateResult(
-                        SharedStateStatus.SET,
-                        mapOf(
-                                "experienceCloud.org" to "orgid"
-                        )
+                    SharedStateStatus.SET,
+                    mapOf(
+                        "experienceCloud.org" to "orgid"
+                    )
                 )
             }
             return@thenAnswer null
@@ -279,15 +279,15 @@ class IdentityExtensionTests {
     fun `forceSyncIdentifiers() should return false on Configuration state without orgId `() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
         Mockito.`when`(
-                mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
                 return@thenAnswer SharedStateResult(
-                        SharedStateStatus.SET,
-                        mapOf(
-                                "no.server.config" to "orgid"
-                        )
+                    SharedStateStatus.SET,
+                    mapOf(
+                        "no.server.config" to "orgid"
+                    )
                 )
             }
             return@thenAnswer null
@@ -305,15 +305,15 @@ class IdentityExtensionTests {
     fun `forceSyncIdentifiers() should still create a shared state if OPTED_OUT`() {
         val identityExtension = initializeSpiedIdentityExtension()
         Mockito.`when`(
-                mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
                 return@thenAnswer SharedStateResult(
-                        SharedStateStatus.SET,
-                        mapOf(
-                                "experienceCloud.org" to "orgid"
-                        )
+                    SharedStateStatus.SET,
+                    mapOf(
+                        "experienceCloud.org" to "orgid"
+                    )
                 )
             }
             return@thenAnswer null
@@ -391,7 +391,7 @@ class IdentityExtensionTests {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
 
         spiedIdentityExtension.onRegistered()
-        spiedIdentityExtension.setHasSynced(true);
+        spiedIdentityExtension.setHasSynced(true)
 
         Mockito.`when`(
             mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
@@ -429,7 +429,7 @@ class IdentityExtensionTests {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
 
         spiedIdentityExtension.onRegistered()
-        spiedIdentityExtension.setHasSynced(true);
+        spiedIdentityExtension.setHasSynced(true)
 
         Mockito.`when`(
             mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
@@ -459,7 +459,7 @@ class IdentityExtensionTests {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
 
         spiedIdentityExtension.onRegistered()
-        spiedIdentityExtension.setHasSynced(true);
+        spiedIdentityExtension.setHasSynced(true)
 
         Mockito.`when`(
             mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
@@ -497,7 +497,7 @@ class IdentityExtensionTests {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
 
         spiedIdentityExtension.onRegistered()
-        spiedIdentityExtension.setHasSynced(true);
+        spiedIdentityExtension.setHasSynced(true)
 
         Mockito.`when`(
             mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
@@ -942,9 +942,9 @@ class IdentityExtensionTests {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
         assertFalse(
             spiedIdentityExtension.handleSyncIdentifiers(
-                    Event.Builder("event", "type", "source").build(),
-                    null,
-                    false
+                Event.Builder("event", "type", "source").build(),
+                null,
+                false
             )
         )
         verify(spiedIdentityExtension, never()).extractIdentifiers(any())
@@ -957,9 +957,9 @@ class IdentityExtensionTests {
         val state = ConfigurationSharedStateIdentity()
         assertFalse(
             spiedIdentityExtension.handleSyncIdentifiers(
-                    Event.Builder("event", "type", "source").build(),
-                    state,
-                    false
+                Event.Builder("event", "type", "source").build(),
+                state,
+                false
             )
         )
 
@@ -979,9 +979,9 @@ class IdentityExtensionTests {
         )
         assertFalse(
             spiedIdentityExtension.handleSyncIdentifiers(
-                    Event.Builder("event", "type", "source").build(),
-                    state,
-                    false
+                Event.Builder("event", "type", "source").build(),
+                state,
+                false
             )
         )
 

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
@@ -157,7 +157,7 @@ class IdentityExtensionTests {
     fun `readyForEvent() - handle getExperienceCloudId or getIdentifiers event without valid configuration`() {
         val identityExtension = initializeSpiedIdentityExtension()
         identityExtension.onRegistered()
-        identityExtension.setHasSynced(true);
+        identityExtension.setHasSynced(true)
 
         Mockito.`when`(
             mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
@@ -179,7 +179,7 @@ class IdentityExtensionTests {
     fun `readyForEvent() should return false for appendUrl and urlVars events if Analytics extension is not registered`() {
         val identityExtension = initializeSpiedIdentityExtension()
         identityExtension.onRegistered()
-        identityExtension.setHasSynced(true);
+        identityExtension.setHasSynced(true)
 
         val countDownLatch = CountDownLatch(2)
         Mockito.`when`(
@@ -254,15 +254,15 @@ class IdentityExtensionTests {
     fun `forceSyncIdentifiers() should return true on valid Configuration state `() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
         Mockito.`when`(
-                mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
                 return@thenAnswer SharedStateResult(
-                        SharedStateStatus.SET,
-                        mapOf(
-                                "experienceCloud.org" to "orgid"
-                        )
+                    SharedStateStatus.SET,
+                    mapOf(
+                        "experienceCloud.org" to "orgid"
+                    )
                 )
             }
             return@thenAnswer null
@@ -279,15 +279,15 @@ class IdentityExtensionTests {
     fun `forceSyncIdentifiers() should return false on Configuration state without orgId `() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
         Mockito.`when`(
-                mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
                 return@thenAnswer SharedStateResult(
-                        SharedStateStatus.SET,
-                        mapOf(
-                                "no.server.config" to "orgid"
-                        )
+                    SharedStateStatus.SET,
+                    mapOf(
+                        "no.server.config" to "orgid"
+                    )
                 )
             }
             return@thenAnswer null
@@ -305,15 +305,15 @@ class IdentityExtensionTests {
     fun `forceSyncIdentifiers() should still create a shared state if OPTED_OUT`() {
         val identityExtension = initializeSpiedIdentityExtension()
         Mockito.`when`(
-                mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
                 return@thenAnswer SharedStateResult(
-                        SharedStateStatus.SET,
-                        mapOf(
-                                "experienceCloud.org" to "orgid"
-                        )
+                    SharedStateStatus.SET,
+                    mapOf(
+                        "experienceCloud.org" to "orgid"
+                    )
                 )
             }
             return@thenAnswer null
@@ -391,7 +391,7 @@ class IdentityExtensionTests {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
 
         spiedIdentityExtension.onRegistered()
-        spiedIdentityExtension.setHasSynced(true);
+        spiedIdentityExtension.setHasSynced(true)
 
         Mockito.`when`(
             mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
@@ -429,7 +429,7 @@ class IdentityExtensionTests {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
 
         spiedIdentityExtension.onRegistered()
-        spiedIdentityExtension.setHasSynced(true);
+        spiedIdentityExtension.setHasSynced(true)
 
         Mockito.`when`(
             mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
@@ -459,7 +459,7 @@ class IdentityExtensionTests {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
 
         spiedIdentityExtension.onRegistered()
-        spiedIdentityExtension.setHasSynced(true);
+        spiedIdentityExtension.setHasSynced(true)
 
         Mockito.`when`(
             mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
@@ -497,7 +497,7 @@ class IdentityExtensionTests {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
 
         spiedIdentityExtension.onRegistered()
-        spiedIdentityExtension.setHasSynced(true);
+        spiedIdentityExtension.setHasSynced(true)
 
         Mockito.`when`(
             mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
@@ -934,9 +934,9 @@ class IdentityExtensionTests {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
         assertFalse(
             spiedIdentityExtension.handleSyncIdentifiers(
-                    Event.Builder("event", "type", "source").build(),
-                    null,
-                    false
+                Event.Builder("event", "type", "source").build(),
+                null,
+                false
             )
         )
         verify(spiedIdentityExtension, never()).extractIdentifiers(any())
@@ -949,9 +949,9 @@ class IdentityExtensionTests {
         val state = ConfigurationSharedStateIdentity()
         assertFalse(
             spiedIdentityExtension.handleSyncIdentifiers(
-                    Event.Builder("event", "type", "source").build(),
-                    state,
-                    false
+                Event.Builder("event", "type", "source").build(),
+                state,
+                false
             )
         )
 
@@ -971,9 +971,9 @@ class IdentityExtensionTests {
         )
         assertFalse(
             spiedIdentityExtension.handleSyncIdentifiers(
-                    Event.Builder("event", "type", "source").build(),
-                    state,
-                    false
+                Event.Builder("event", "type", "source").build(),
+                state,
+                false
             )
         )
 

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
@@ -568,14 +568,6 @@ class IdentityExtensionTests {
     }
 
     @Test
-    fun `handleIdentityRequestReset() - event is null`() {
-        val spiedIdentityExtension = initializeSpiedIdentityExtension()
-        spiedIdentityExtension.handleIdentityRequestReset(null)
-
-        verify(spiedIdentityExtension, never()).processIdentityRequest(any())
-    }
-
-    @Test
     fun `handleIdentityRequestReset() - OptedOut`() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
 

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
@@ -42,6 +42,7 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.eq
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileInputStream
@@ -116,7 +117,7 @@ class IdentityExtensionTests {
         identityExtension.onRegistered()
 
         Mockito.`when`(
-            mockedExtensionApi.getSharedState(any(), any(), anyOrNull(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
@@ -137,7 +138,7 @@ class IdentityExtensionTests {
         identityExtension.onRegistered()
 
         Mockito.`when`(
-            mockedExtensionApi.getSharedState(any(), any(), anyOrNull(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
@@ -156,9 +157,10 @@ class IdentityExtensionTests {
     fun `readyForEvent() - handle getExperienceCloudId or getIdentifiers event without valid configuration`() {
         val identityExtension = initializeSpiedIdentityExtension()
         identityExtension.onRegistered()
+        identityExtension.setHasSynced(true);
 
         Mockito.`when`(
-            mockedExtensionApi.getSharedState(any(), any(), anyOrNull(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
@@ -177,9 +179,11 @@ class IdentityExtensionTests {
     fun `readyForEvent() should return false for appendUrl and urlVars events if Analytics extension is not registered`() {
         val identityExtension = initializeSpiedIdentityExtension()
         identityExtension.onRegistered()
+        identityExtension.setHasSynced(true);
+
         val countDownLatch = CountDownLatch(2)
         Mockito.`when`(
-            mockedExtensionApi.getSharedState(any(), any(), anyOrNull(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
@@ -218,10 +222,10 @@ class IdentityExtensionTests {
     }
 
     @Test
-    fun `readyForEvent() should trigger one forceSync event `() {
+    fun `readyForEvent() should trigger forceSync event `() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
         Mockito.`when`(
-            mockedExtensionApi.getSharedState(any(), any(), anyOrNull(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
@@ -234,18 +238,91 @@ class IdentityExtensionTests {
             }
             return@thenAnswer null
         }
-        spiedIdentityExtension.readyForEvent(Event.Builder("event", "type", "source").build())
 
-        spiedIdentityExtension.readyForEvent(Event.Builder("event", "type", "source").build())
-        verify(spiedIdentityExtension, times(1)).forceSyncIdentifiers(any())
+        val testEvent1 = Event.Builder("event", "type", "source").build()
+        spiedIdentityExtension.readyForEvent(testEvent1)
+
+        val testEvent2 = Event.Builder("event", "type", "source").build()
+        spiedIdentityExtension.readyForEvent(testEvent2)
+
+        verify(spiedIdentityExtension, times(1)).readyForSyncIdentifiers(any())
+        verify(mockedExtensionApi, times(1)).createSharedState(any(), eq(testEvent1))
+        verify(spiedIdentityExtension, times(2)).forceSyncIdentifiers(any())
+    }
+
+    @Test
+    fun `forceSyncIdentifiers() should return true on valid Configuration state `() {
+        val spiedIdentityExtension = initializeSpiedIdentityExtension()
+        Mockito.`when`(
+                mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
+        ).thenAnswer { invocation ->
+            val extension = invocation.arguments[0] as? String
+            if ("com.adobe.module.configuration" === extension) {
+                return@thenAnswer SharedStateResult(
+                        SharedStateStatus.SET,
+                        mapOf(
+                                "experienceCloud.org" to "orgid"
+                        )
+                )
+            }
+            return@thenAnswer null
+        }
+
+        val event = Event.Builder("event", "type", "source").build()
+        assertTrue(spiedIdentityExtension.forceSyncIdentifiers(event))
+
+        verify(spiedIdentityExtension, times(1)).readyForSyncIdentifiers(any())
+        verify(mockedExtensionApi, times(1)).createSharedState(any(), eq(event))
+    }
+
+    @Test
+    fun `forceSyncIdentifiers() should return false on Configuration state without orgId `() {
+        val spiedIdentityExtension = initializeSpiedIdentityExtension()
+        Mockito.`when`(
+                mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
+        ).thenAnswer { invocation ->
+            val extension = invocation.arguments[0] as? String
+            if ("com.adobe.module.configuration" === extension) {
+                return@thenAnswer SharedStateResult(
+                        SharedStateStatus.SET,
+                        mapOf(
+                                "no.server.config" to "orgid"
+                        )
+                )
+            }
+            return@thenAnswer null
+        }
+
+        val event = Event.Builder("event", "type", "source").build()
+        assertFalse(spiedIdentityExtension.forceSyncIdentifiers(event))
+
+        // forceSyncIdentifiers fails from call to readyForSyncIdentifiers
+        verify(spiedIdentityExtension, times(1)).readyForSyncIdentifiers(any())
+        verify(mockedExtensionApi, never()).createSharedState(any(), any())
     }
 
     @Test
     fun `forceSyncIdentifiers() should still create a shared state if OPTED_OUT`() {
         val identityExtension = initializeSpiedIdentityExtension()
+        Mockito.`when`(
+                mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
+        ).thenAnswer { invocation ->
+            val extension = invocation.arguments[0] as? String
+            if ("com.adobe.module.configuration" === extension) {
+                return@thenAnswer SharedStateResult(
+                        SharedStateStatus.SET,
+                        mapOf(
+                                "experienceCloud.org" to "orgid"
+                        )
+                )
+            }
+            return@thenAnswer null
+        }
         identityExtension.setPrivacyStatus(MobilePrivacyStatus.OPT_OUT)
-        identityExtension.forceSyncIdentifiers(Event.Builder("event", "type", "source").build())
-        verify(mockedExtensionApi, times(1)).createSharedState(any(), anyOrNull())
+
+        val event = Event.Builder("event", "type", "source").build()
+        assertTrue(identityExtension.forceSyncIdentifiers(event))
+        verify(mockedExtensionApi, times(1)).createSharedState(any(), eq(event))
     }
 
     @Test
@@ -253,9 +330,11 @@ class IdentityExtensionTests {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
 
         spiedIdentityExtension.onRegistered()
+        // Initial sync needs to occur before a sync event will call readyForSyncIdentifiers
+        spiedIdentityExtension.setHasSynced(true)
 
         Mockito.`when`(
-            mockedExtensionApi.getSharedState(any(), any(), anyOrNull(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
@@ -278,13 +357,14 @@ class IdentityExtensionTests {
     }
 
     @Test
-    fun `readyForSyncIdentifiers() for sync event - no valid orgId - return false`() {
+    fun `readyForEvent() for sync event - no valid orgId - return false`() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
 
         spiedIdentityExtension.onRegistered()
+        spiedIdentityExtension.setHasSynced(true)
 
         Mockito.`when`(
-            mockedExtensionApi.getSharedState(any(), any(), anyOrNull(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
@@ -303,17 +383,18 @@ class IdentityExtensionTests {
                     .build()
             )
         )
-        verify(spiedIdentityExtension, times(2)).isSyncEvent(any())
+        verify(spiedIdentityExtension, times(1)).isSyncEvent(any())
     }
 
     @Test
-    fun `readyForSyncIdentifiers() - appendUrlEvent - happy`() {
+    fun `readyForEvent() - appendUrlEvent - happy`() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
 
         spiedIdentityExtension.onRegistered()
+        spiedIdentityExtension.setHasSynced(true);
 
         Mockito.`when`(
-            mockedExtensionApi.getSharedState(any(), any(), anyOrNull(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
@@ -344,13 +425,14 @@ class IdentityExtensionTests {
     }
 
     @Test
-    fun `readyForSyncIdentifiers() - appendUrlEvent - invalid analytics`() {
+    fun `readyForEvent() - appendUrlEvent - invalid analytics`() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
 
         spiedIdentityExtension.onRegistered()
+        spiedIdentityExtension.setHasSynced(true);
 
         Mockito.`when`(
-            mockedExtensionApi.getSharedState(any(), any(), anyOrNull(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
@@ -373,13 +455,14 @@ class IdentityExtensionTests {
     }
 
     @Test
-    fun `readyForSyncIdentifiers() - getUrlVarsEvent - happy`() {
+    fun `readyForEvent() - getUrlVarsEvent - happy`() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
 
         spiedIdentityExtension.onRegistered()
+        spiedIdentityExtension.setHasSynced(true);
 
         Mockito.`when`(
-            mockedExtensionApi.getSharedState(any(), any(), anyOrNull(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
@@ -410,13 +493,14 @@ class IdentityExtensionTests {
     }
 
     @Test
-    fun `readyForSyncIdentifiers() - getUrlVarsEvent - invalid analytics`() {
+    fun `readyForEvent() - getUrlVarsEvent - invalid analytics`() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
 
         spiedIdentityExtension.onRegistered()
+        spiedIdentityExtension.setHasSynced(true);
 
         Mockito.`when`(
-            mockedExtensionApi.getSharedState(any(), any(), anyOrNull(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
@@ -660,7 +744,7 @@ class IdentityExtensionTests {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
         var retrievedConfiguration = false
         Mockito.`when`(
-            mockedExtensionApi.getSharedState(any(), any(), anyOrNull(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
@@ -678,7 +762,7 @@ class IdentityExtensionTests {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
         var retrievedConfiguration = false
         Mockito.`when`(
-            mockedExtensionApi.getSharedState(any(), any(), anyOrNull(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
@@ -702,7 +786,7 @@ class IdentityExtensionTests {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
         var retrievedConfiguration = false
         Mockito.`when`(
-            mockedExtensionApi.getSharedState(any(), any(), anyOrNull(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
@@ -730,7 +814,7 @@ class IdentityExtensionTests {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
         var retrievedConfiguration = false
         Mockito.`when`(
-            mockedExtensionApi.getSharedState(any(), any(), anyOrNull(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
@@ -757,7 +841,7 @@ class IdentityExtensionTests {
     fun `processAudienceResponse() - happy`() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
         Mockito.`when`(
-            mockedExtensionApi.getSharedState(any(), any(), anyOrNull(), any())
+            mockedExtensionApi.getSharedState(any(), anyOrNull(), any(), any())
         ).thenAnswer { invocation ->
             val extension = invocation.arguments[0] as? String
             if ("com.adobe.module.configuration" === extension) {
@@ -854,26 +938,28 @@ class IdentityExtensionTests {
     }
 
     @Test
-    fun `handleSyncIdentifiers() - null configuration`() {
+    fun `handleSyncIdentifiers() - returns false on null configuration`() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
-        assertTrue(
+        assertFalse(
             spiedIdentityExtension.handleSyncIdentifiers(
-                Event.Builder("event", "type", "source").build(),
-                null
+                    Event.Builder("event", "type", "source").build(),
+                    null,
+                    false
             )
         )
         verify(spiedIdentityExtension, never()).extractIdentifiers(any())
     }
 
     @Test
-    fun `handleSyncIdentifiers() - cached state is OPTED_OUT`() {
+    fun `handleSyncIdentifiers() - returns false on cached state is OPTED_OUT`() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
         spiedIdentityExtension.setPrivacyStatus(MobilePrivacyStatus.OPT_OUT)
         val state = ConfigurationSharedStateIdentity()
-        assertTrue(
+        assertFalse(
             spiedIdentityExtension.handleSyncIdentifiers(
-                Event.Builder("event", "type", "source").build(),
-                state
+                    Event.Builder("event", "type", "source").build(),
+                    state,
+                    false
             )
         )
 
@@ -881,7 +967,7 @@ class IdentityExtensionTests {
     }
 
     @Test
-    fun `handleSyncIdentifiers() - latest state is OPTED_OUT`() {
+    fun `handleSyncIdentifiers() - returns false on latest state is OPTED_OUT`() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
         val state = ConfigurationSharedStateIdentity()
         state.getConfigurationProperties(
@@ -891,10 +977,11 @@ class IdentityExtensionTests {
 
             )
         )
-        assertTrue(
+        assertFalse(
             spiedIdentityExtension.handleSyncIdentifiers(
-                Event.Builder("event", "type", "source").build(),
-                state
+                    Event.Builder("event", "type", "source").build(),
+                    state,
+                    false
             )
         )
 
@@ -902,7 +989,7 @@ class IdentityExtensionTests {
     }
 
     @Test
-    fun `handleSyncIdentifiers() - null event`() {
+    fun `handleSyncIdentifiers() - returns false on null event`() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
         val state = ConfigurationSharedStateIdentity()
         state.getConfigurationProperties(
@@ -912,7 +999,7 @@ class IdentityExtensionTests {
 
             )
         )
-        assertTrue(spiedIdentityExtension.handleSyncIdentifiers(null, state))
+        assertFalse(spiedIdentityExtension.handleSyncIdentifiers(null, state, false))
 
         verify(spiedIdentityExtension, never()).extractIdentifiers(any())
     }

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityFunctionalTests.kt
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityFunctionalTests.kt
@@ -1972,7 +1972,7 @@ class IdentityFunctionalTests {
             }
         }
 
-        identityExtension.processIdentityRequest(
+        identityExtension.handleIdentityRequestReset(
             Event.Builder(
                 "event",
                 "com.adobe.eventType.generic.identity",

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityFunctionalTests.kt
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityFunctionalTests.kt
@@ -1979,15 +1979,6 @@ class IdentityFunctionalTests {
                 "com.adobe.eventSource.requestReset"
             ).build()
         )
-        val eventCaptor = ArgumentCaptor.forClass(Event::class.java)
-        verify(mockedExtensionApi, atLeast(1)).dispatch(eventCaptor.capture())
-        val event = eventCaptor.value
-        assertNotNull(event.eventData)
-        assertTrue(event.eventData.contains("forcesync"))
-        assertTrue(event.eventData.contains("authenticationstate"))
-        assertTrue(event.eventData.contains("issyncevent"))
-
-        identityExtension.processIdentityRequest(event)
 
         countDownLatch.await()
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. There are cases when Identity will create an initial shared state using “null” twice when booting. The iOS implementation has a check for this which I’ll need to add to the Android implementation.
2. On privacy toggle or a call to resetIdentities, a force sync event is dispatched to the Event Hub which when processed will generate a new ECID. This can cause a delay where, if any other events are already in the queue will get processed without an ECID. iOS calls syncIdentifiers directly here to ensure the ECID is generated when resetIdentities is processed. I’ll make that change to Android as well.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
