### PR TITLE
Fix response type for config requestIdentity

### DIFF
--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtension.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtension.kt
@@ -401,7 +401,8 @@ internal class ConfigurationExtension : Extension {
      * @param event the event to which the current SDK Identifiers should be
      *        dispatched as a response
      */
-    private fun retrieveSDKIdentifiers(event: Event) {
+    @VisibleForTesting
+    internal fun retrieveSDKIdentifiers(event: Event) {
         val eventData = mutableMapOf<String, Any?>()
         MobileIdentitiesProvider.collectSdkIdentifiers(event, api).also { sdkIdentitiesJson ->
             eventData[CONFIGURATION_RESPONSE_IDENTITY_ALL_IDENTIFIERS] = sdkIdentitiesJson
@@ -410,7 +411,7 @@ internal class ConfigurationExtension : Extension {
         val responseIdentityEvent = Event.Builder(
             "Configuration Response Identity",
             EventType.CONFIGURATION,
-            EventSource.REQUEST_IDENTITY
+            EventSource.RESPONSE_IDENTITY
         ).setEventData(eventData).inResponseToEvent(event).build()
 
         api.dispatch(responseIdentityEvent)

--- a/code/core/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtensionTest.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtensionTest.kt
@@ -47,7 +47,6 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
-import java.util.*
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit

--- a/code/integration-tests/build.gradle
+++ b/code/integration-tests/build.gradle
@@ -46,6 +46,10 @@ dependencies {
     implementation project(path: ':identity')
     implementation project(path: ':lifecycle')
 
+    androidTestImplementation('com.adobe.marketing.mobile:analytics:2.0.0-SNAPSHOT'){
+        transitive = false
+    }
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/code/integration-tests/src/androidTest/java/com/adobe/marketing/mobile/integration/identity/IdentityIntegrationTests.kt
+++ b/code/integration-tests/src/androidTest/java/com/adobe/marketing/mobile/integration/identity/IdentityIntegrationTests.kt
@@ -303,7 +303,7 @@ class IdentityIntegrationTests {
         countDownLatch.await()
     }
 
-    @Test
+    @Test(timeout = TEST_TIMEOUT)
     @Ignore
     //TODO: Fix issue where Analytics does not update persistence and shared state with latest vid
     fun testAppendTo_whenValidAnalyticsIds_includesAnalyticsIdsInReturnedUrl() {

--- a/code/integration-tests/src/androidTest/java/com/adobe/marketing/mobile/integration/identity/IdentityIntegrationTests.kt
+++ b/code/integration-tests/src/androidTest/java/com/adobe/marketing/mobile/integration/identity/IdentityIntegrationTests.kt
@@ -348,6 +348,7 @@ class IdentityIntegrationTests {
         countDownLatch.await()
 
         assertNotNull(receivedSDKIdentities)
+        assertNotNull(ecid)
         val assertMessage = "Received SDKIdentities: " + receivedSDKIdentities
         assertTrue(assertMessage, receivedSDKIdentities?.contains("{\"namespace\":\"DSID_20914\",\"value\":\"adid\",\"type\":\"integrationCode\"}") ?: false)
         assertTrue(assertMessage, receivedSDKIdentities?.contains("{\"namespace\":\"id1\",\"value\":\"value1\",\"type\":\"integrationCode\"}") ?: false)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The response type for Config requestIdentity should be responseIdentity.
For now the testGetSdkIdentities integration test is still ignored, pending fix in Analytics extension.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and integration tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
