### PR TITLE
Fix time unit for configuration retry

### DIFF
--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtension.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtension.kt
@@ -436,7 +436,7 @@ internal class ConfigurationExtension : Extension {
                 )
             },
             retryDelay,
-            TimeUnit.SECONDS
+            TimeUnit.MILLISECONDS
         )
     }
 

--- a/code/core/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtensionTest.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtensionTest.kt
@@ -528,14 +528,14 @@ class ConfigurationExtensionTest {
         verify(mockExecutorService).schedule(
             Mockito.any(Runnable::class.java),
             eq(5000L),
-            eq(TimeUnit.SECONDS)
+            eq(TimeUnit.MILLISECONDS)
         )
 
         // Verify second retry scheduling
         verify(mockExecutorService).schedule(
             Mockito.any(Runnable::class.java),
             eq(10000L),
-            eq(TimeUnit.SECONDS)
+            eq(TimeUnit.MILLISECONDS)
         )
 
         // Verify that cached state is set twice for 2 failed downloads


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently when a configuration download fails, a retry job is expected to be dispatched after 5 seconds. However the job is erroneously being dispatched after 5000 seconds. Fix the time units for the dispatch job.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Currently when a configuration download fails, a retry job is expected to be dispatched after 5 seconds. However the job is erroneously being dispatched after 5000 seconds. Fix the time units for the dispatch job.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Unit tests
- Manual test after simulating an network outage 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
