### PR TITLE
Close connection after network requests

### DIFF
--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationDownloader.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationDownloader.kt
@@ -109,6 +109,7 @@ internal class ConfigurationDownloader {
 
         val networkCallback = NetworkCallback { response: HttpConnecting ->
             val config = handleDownloadResponse(url, response)
+            response.close()
             completionCallback.invoke(config)
         }
 

--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationDownloader.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationDownloader.kt
@@ -107,9 +107,9 @@ internal class ConfigurationDownloader {
             DEFAULT_READ_TIMEOUT_MS
         )
 
-        val networkCallback = NetworkCallback { response: HttpConnecting ->
+        val networkCallback = NetworkCallback { response: HttpConnecting? ->
             val config = handleDownloadResponse(url, response)
-            response.close()
+            response?.close()
             completionCallback.invoke(config)
         }
 
@@ -124,7 +124,19 @@ internal class ConfigurationDownloader {
      * @param response the response which is to be processed
      * @return a map representation of the json configuration obtained from [response]
      */
-    private fun handleDownloadResponse(url: String, response: HttpConnecting): Map<String, Any?>? {
+    private fun handleDownloadResponse(url: String, response: HttpConnecting?): Map<String, Any?>? {
+        if (response == null) {
+            Log.trace(
+                ConfigurationExtension.TAG,
+                LOG_TAG,
+                "Received a null response."
+            )
+
+            // Return null here to trigger a retry as this is likely an internal failure
+            // in the network service
+            return null
+        }
+
         return when (response.responseCode) {
             HttpURLConnection.HTTP_OK -> {
                 val metadata = mutableMapOf<String, String>()

--- a/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/download/RulesLoader.java
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/download/RulesLoader.java
@@ -104,6 +104,7 @@ public class RulesLoader {
         final NetworkCallback networkCallback =
                 response -> {
                     final RulesLoadResult result = handleDownloadResponse(url, response);
+                    response.close();
                     callback.call(result);
                 };
 

--- a/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/download/RulesLoader.java
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/download/RulesLoader.java
@@ -104,7 +104,11 @@ public class RulesLoader {
         final NetworkCallback networkCallback =
                 response -> {
                     final RulesLoadResult result = handleDownloadResponse(url, response);
-                    response.close();
+
+                    if (response != null) {
+                        response.close();
+                    }
+
                     callback.call(result);
                 };
 
@@ -170,6 +174,12 @@ public class RulesLoader {
 
     private RulesLoadResult handleDownloadResponse(
             final String url, final HttpConnecting response) {
+
+        if (response == null) {
+            Log.trace(TAG, cacheName, "Received null response.");
+            return new RulesLoadResult(null, RulesLoadResult.Reason.NO_DATA);
+        }
+
         switch (response.getResponseCode()) {
             case HttpURLConnection.HTTP_OK:
                 return extractRules(

--- a/code/core/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationDownloaderTest.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationDownloaderTest.kt
@@ -89,13 +89,15 @@ class ConfigurationDownloaderTest {
     @Test
     fun `Download always makes a network request for a valid url`() {
         val mockConfigJson = "{}"
+        val simulatedResponse = simulateNetworkResponse(
+            HttpURLConnection.HTTP_OK,
+            mockConfigJson.byteInputStream(),
+            mapOf()
+        )
+
         `when`(mockNetworkService.connectAsync(any(), any())).then {
             val callback = it.getArgument<NetworkCallback>(1)
-            val simulatedResponse = simulateNetworkResponse(
-                HttpURLConnection.HTTP_OK,
-                mockConfigJson.byteInputStream(),
-                mapOf()
-            )
+
             callback.call(simulatedResponse)
         }
 
@@ -108,14 +110,16 @@ class ConfigurationDownloaderTest {
         verify(mockNetworkService, times(1)).connectAsync(any(), any())
         // verify that the original callback is invoked with right content
         verify(mockCompletionCallback).invoke(emptyMap())
+        verify(simulatedResponse).close()
     }
 
     @Test
     fun `Download when RemoteDownload result is null`() {
+        val simulatedResponse =
+            simulateNetworkResponse(HttpURLConnection.HTTP_OK, null, mapOf())
+
         `when`(mockNetworkService.connectAsync(any(), any())).then {
             val callback = it.getArgument<NetworkCallback>(1)
-            val simulatedResponse =
-                simulateNetworkResponse(HttpURLConnection.HTTP_OK, null, mapOf())
             callback.call(simulatedResponse)
         }
 
@@ -124,18 +128,20 @@ class ConfigurationDownloaderTest {
         verify(mockCacheService).get(ConfigurationDownloader.CONFIG_CACHE_NAME, SAMPLE_URL)
         verify(mockNetworkService, times(1)).connectAsync(any(), any())
         verify(mockCompletionCallback).invoke(null)
+        verify(simulatedResponse).close()
     }
 
     @Test
     fun `Download when download result file cannot be parsed`() {
         val mockConfigJson = "{invalid json}"
+        val simulatedResponse = simulateNetworkResponse(
+            HttpURLConnection.HTTP_OK,
+            mockConfigJson.byteInputStream(),
+            mapOf()
+        )
+
         `when`(mockNetworkService.connectAsync(any(), any())).then {
             val callback = it.getArgument<NetworkCallback>(1)
-            val simulatedResponse = simulateNetworkResponse(
-                HttpURLConnection.HTTP_OK,
-                mockConfigJson.byteInputStream(),
-                mapOf()
-            )
             callback.call(simulatedResponse)
         }
 
@@ -144,18 +150,21 @@ class ConfigurationDownloaderTest {
         verify(mockCacheService).get(ConfigurationDownloader.CONFIG_CACHE_NAME, SAMPLE_URL)
         verify(mockNetworkService, times(1)).connectAsync(any(), any())
         verify(mockCompletionCallback).invoke(null)
+        verify(simulatedResponse).close()
     }
 
     @Test
     fun `Download when download result is empty`() {
         val mockConfigJson = ""
+        val simulatedResponse = simulateNetworkResponse(
+            HttpURLConnection.HTTP_OK,
+            mockConfigJson.byteInputStream(),
+            mapOf()
+        )
+
         `when`(mockNetworkService.connectAsync(any(), any())).then {
             val callback = it.getArgument<NetworkCallback>(1)
-            val simulatedResponse = simulateNetworkResponse(
-                HttpURLConnection.HTTP_OK,
-                mockConfigJson.byteInputStream(),
-                mapOf()
-            )
+
             callback.call(simulatedResponse)
         }
 
@@ -165,6 +174,7 @@ class ConfigurationDownloaderTest {
         verify(mockNetworkService, times(1)).connectAsync(any(), any())
         // verify that the original callback is invoked with right content
         verify(mockCompletionCallback).invoke(emptyMap())
+        verify(simulatedResponse).close()
     }
 
     @Test
@@ -178,13 +188,14 @@ class ConfigurationDownloaderTest {
             "\"timeout\": 30.5" +
             "}"
 
+        val simulatedResponse = simulateNetworkResponse(
+            HttpURLConnection.HTTP_OK,
+            mockConfigContentJson.byteInputStream(),
+            mapOf()
+        )
+
         `when`(mockNetworkService.connectAsync(any(), any())).then {
             val callback = it.getArgument<NetworkCallback>(1)
-            val simulatedResponse = simulateNetworkResponse(
-                HttpURLConnection.HTTP_OK,
-                mockConfigContentJson.byteInputStream(),
-                mapOf()
-            )
             callback.call(simulatedResponse)
         }
 
@@ -203,6 +214,7 @@ class ConfigurationDownloaderTest {
         verify(mockCacheService).get(ConfigurationDownloader.CONFIG_CACHE_NAME, SAMPLE_URL)
         verify(mockNetworkService, times(1)).connectAsync(any(), any())
         verify(mockCompletionCallback).invoke(expectedConfig)
+        verify(simulatedResponse).close()
     }
 
     @Test
@@ -212,13 +224,16 @@ class ConfigurationDownloaderTest {
             "\"global.ssl\": true,\n" +
             "\"rules.url\"= \"https://assets.adobedtm.com/launch-rules.zip\"," + // This line has = instead of :
             "}"
+
+        val simulatedResponse = simulateNetworkResponse(
+            HttpURLConnection.HTTP_OK,
+            mockConfigContentJson.byteInputStream(),
+            mapOf()
+        )
+
         `when`(mockNetworkService.connectAsync(any(), any())).then {
             val callback = it.getArgument<NetworkCallback>(1)
-            val simulatedResponse = simulateNetworkResponse(
-                HttpURLConnection.HTTP_OK,
-                mockConfigContentJson.byteInputStream(),
-                mapOf()
-            )
+
             callback.call(simulatedResponse)
         }
 
@@ -227,14 +242,15 @@ class ConfigurationDownloaderTest {
         verify(mockCacheService).get(ConfigurationDownloader.CONFIG_CACHE_NAME, SAMPLE_URL)
         verify(mockNetworkService, times(1)).connectAsync(any(), any())
         verify(mockCompletionCallback).invoke(null)
+        verify(simulatedResponse).close()
     }
 
     @Test
     fun `Download when response is HTTP_NOT_MODIFIED`() {
+        val simulatedResponse = simulateNetworkResponse(HttpURLConnection.HTTP_NOT_MODIFIED, null, mapOf())
+
         `when`(mockNetworkService.connectAsync(any(), any())).then {
             val callback = it.getArgument<NetworkCallback>(1)
-            val simulatedResponse =
-                simulateNetworkResponse(HttpURLConnection.HTTP_NOT_MODIFIED, null, mapOf())
             callback.call(simulatedResponse)
         }
 
@@ -286,6 +302,7 @@ class ConfigurationDownloaderTest {
         // verify that the original callback is invoked with right content
         val expectedConfig = mapOf("cachedKey" to "value")
         verify(mockCompletionCallback).invoke(expectedConfig)
+        verify(simulatedResponse).close()
     }
 
     @After

--- a/code/core/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationDownloaderTest.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationDownloaderTest.kt
@@ -114,6 +114,26 @@ class ConfigurationDownloaderTest {
     }
 
     @Test
+    fun `Download when network response is null`() {
+        `when`(mockNetworkService.connectAsync(any(), any())).then {
+            val callback = it.getArgument<NetworkCallback>(1)
+
+            callback.call(null)
+        }
+
+        configurationDownloader.download(SAMPLE_URL, mockCompletionCallback)
+
+        verify(mockCacheService, times(1)).get(
+            ConfigurationDownloader.CONFIG_CACHE_NAME,
+            SAMPLE_URL
+        )
+        verify(mockNetworkService, times(1)).connectAsync(any(), any())
+
+        // verify that the original callback is invoked with null content
+        verify(mockCompletionCallback).invoke(null)
+    }
+
+    @Test
     fun `Download when RemoteDownload result is null`() {
         val simulatedResponse =
             simulateNetworkResponse(HttpURLConnection.HTTP_OK, null, mapOf())

--- a/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/download/RulesLoaderTest.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/download/RulesLoaderTest.java
@@ -177,6 +177,7 @@ public class RulesLoaderTest {
         assertEquals(
                 String.valueOf(SAMPLE_LAST_MODIFIED_MS),
                 capturedCacheEntry.getMetadata().get(RulesLoader.HTTP_HEADER_LAST_MODIFIED));
+        verify(mockResponse).close();
     }
 
     @Test
@@ -225,6 +226,7 @@ public class RulesLoaderTest {
                 ArgumentCaptor.forClass(NetworkRequest.class);
         verify(mockNetworkService, times(1)).connectAsync(networkRequestCaptor.capture(), any());
         verifyNetworkRequestParams(expectedNetworkRequest, networkRequestCaptor.getValue());
+        verify(mockResponse).close();
 
         final ArgumentCaptor<RulesLoadResult> resultCaptor =
                 ArgumentCaptor.forClass(RulesLoadResult.class);
@@ -273,6 +275,7 @@ public class RulesLoaderTest {
                 ArgumentCaptor.forClass(NetworkRequest.class);
         verify(mockNetworkService, times(1)).connectAsync(networkRequestCaptor.capture(), any());
         verifyNetworkRequestParams(expectedNetworkRequest, networkRequestCaptor.getValue());
+        verify(mockResponse).close();
 
         final ArgumentCaptor<RulesLoadResult> resultCaptor =
                 ArgumentCaptor.forClass(RulesLoadResult.class);
@@ -315,6 +318,7 @@ public class RulesLoaderTest {
                 ArgumentCaptor.forClass(NetworkRequest.class);
         verify(mockNetworkService, times(1)).connectAsync(networkRequestCaptor.capture(), any());
         verifyNetworkRequestParams(expectedNetworkRequest, networkRequestCaptor.getValue());
+        verify(mockResponse).close();
 
         final ArgumentCaptor<RulesLoadResult> resultCaptor =
                 ArgumentCaptor.forClass(RulesLoadResult.class);
@@ -354,6 +358,7 @@ public class RulesLoaderTest {
                 ArgumentCaptor.forClass(NetworkRequest.class);
         verify(mockNetworkService, times(1)).connectAsync(networkRequestCaptor.capture(), any());
         verifyNetworkRequestParams(expectedNetworkRequest, networkRequestCaptor.getValue());
+        verify(mockResponse).close();
 
         final ArgumentCaptor<RulesLoadResult> resultCaptor =
                 ArgumentCaptor.forClass(RulesLoadResult.class);
@@ -409,6 +414,7 @@ public class RulesLoaderTest {
                 ArgumentCaptor.forClass(NetworkRequest.class);
         verify(mockNetworkService, times(1)).connectAsync(networkRequestCaptor.capture(), any());
         verifyNetworkRequestParams(expectedNetworkRequest, networkRequestCaptor.getValue());
+        verify(mockResponse).close();
 
         final ArgumentCaptor<RulesLoadResult> resultCaptor =
                 ArgumentCaptor.forClass(RulesLoadResult.class);
@@ -448,6 +454,7 @@ public class RulesLoaderTest {
                 ArgumentCaptor.forClass(NetworkRequest.class);
         verify(mockNetworkService, times(1)).connectAsync(networkRequestCaptor.capture(), any());
         verifyNetworkRequestParams(expectedNetworkRequest, networkRequestCaptor.getValue());
+        verify(mockResponse, times(1)).close();
 
         final ArgumentCaptor<RulesLoadResult> resultCaptor =
                 ArgumentCaptor.forClass(RulesLoadResult.class);

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityHitsProcessing.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityHitsProcessing.java
@@ -152,6 +152,8 @@ class IdentityHitsProcessing implements HitProcessing {
                                         connection.getResponseCode());
                                 processingResult.complete(false);
                             }
+
+                            connection.close();
                         });
     }
 

--- a/code/signal/src/main/java/com/adobe/marketing/mobile/signal/internal/SignalHitProcessor.kt
+++ b/code/signal/src/main/java/com/adobe/marketing/mobile/signal/internal/SignalHitProcessor.kt
@@ -54,7 +54,7 @@ internal class SignalHitProcessor : HitProcessing {
         }
         networkService.connectAsync(request) { connection ->
             if (connection == null) {
-                processingResult.complete(false)
+                processingResult.complete(true)
                 return@connectAsync
             }
             when (val responseCode = connection.responseCode) {

--- a/code/signal/src/main/java/com/adobe/marketing/mobile/signal/internal/SignalHitProcessor.kt
+++ b/code/signal/src/main/java/com/adobe/marketing/mobile/signal/internal/SignalHitProcessor.kt
@@ -83,7 +83,7 @@ internal class SignalHitProcessor : HitProcessing {
                     )
                     processingResult.complete(true)
                 }
-            }
+            }.also { connection.close() }
         }
     }
 


### PR DESCRIPTION
After any nework request the connection needs to be closed to ensure that the resource streams do not leak.

<!--- Provide a general summary of your changes in the Title above -->

## Description
After any network request the connection needs to be closed to ensure that the resource streams do not leak.
<!--- Describe your changes in detail -->

## Related Issue
#382 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Unit tests 
- Manual tests using `testapp-kotlin` 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
