### PR TITLE
Update versions to 2.0.1

### DIFF
--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/CoreConstants.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/CoreConstants.kt
@@ -13,7 +13,7 @@ package com.adobe.marketing.mobile.internal
 
 internal object CoreConstants {
     const val LOG_TAG = "MobileCore"
-    const val VERSION = "2.0.0"
+    const val VERSION = "2.0.1"
 
     object EventDataKeys {
         /**

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -5,20 +5,20 @@ android.useAndroidX=true
 #
 #Maven artifacts
 #Core extension
-coreExtensionVersion=2.0.0
+coreExtensionVersion=2.0.1
 coreExtensionName=core
 coreExtensionAARName=core-phone-release.aar
 mavenRepoName=AdobeMobileCoreSdk
 mavenRepoDescription=Android Core Extension for Adobe Mobile Marketing
 #Signal extension
-signalExtensionVersion=2.0.0
+signalExtensionVersion=2.0.1
 signalExtensionName=signal
 signalExtensionAARName=signal-phone-release.aar
 #Lifecycle extension
-lifecycleExtensionVersion=2.0.0
+lifecycleExtensionVersion=2.0.1
 lifecycleExtensionName=lifecycle
 lifecycleExtensionAARName=lifecycle-phone-release.aar
 #Identity extension
-identityExtensionVersion=2.0.0
+identityExtensionVersion=2.0.1
 identityExtensionName=identity
 identityExtensionAARName=identity-phone-release.aar

--- a/code/identity/src/phone/java/com/adobe/marketing/mobile/Identity.java
+++ b/code/identity/src/phone/java/com/adobe/marketing/mobile/Identity.java
@@ -26,7 +26,7 @@ import java.util.Map;
 public class Identity {
 
     private static final String CLASS_NAME = "Identity";
-    private static final String EXTENSION_VERSION = "2.0.0";
+    private static final String EXTENSION_VERSION = "2.0.1";
     private static final String REQUEST_IDENTITY_EVENT_NAME = "IdentityRequestIdentity";
     private static final int PUBLIC_API_TIME_OUT_MILLISECOND = 500; // ms
     private static final String LOG_TAG = "Identity";

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/IdentityAPITests.java
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/IdentityAPITests.java
@@ -36,7 +36,7 @@ public class IdentityAPITests {
 
     @Test
     public void test_extensionVersion() {
-        assertEquals("2.0.0", Identity.extensionVersion());
+        assertEquals("2.0.1", Identity.extensionVersion());
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
@@ -108,7 +108,7 @@ class IdentityExtensionTests {
     @Test
     fun `get extension version`() {
         val identityExtension = initializeSpiedIdentityExtension()
-        assertEquals("2.0.0", identityExtension.version)
+        assertEquals("2.0.1", identityExtension.version)
     }
 
     @Test

--- a/code/lifecycle/src/phone/java/com/adobe/marketing/mobile/Lifecycle.java
+++ b/code/lifecycle/src/phone/java/com/adobe/marketing/mobile/Lifecycle.java
@@ -16,7 +16,7 @@ import com.adobe.marketing.mobile.services.Log;
 
 public class Lifecycle {
 
-    private static final String EXTENSION_VERSION = "2.0.0";
+    private static final String EXTENSION_VERSION = "2.0.1";
 
     public static final Class<? extends Extension> EXTENSION = LifecycleExtension.class;
 

--- a/code/lifecycle/src/test/java/com/adobe/marketing/mobile/lifecycle/LifecycleExtensionTest.java
+++ b/code/lifecycle/src/test/java/com/adobe/marketing/mobile/lifecycle/LifecycleExtensionTest.java
@@ -92,7 +92,7 @@ public class LifecycleExtensionTest {
 
     @Test
     public void testGetVersion() {
-        assertEquals("2.0.0", lifecycle.getVersion());
+        assertEquals("2.0.1", lifecycle.getVersion());
     }
 
     @Test

--- a/code/signal/src/phone/java/com/adobe/marketing/mobile/Signal.java
+++ b/code/signal/src/phone/java/com/adobe/marketing/mobile/Signal.java
@@ -17,7 +17,7 @@ import com.adobe.marketing.mobile.signal.internal.SignalExtension;
 
 public class Signal {
 
-    private static final String EXTENSION_VERSION = "2.0.0";
+    private static final String EXTENSION_VERSION = "2.0.1";
     private static final String CLASS_NAME = "Signal";
 
     public static final Class<? extends Extension> EXTENSION = SignalExtension.class;

--- a/code/signal/src/test/java/com/adobe/marketing/mobile/SignalAPITest.java
+++ b/code/signal/src/test/java/com/adobe/marketing/mobile/SignalAPITest.java
@@ -27,7 +27,7 @@ public class SignalAPITest {
 
     @Test
     public void test_extensionVersion() {
-        assertEquals("2.0.0", Signal.extensionVersion());
+        assertEquals("2.0.1", Signal.extensionVersion());
     }
 
     @Test

--- a/code/signal/src/test/java/com/adobe/marketing/mobile/signal/internal/SignalExtensionProtectedMethodsTests.kt
+++ b/code/signal/src/test/java/com/adobe/marketing/mobile/signal/internal/SignalExtensionProtectedMethodsTests.kt
@@ -112,7 +112,7 @@ class SignalExtensionProtectedMethodsTests {
 
     @Test
     fun `Test getVersion() `() {
-        assertEquals("2.0.0", ExtensionHelper.getVersion(signalExtension))
+        assertEquals("2.0.1", ExtensionHelper.getVersion(signalExtension))
     }
 
     @Test


### PR DESCRIPTION
Currently when a configuration download fails, a retry job
is expected to be dispatched after 5 seconds. However the
job is erroneously being dispatched after 5000 sconds.
Fix the time units for the dispatchj job.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
