### PR TITLE
Use latest configuration on Identity bootup (resolves #414)

### DIFF
--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/ConfigurationSharedStateIdentity.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/ConfigurationSharedStateIdentity.java
@@ -35,12 +35,12 @@ final class ConfigurationSharedStateIdentity {
     private final MobilePrivacyStatus privacyStatus;
 
     /** {@link String} containing the host value for the Experience Cloud Server */
-    private final String marketingCloudServer;
+    private final String experienceCloudServer;
 
     /**
      * Extracts data from the provided shared state data and sets the internal configuration
      * appropriately. Sets default values for {@link #privacyStatus}, and {@link
-     * #marketingCloudServer} if provided shared state does not contain valid values.
+     * #experienceCloudServer} if provided shared state does not contain valid values.
      *
      * @param sharedState EventData representing a {@code Configuration} shared state
      */
@@ -53,11 +53,7 @@ final class ConfigurationSharedStateIdentity {
                         IdentityConstants.JSON_EXPERIENCE_CLOUD_SERVER_KEY,
                         Defaults.SERVER);
 
-        if (StringUtils.isNullOrEmpty(server)) {
-            this.marketingCloudServer = Defaults.SERVER;
-        } else {
-            this.marketingCloudServer = server;
-        }
+        this.experienceCloudServer = StringUtils.isNullOrEmpty(server) ? Defaults.SERVER : server;
 
         this.privacyStatus =
                 MobilePrivacyStatus.fromString(
@@ -90,8 +86,8 @@ final class ConfigurationSharedStateIdentity {
      *
      * @return the Experience Cloud server; defaults to {@link Defaults#SERVER}
      */
-    @NonNull String getMarketingCloudServer() {
-        return marketingCloudServer;
+    @NonNull String getExperienceCloudServer() {
+        return experienceCloudServer;
     }
 
     /**

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/ConfigurationSharedStateIdentity.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/ConfigurationSharedStateIdentity.java
@@ -11,9 +11,10 @@
 
 package com.adobe.marketing.mobile.identity;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.adobe.marketing.mobile.MobilePrivacyStatus;
 import com.adobe.marketing.mobile.identity.IdentityConstants.Defaults;
-import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.StringUtils;
 import java.util.Map;
@@ -27,52 +28,35 @@ import java.util.Map;
  */
 final class ConfigurationSharedStateIdentity {
 
-    private static final String LOG_SOURCE = "ConfigurationSharedStateIdentity";
-
     /** {@link String} containing value of the customer's Experience Cloud Organization ID */
-    String orgID;
+    private final String orgID;
 
     /** {@link MobilePrivacyStatus} value containing the current opt status of the user */
-    MobilePrivacyStatus privacyStatus;
+    private final MobilePrivacyStatus privacyStatus;
 
     /** {@link String} containing the host value for the Experience Cloud Server */
-    String marketingCloudServer;
-
-    /**
-     * Constructor sets default values for {@link #privacyStatus}, and {@link #marketingCloudServer}
-     */
-    ConfigurationSharedStateIdentity() {
-        this.orgID = null;
-        this.privacyStatus = Defaults.DEFAULT_MOBILE_PRIVACY;
-        this.marketingCloudServer = Defaults.SERVER;
-    }
+    private final String marketingCloudServer;
 
     /**
      * Extracts data from the provided shared state data and sets the internal configuration
-     * appropriately
+     * appropriately. Sets default values for {@link #privacyStatus}, and {@link
+     * #marketingCloudServer} if provided shared state does not contain valid values.
      *
      * @param sharedState EventData representing a {@code Configuration} shared state
      */
-    void getConfigurationProperties(final Map<String, Object> sharedState) {
-        if (sharedState == null) {
-            Log.debug(
-                    IdentityConstants.LOG_TAG,
-                    LOG_SOURCE,
-                    "getConfigurationProperties : Using default configurations because config"
-                            + " state was null.");
-            return;
-        }
-
+    ConfigurationSharedStateIdentity(final Map<String, Object> sharedState) {
         this.orgID =
                 DataReader.optString(sharedState, IdentityConstants.JSON_CONFIG_ORGID_KEY, null);
-        this.marketingCloudServer =
+        String server =
                 DataReader.optString(
                         sharedState,
                         IdentityConstants.JSON_EXPERIENCE_CLOUD_SERVER_KEY,
                         Defaults.SERVER);
 
-        if (StringUtils.isNullOrEmpty(this.marketingCloudServer)) {
+        if (StringUtils.isNullOrEmpty(server)) {
             this.marketingCloudServer = Defaults.SERVER;
+        } else {
+            this.marketingCloudServer = server;
         }
 
         this.privacyStatus =
@@ -81,6 +65,33 @@ final class ConfigurationSharedStateIdentity {
                                 sharedState,
                                 IdentityConstants.JSON_CONFIG_PRIVACY_KEY,
                                 Defaults.DEFAULT_MOBILE_PRIVACY.getValue()));
+    }
+
+    /**
+     * The Experience Cloud organization ID.
+     *
+     * @return the Experience Cloud organization ID or null if one wasn't set.
+     */
+    @Nullable String getOrgID() {
+        return orgID;
+    }
+
+    /**
+     * The privacy status.
+     *
+     * @return the privacy status; defaults to {@link Defaults#DEFAULT_MOBILE_PRIVACY}.
+     */
+    @NonNull MobilePrivacyStatus getPrivacyStatus() {
+        return privacyStatus;
+    }
+
+    /**
+     * The Experience Cloud server.
+     *
+     * @return the Experience Cloud server; defaults to {@link Defaults#SERVER}
+     */
+    @NonNull String getMarketingCloudServer() {
+        return marketingCloudServer;
     }
 
     /**

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -249,8 +249,7 @@ public final class IdentityExtension extends Extension {
     @VisibleForTesting
     boolean readyForSyncIdentifiers(final Map<String, Object> configurationSharedState) {
         updateLatestValidConfiguration(configurationSharedState);
-        return latestValidConfig != null
-                && !StringUtils.isNullOrEmpty(latestValidConfig.orgID);
+        return latestValidConfig != null && !StringUtils.isNullOrEmpty(latestValidConfig.orgID);
     }
 
     @VisibleForTesting

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -1961,7 +1961,7 @@ public final class IdentityExtension extends Extension {
         final URLBuilder urlBuilder = new URLBuilder();
         urlBuilder
                 .addPath("id")
-                .setServer(configSharedState.getMarketingCloudServer())
+                .setServer(configSharedState.getExperienceCloudServer())
                 .addQueryParameters(queryParameters);
 
         final String customerIdsString = generateURLEncodedValuesCustomerIdString(customerIds);
@@ -2005,7 +2005,7 @@ public final class IdentityExtension extends Extension {
         final URLBuilder urlBuilder = new URLBuilder();
         urlBuilder
                 .addPath(IdentityConstants.UrlKeys.PATH_OPTOUT)
-                .setServer(configSharedState.getMarketingCloudServer())
+                .setServer(configSharedState.getExperienceCloudServer())
                 .addQueryParameters(queryParameters);
 
         return urlBuilder.build();

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -2405,22 +2405,6 @@ public final class IdentityExtension extends Extension {
         return requiresSharedStateUpdate;
     }
 
-    private Event createForcedSyncEvent() {
-        final Map<String, Object> eventData = new HashMap<>();
-        eventData.put(IdentityConstants.EventDataKeys.Identity.FORCE_SYNC, true);
-        eventData.put(IdentityConstants.EventDataKeys.Identity.IS_SYNC_EVENT, true);
-        eventData.put(
-                IdentityConstants.EventDataKeys.Identity.AUTHENTICATION_STATE,
-                VisitorID.AuthenticationState.UNKNOWN.getValue());
-
-        return new Event.Builder(
-                        "id-construct-forced-sync",
-                        EventType.IDENTITY,
-                        EventSource.REQUEST_IDENTITY)
-                .setEventData(eventData)
-                .build();
-    }
-
     /**
      * Checks if two {@link VisitorID}s have the same id type. This method is used for identifying
      * if an id needs to be updated or if it is completely new.

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -249,7 +249,7 @@ public final class IdentityExtension extends Extension {
     @VisibleForTesting
     boolean readyForSyncIdentifiers(final Map<String, Object> configurationSharedState) {
         updateLatestValidConfiguration(configurationSharedState);
-        if (latestValidConfig == null || StringUtils.isNullOrEmpty(latestValidConfig.orgID)) {
+        if (latestValidConfig == null || StringUtils.isNullOrEmpty(latestValidConfig.getOrgID())) {
             Log.debug(
                     IdentityConstants.LOG_TAG,
                     LOG_SOURCE,
@@ -481,8 +481,7 @@ public final class IdentityExtension extends Extension {
                         null);
 
         if (!StringUtils.isNullOrEmpty(orgId)) {
-            latestValidConfig = new ConfigurationSharedStateIdentity();
-            latestValidConfig.getConfigurationProperties(data);
+            latestValidConfig = new ConfigurationSharedStateIdentity(data);
         }
     }
 
@@ -575,10 +574,9 @@ public final class IdentityExtension extends Extension {
             // Make sure that the configuration shared state at this point has not changed the
             // privacy status
             ConfigurationSharedStateIdentity configSharedState =
-                    new ConfigurationSharedStateIdentity();
-            configSharedState.getConfigurationProperties(identitySharedState.getValue());
+                    new ConfigurationSharedStateIdentity(identitySharedState.getValue());
 
-            if (configSharedState.privacyStatus.equals(MobilePrivacyStatus.OPT_OUT)) {
+            if (configSharedState.getPrivacyStatus().equals(MobilePrivacyStatus.OPT_OUT)) {
                 sendOptOutHit(configSharedState);
             }
         }
@@ -758,8 +756,8 @@ public final class IdentityExtension extends Extension {
 
         Map<String, Object> configuration = result.getValue();
 
-        ConfigurationSharedStateIdentity configSharedState = new ConfigurationSharedStateIdentity();
-        configSharedState.getConfigurationProperties(configuration);
+        ConfigurationSharedStateIdentity configSharedState =
+                new ConfigurationSharedStateIdentity(configuration);
 
         Log.trace(
                 IdentityConstants.LOG_TAG,
@@ -806,10 +804,9 @@ public final class IdentityExtension extends Extension {
             // Otherwise, check to see if currently we are still opt_out, and if so, send the OPT
             // OUT hit
             ConfigurationSharedStateIdentity configSharedState =
-                    new ConfigurationSharedStateIdentity();
-            configSharedState.getConfigurationProperties(configuration);
+                    new ConfigurationSharedStateIdentity(configuration);
 
-            if (configSharedState.privacyStatus.equals(MobilePrivacyStatus.OPT_OUT)) {
+            if (configSharedState.getPrivacyStatus().equals(MobilePrivacyStatus.OPT_OUT)) {
                 sendOptOutHit(configSharedState);
             }
         }
@@ -841,7 +838,7 @@ public final class IdentityExtension extends Extension {
             return false;
         }
 
-        if (latestValidConfig.privacyStatus == MobilePrivacyStatus.OPT_OUT) {
+        if (latestValidConfig.getPrivacyStatus() == MobilePrivacyStatus.OPT_OUT) {
             Log.debug(
                     IdentityConstants.LOG_TAG,
                     LOG_SOURCE,
@@ -857,17 +854,6 @@ public final class IdentityExtension extends Extension {
                     "handleSyncIdentifiers : Ignoring the Sync Identifiers call because the event"
                             + " sent was null.");
             return false;
-        }
-
-        // if the marketingCloudServer is null or empty use the default server
-        if (StringUtils.isNullOrEmpty(latestValidConfig.marketingCloudServer)) {
-            latestValidConfig.marketingCloudServer = IdentityConstants.Defaults.SERVER;
-            Log.debug(
-                    IdentityConstants.LOG_TAG,
-                    LOG_SOURCE,
-                    "handleSyncIdentifiers : The experienceCloud.server was empty is the"
-                            + " configuration, hence used the default server: (%s).",
-                    latestValidConfig.marketingCloudServer);
         }
 
         final Map<String, Object> eventData = event.getEventData();
@@ -1471,7 +1457,7 @@ public final class IdentityExtension extends Extension {
         }
 
         // add Experience Cloud Org ID
-        String orgId = configSharedState != null ? configSharedState.orgID : null;
+        String orgId = configSharedState != null ? configSharedState.getOrgID() : null;
 
         if (!StringUtils.isNullOrEmpty(orgId)) {
             theIdString =
@@ -1958,7 +1944,7 @@ public final class IdentityExtension extends Extension {
             }
         }
 
-        queryParameters.put(IdentityConstants.UrlKeys.ORGID, configSharedState.orgID);
+        queryParameters.put(IdentityConstants.UrlKeys.ORGID, configSharedState.getOrgID());
 
         if (mid != null) {
             queryParameters.put(IdentityConstants.UrlKeys.MID, mid);
@@ -1975,7 +1961,7 @@ public final class IdentityExtension extends Extension {
         final URLBuilder urlBuilder = new URLBuilder();
         urlBuilder
                 .addPath("id")
-                .setServer(configSharedState.marketingCloudServer)
+                .setServer(configSharedState.getMarketingCloudServer())
                 .addQueryParameters(queryParameters);
 
         final String customerIdsString = generateURLEncodedValuesCustomerIdString(customerIds);
@@ -2008,18 +1994,18 @@ public final class IdentityExtension extends Extension {
             return null;
         }
 
-        if (configSharedState.orgID == null || mid == null) {
+        if (configSharedState.getOrgID() == null || mid == null) {
             return null;
         }
 
         final Map<String, String> queryParameters = new HashMap<>();
-        queryParameters.put(IdentityConstants.UrlKeys.ORGID, configSharedState.orgID);
+        queryParameters.put(IdentityConstants.UrlKeys.ORGID, configSharedState.getOrgID());
         queryParameters.put(IdentityConstants.UrlKeys.MID, mid);
 
         final URLBuilder urlBuilder = new URLBuilder();
         urlBuilder
                 .addPath(IdentityConstants.UrlKeys.PATH_OPTOUT)
-                .setServer(configSharedState.marketingCloudServer)
+                .setServer(configSharedState.getMarketingCloudServer())
                 .addQueryParameters(queryParameters);
 
         return urlBuilder.build();

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -250,7 +250,7 @@ public final class IdentityExtension extends Extension {
     boolean readyForSyncIdentifiers(final Map<String, Object> configurationSharedState) {
         updateLatestValidConfiguration(configurationSharedState);
         return latestValidConfig != null
-                && latestValidConfig.canSyncIdentifiersWithCurrentConfiguration();
+                && !StringUtils.isNullOrEmpty(latestValidConfig.orgID);
     }
 
     @VisibleForTesting

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/identity/ConfigurationSharedStateIdentityTest.java
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/identity/ConfigurationSharedStateIdentityTest.java
@@ -100,10 +100,10 @@ public class ConfigurationSharedStateIdentityTest {
                 configurationSharedStateIdentity.getPrivacyStatus(), MobilePrivacyStatus.UNKNOWN);
     }
 
-    // marketing server
+    // experience cloud server
     @Test
     public void
-            testExtractConfigurationProperties_SetsMarketingServer_When_NonNullMarketingServer() {
+            testExtractConfigurationProperties_SetsExperienceCloudServer_When_NonNullExperienceCloudServer() {
         Map<String, Object> testSharedData = new HashMap<>();
         testSharedData.put(
                 IdentityTestConstants.JSON_EXPERIENCE_CLOUD_SERVER_KEY, "my-custom-server");
@@ -111,19 +111,19 @@ public class ConfigurationSharedStateIdentityTest {
         ConfigurationSharedStateIdentity configurationSharedStateIdentity =
                 new ConfigurationSharedStateIdentity(testSharedData);
         assertEquals(
-                configurationSharedStateIdentity.getMarketingCloudServer(), "my-custom-server");
+                configurationSharedStateIdentity.getExperienceCloudServer(), "my-custom-server");
     }
 
     @Test
     public void
-            testExtractConfigurationProperties_SetsMarketingServerToDefault_When_NullMarketingServer() {
+            testExtractConfigurationProperties_SetsExperienceCloudServerToDefault_When_NullExperienceCloudServer() {
         Map<String, Object> testSharedData = new HashMap<>();
         testSharedData.put("random-key", "random-value");
 
         ConfigurationSharedStateIdentity configurationSharedStateIdentity =
                 new ConfigurationSharedStateIdentity(testSharedData);
         assertEquals(
-                configurationSharedStateIdentity.getMarketingCloudServer(),
+                configurationSharedStateIdentity.getExperienceCloudServer(),
                 IdentityTestConstants.Defaults.SERVER);
     }
 
@@ -249,7 +249,7 @@ public class ConfigurationSharedStateIdentityTest {
                 configurationSharedStateIdentity.getPrivacyStatus(),
                 IdentityTestConstants.Defaults.DEFAULT_MOBILE_PRIVACY);
         assertEquals(
-                configurationSharedStateIdentity.getMarketingCloudServer(),
+                configurationSharedStateIdentity.getExperienceCloudServer(),
                 IdentityTestConstants.Defaults.SERVER);
     }
 }

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/identity/ConfigurationSharedStateIdentityTest.java
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/identity/ConfigurationSharedStateIdentityTest.java
@@ -14,30 +14,24 @@ package com.adobe.marketing.mobile.identity;
 import static org.junit.Assert.*;
 
 import com.adobe.marketing.mobile.MobilePrivacyStatus;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 public class ConfigurationSharedStateIdentityTest {
 
-    private ConfigurationSharedStateIdentity configurationSharedStateIdentity;
-
-    @Before
-    public void setup() {
-        configurationSharedStateIdentity = new ConfigurationSharedStateIdentity();
-    }
-
     @Test
     public void testConstructor_ShouldSetDefault() {
-        verifyDefaultValues();
+        verifyDefaultValues(new ConfigurationSharedStateIdentity(Collections.emptyMap()));
     }
 
     @Test
     public void testExtractConfigurationProperties_ShouldLetDefaultValuesBe_When_NullSharedState() {
-        configurationSharedStateIdentity.getConfigurationProperties(null);
-        verifyDefaultValues();
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(null);
+        verifyDefaultValues(configurationSharedStateIdentity);
     }
 
     // org id
@@ -46,8 +40,9 @@ public class ConfigurationSharedStateIdentityTest {
         Map<String, Object> testSharedData = new HashMap<>();
         testSharedData.put(IdentityTestConstants.JSON_CONFIG_ORGID_KEY, "test-org-id");
 
-        configurationSharedStateIdentity.getConfigurationProperties(testSharedData);
-        assertEquals(configurationSharedStateIdentity.orgID, "test-org-id");
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
+        assertEquals(configurationSharedStateIdentity.getOrgID(), "test-org-id");
     }
 
     @Test
@@ -55,8 +50,9 @@ public class ConfigurationSharedStateIdentityTest {
         Map<String, Object> testSharedData = new HashMap<>();
         testSharedData.put("random-key", "random-value");
 
-        configurationSharedStateIdentity.getConfigurationProperties(testSharedData);
-        assertNull(configurationSharedStateIdentity.orgID, null);
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
+        assertNull(configurationSharedStateIdentity.getOrgID(), null);
     }
 
     // privacy
@@ -65,9 +61,10 @@ public class ConfigurationSharedStateIdentityTest {
         Map<String, Object> testSharedData = new HashMap<>();
         testSharedData.put(IdentityTestConstants.JSON_CONFIG_PRIVACY_KEY, "optedin");
 
-        configurationSharedStateIdentity.getConfigurationProperties(testSharedData);
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
         Assert.assertEquals(
-                configurationSharedStateIdentity.privacyStatus, MobilePrivacyStatus.OPT_IN);
+                configurationSharedStateIdentity.getPrivacyStatus(), MobilePrivacyStatus.OPT_IN);
     }
 
     @Test
@@ -75,8 +72,10 @@ public class ConfigurationSharedStateIdentityTest {
         Map<String, Object> testSharedData = new HashMap<>();
         testSharedData.put(IdentityTestConstants.JSON_CONFIG_PRIVACY_KEY, "invalidValue");
 
-        configurationSharedStateIdentity.getConfigurationProperties(testSharedData);
-        assertEquals(configurationSharedStateIdentity.privacyStatus, MobilePrivacyStatus.UNKNOWN);
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
+        assertEquals(
+                configurationSharedStateIdentity.getPrivacyStatus(), MobilePrivacyStatus.UNKNOWN);
     }
 
     @Test
@@ -84,8 +83,10 @@ public class ConfigurationSharedStateIdentityTest {
         Map<String, Object> testSharedData = new HashMap<>();
         testSharedData.put("random-key", "random-value");
 
-        configurationSharedStateIdentity.getConfigurationProperties(testSharedData);
-        assertEquals(configurationSharedStateIdentity.privacyStatus, MobilePrivacyStatus.UNKNOWN);
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
+        assertEquals(
+                configurationSharedStateIdentity.getPrivacyStatus(), MobilePrivacyStatus.UNKNOWN);
     }
 
     @Test
@@ -93,8 +94,10 @@ public class ConfigurationSharedStateIdentityTest {
         Map<String, Object> testSharedData = new HashMap<>();
         testSharedData.put(IdentityTestConstants.JSON_CONFIG_PRIVACY_KEY, "opted-whatever");
 
-        configurationSharedStateIdentity.getConfigurationProperties(testSharedData);
-        assertEquals(configurationSharedStateIdentity.privacyStatus, MobilePrivacyStatus.UNKNOWN);
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
+        assertEquals(
+                configurationSharedStateIdentity.getPrivacyStatus(), MobilePrivacyStatus.UNKNOWN);
     }
 
     // marketing server
@@ -105,8 +108,10 @@ public class ConfigurationSharedStateIdentityTest {
         testSharedData.put(
                 IdentityTestConstants.JSON_EXPERIENCE_CLOUD_SERVER_KEY, "my-custom-server");
 
-        configurationSharedStateIdentity.getConfigurationProperties(testSharedData);
-        assertEquals(configurationSharedStateIdentity.marketingCloudServer, "my-custom-server");
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
+        assertEquals(
+                configurationSharedStateIdentity.getMarketingCloudServer(), "my-custom-server");
     }
 
     @Test
@@ -115,9 +120,10 @@ public class ConfigurationSharedStateIdentityTest {
         Map<String, Object> testSharedData = new HashMap<>();
         testSharedData.put("random-key", "random-value");
 
-        configurationSharedStateIdentity.getConfigurationProperties(testSharedData);
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
         assertEquals(
-                configurationSharedStateIdentity.marketingCloudServer,
+                configurationSharedStateIdentity.getMarketingCloudServer(),
                 IdentityTestConstants.Defaults.SERVER);
     }
 
@@ -125,78 +131,125 @@ public class ConfigurationSharedStateIdentityTest {
     @Test
     public void
             testShouldSyncIdentifiersWithCurrentConfiguration_ShouldReturnFalse_When_NullOrgID() {
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(null);
         assertFalse(configurationSharedStateIdentity.canSyncIdentifiersWithCurrentConfiguration());
     }
 
     @Test
     public void
             testShouldSyncIdentifiersWithCurrentConfiguration_ShouldReturnFalse_When_EmptyOrgID() {
-        configurationSharedStateIdentity.orgID = "";
+        Map<String, Object> testSharedData = new HashMap<>();
+        testSharedData.put(IdentityTestConstants.JSON_CONFIG_ORGID_KEY, "");
+
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
         assertFalse(configurationSharedStateIdentity.canSyncIdentifiersWithCurrentConfiguration());
     }
 
     @Test
     public void
             testShouldSyncIdentifiersWithCurrentConfiguration_ShouldReturnFalse_When_PrivacyOptedOut() {
-        configurationSharedStateIdentity.privacyStatus = MobilePrivacyStatus.OPT_OUT;
+        Map<String, Object> testSharedData = new HashMap<>();
+        testSharedData.put(
+                IdentityTestConstants.JSON_CONFIG_PRIVACY_KEY,
+                MobilePrivacyStatus.OPT_OUT.getValue());
+
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
         assertFalse(configurationSharedStateIdentity.canSyncIdentifiersWithCurrentConfiguration());
     }
 
     @Test
     public void
             testShouldSyncIdentifiersWithCurrentConfiguration_ShouldReturnFalse_When_PrivacyOptedOut_NonEmptyOrgID() {
-        configurationSharedStateIdentity.privacyStatus = MobilePrivacyStatus.OPT_OUT;
-        configurationSharedStateIdentity.orgID = "non-empty-org-id";
+        Map<String, Object> testSharedData = new HashMap<>();
+        testSharedData.put(IdentityTestConstants.JSON_CONFIG_ORGID_KEY, "non-empty-org-id");
+        testSharedData.put(
+                IdentityTestConstants.JSON_CONFIG_PRIVACY_KEY,
+                MobilePrivacyStatus.OPT_OUT.getValue());
+
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
         assertFalse(configurationSharedStateIdentity.canSyncIdentifiersWithCurrentConfiguration());
     }
 
     @Test
     public void
             testShouldSyncIdentifiersWithCurrentConfiguration_ShouldReturnFalse_When_PrivacyOptedIn_EmptyOrgID() {
-        configurationSharedStateIdentity.privacyStatus = MobilePrivacyStatus.OPT_IN;
-        configurationSharedStateIdentity.orgID = "";
+        Map<String, Object> testSharedData = new HashMap<>();
+        testSharedData.put(IdentityTestConstants.JSON_CONFIG_ORGID_KEY, "");
+        testSharedData.put(
+                IdentityTestConstants.JSON_CONFIG_PRIVACY_KEY,
+                MobilePrivacyStatus.OPT_IN.getValue());
+
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
         assertFalse(configurationSharedStateIdentity.canSyncIdentifiersWithCurrentConfiguration());
     }
 
     @Test
     public void
             testShouldSyncIdentifiersWithCurrentConfiguration_ShouldReturnFalse_When_PrivacyOptedIn_NullOrgID() {
-        configurationSharedStateIdentity.privacyStatus = MobilePrivacyStatus.OPT_IN;
-        configurationSharedStateIdentity.orgID = null;
+        Map<String, Object> testSharedData = new HashMap<>();
+        testSharedData.put(
+                IdentityTestConstants.JSON_CONFIG_PRIVACY_KEY,
+                MobilePrivacyStatus.OPT_IN.getValue());
+
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
         assertFalse(configurationSharedStateIdentity.canSyncIdentifiersWithCurrentConfiguration());
     }
 
     @Test
     public void
             testShouldSyncIdentifiersWithCurrentConfiguration_ShouldReturnFalse_When_PrivacyUnknown_NullOrgID() {
-        configurationSharedStateIdentity.privacyStatus = MobilePrivacyStatus.UNKNOWN;
-        configurationSharedStateIdentity.orgID = null;
+        Map<String, Object> testSharedData = new HashMap<>();
+        testSharedData.put(
+                IdentityTestConstants.JSON_CONFIG_PRIVACY_KEY,
+                MobilePrivacyStatus.UNKNOWN.getValue());
+
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
         assertFalse(configurationSharedStateIdentity.canSyncIdentifiersWithCurrentConfiguration());
     }
 
     @Test
     public void
             testShouldSyncIdentifiersWithCurrentConfiguration_ShouldReturnTrue_When_PrivacyUnknown_NonNullOrgID() {
-        configurationSharedStateIdentity.privacyStatus = MobilePrivacyStatus.UNKNOWN;
-        configurationSharedStateIdentity.orgID = "non-empty-org-id";
+        Map<String, Object> testSharedData = new HashMap<>();
+        testSharedData.put(IdentityTestConstants.JSON_CONFIG_ORGID_KEY, "non-empty-org-id");
+        testSharedData.put(
+                IdentityTestConstants.JSON_CONFIG_PRIVACY_KEY,
+                MobilePrivacyStatus.UNKNOWN.getValue());
+
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
         assertTrue(configurationSharedStateIdentity.canSyncIdentifiersWithCurrentConfiguration());
     }
 
     @Test
     public void
             testShouldSyncIdentifiersWithCurrentConfiguration_ShouldReturnTrue_When_PrivacyOptedIn_NonNullOrgID() {
-        configurationSharedStateIdentity.privacyStatus = MobilePrivacyStatus.OPT_IN;
-        configurationSharedStateIdentity.orgID = "non-empty-org-id";
+        Map<String, Object> testSharedData = new HashMap<>();
+        testSharedData.put(IdentityTestConstants.JSON_CONFIG_ORGID_KEY, "non-empty-org-id");
+        testSharedData.put(
+                IdentityTestConstants.JSON_CONFIG_PRIVACY_KEY,
+                MobilePrivacyStatus.OPT_IN.getValue());
+
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
         assertTrue(configurationSharedStateIdentity.canSyncIdentifiersWithCurrentConfiguration());
     }
 
-    private void verifyDefaultValues() {
-        assertNull(configurationSharedStateIdentity.orgID);
+    private void verifyDefaultValues(
+            ConfigurationSharedStateIdentity configurationSharedStateIdentity) {
+        assertNull(configurationSharedStateIdentity.getOrgID());
         Assert.assertEquals(
-                configurationSharedStateIdentity.privacyStatus,
+                configurationSharedStateIdentity.getPrivacyStatus(),
                 IdentityTestConstants.Defaults.DEFAULT_MOBILE_PRIVACY);
         assertEquals(
-                configurationSharedStateIdentity.marketingCloudServer,
+                configurationSharedStateIdentity.getMarketingCloudServer(),
                 IdentityTestConstants.Defaults.SERVER);
     }
 }

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
@@ -28,6 +28,7 @@ import com.adobe.marketing.mobile.util.DataReader
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Before
@@ -294,6 +295,29 @@ class IdentityExtensionTests {
         verify(spiedIdentityExtension, times(1)).readyForSyncIdentifiers(any())
         verify(mockedExtensionApi, times(1)).createSharedState(any(), eq(testEvent1))
         verify(spiedIdentityExtension, times(2)).forceSyncIdentifiers(any())
+    }
+
+    @Test
+    fun `readyForSyncIdentifiers() sets latest valid config and returns true on valid configuration`() {
+        val spiedIdentityExtension = initializeSpiedIdentityExtension()
+
+        val config = mapOf<String, Any>("experienceCloud.org" to "orgid", "global.privacy" to "optedin")
+        val result = spiedIdentityExtension.readyForSyncIdentifiers(config)
+
+        assertTrue(result)
+        assertNotNull(spiedIdentityExtension.latestValidConfig)
+        assertTrue(spiedIdentityExtension.latestValidConfig.canSyncIdentifiersWithCurrentConfiguration())
+    }
+
+    @Test
+    fun `readyForSyncIdentifiers() does not set latest valid config and returns false on invalid configuration`() {
+        val spiedIdentityExtension = initializeSpiedIdentityExtension()
+
+        val config = mapOf<String, Any>("global.privacy" to "optedin") // No experienceCloud.org
+        val result = spiedIdentityExtension.readyForSyncIdentifiers(config)
+
+        assertFalse(result)
+        assertNull(spiedIdentityExtension.latestValidConfig)
     }
 
     @Test

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
@@ -595,7 +595,7 @@ class IdentityExtensionTests {
         )
         assertEquals(
             "dpm.demdex.net",
-            spiedIdentityExtension.latestValidConfig.marketingCloudServer
+            spiedIdentityExtension.latestValidConfig.experienceCloudServer
         )
     }
 

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
@@ -982,10 +982,10 @@ class IdentityExtensionTests {
     @Test
     fun `handleSyncIdentifiers() - returns false on null configuration`() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
+        spiedIdentityExtension.latestValidConfig = null
         assertFalse(
             spiedIdentityExtension.handleSyncIdentifiers(
                 Event.Builder("event", "type", "source").build(),
-                null,
                 false
             )
         )
@@ -996,11 +996,10 @@ class IdentityExtensionTests {
     fun `handleSyncIdentifiers() - returns false on cached state is OPTED_OUT`() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
         spiedIdentityExtension.setPrivacyStatus(MobilePrivacyStatus.OPT_OUT)
-        val state = ConfigurationSharedStateIdentity()
+        spiedIdentityExtension.latestValidConfig = ConfigurationSharedStateIdentity()
         assertFalse(
             spiedIdentityExtension.handleSyncIdentifiers(
                 Event.Builder("event", "type", "source").build(),
-                state,
                 false
             )
         )
@@ -1019,10 +1018,10 @@ class IdentityExtensionTests {
 
             )
         )
+        spiedIdentityExtension.latestValidConfig = state
         assertFalse(
             spiedIdentityExtension.handleSyncIdentifiers(
                 Event.Builder("event", "type", "source").build(),
-                state,
                 false
             )
         )
@@ -1041,7 +1040,8 @@ class IdentityExtensionTests {
 
             )
         )
-        assertFalse(spiedIdentityExtension.handleSyncIdentifiers(null, state, false))
+        spiedIdentityExtension.latestValidConfig = state
+        assertFalse(spiedIdentityExtension.handleSyncIdentifiers(null, false))
 
         verify(spiedIdentityExtension, never()).extractIdentifiers(any())
     }

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
@@ -912,7 +912,11 @@ class IdentityExtensionTests {
     @Test(timeout = 10000)
     fun `sendOptOutHit() - happy (200)`() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
-        val state = ConfigurationSharedStateIdentity()
+        val state = ConfigurationSharedStateIdentity(
+            mapOf(
+                "experienceCloud.org" to "orgId"
+            )
+        )
         spiedIdentityExtension.mid = "123455"
         Mockito.`when`(mockedConnection.responseCode).thenReturn(200)
         val countDownLatch = CountDownLatch(1)
@@ -922,11 +926,7 @@ class IdentityExtensionTests {
             callback.call(mockedConnection)
             countDownLatch.countDown()
         }
-        state.getConfigurationProperties(
-            mapOf(
-                "experienceCloud.org" to "orgId"
-            )
-        )
+
         spiedIdentityExtension.sendOptOutHit(state)
         countDownLatch.await()
         verify(mockedConnection, times(1)).close()
@@ -935,7 +935,11 @@ class IdentityExtensionTests {
     @Test(timeout = 10000)
     fun `sendOptOutHit() - bad request (400)`() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
-        val state = ConfigurationSharedStateIdentity()
+        val state = ConfigurationSharedStateIdentity(
+            mapOf(
+                "experienceCloud.org" to "orgId"
+            )
+        )
         spiedIdentityExtension.mid = "123455"
         Mockito.`when`(mockedConnection.responseCode).thenReturn(400)
         val countDownLatch = CountDownLatch(1)
@@ -945,11 +949,7 @@ class IdentityExtensionTests {
             callback.call(mockedConnection)
             countDownLatch.countDown()
         }
-        state.getConfigurationProperties(
-            mapOf(
-                "experienceCloud.org" to "orgId"
-            )
-        )
+
         spiedIdentityExtension.sendOptOutHit(state)
         countDownLatch.await()
         verify(mockedConnection, times(1)).close()
@@ -958,7 +958,11 @@ class IdentityExtensionTests {
     @Test(timeout = 10000)
     fun `sendOptOutHit() - null connection`() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
-        val state = ConfigurationSharedStateIdentity()
+        val state = ConfigurationSharedStateIdentity(
+            mapOf(
+                "experienceCloud.org" to "orgId"
+            )
+        )
         spiedIdentityExtension.mid = "123455"
         Mockito.`when`(mockedConnection.responseCode).thenReturn(200)
         val countDownLatch = CountDownLatch(1)
@@ -968,11 +972,7 @@ class IdentityExtensionTests {
             callback.call(null)
             countDownLatch.countDown()
         }
-        state.getConfigurationProperties(
-            mapOf(
-                "experienceCloud.org" to "orgId"
-            )
-        )
+
         spiedIdentityExtension.sendOptOutHit(state)
         countDownLatch.await()
         verify(mockedConnection, never()).close()
@@ -993,13 +993,13 @@ class IdentityExtensionTests {
 
     @Test
     fun `handleSyncIdentifiers() - returns false on cached state is OPTED_OUT`() {
-        val state = ConfigurationSharedStateIdentity()
-        state.getConfigurationProperties(
+        val state = ConfigurationSharedStateIdentity(
             mapOf(
                 "experienceCloud.org" to "orgid",
                 "global.privacy" to "optedout"
             )
         )
+
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
         spiedIdentityExtension.setPrivacyStatus(MobilePrivacyStatus.OPT_OUT)
         spiedIdentityExtension.latestValidConfig = state
@@ -1016,13 +1016,13 @@ class IdentityExtensionTests {
     @Test
     fun `handleSyncIdentifiers() - returns false on latest state is OPTED_OUT`() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
-        val state = ConfigurationSharedStateIdentity()
-        state.getConfigurationProperties(
+        val state = ConfigurationSharedStateIdentity(
             mapOf(
                 "experienceCloud.org" to "orgid",
                 "global.privacy" to "optedout"
             )
         )
+
         spiedIdentityExtension.latestValidConfig = state
         assertFalse(
             spiedIdentityExtension.handleSyncIdentifiers(
@@ -1037,13 +1037,13 @@ class IdentityExtensionTests {
     @Test
     fun `handleSyncIdentifiers() - returns false on null event`() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
-        val state = ConfigurationSharedStateIdentity()
-        state.getConfigurationProperties(
+        val state = ConfigurationSharedStateIdentity(
             mapOf(
                 "experienceCloud.org" to "orgid",
                 "global.privacy" to "optedout"
             )
         )
+
         spiedIdentityExtension.latestValidConfig = state
         assertFalse(spiedIdentityExtension.handleSyncIdentifiers(null, false))
 
@@ -1800,8 +1800,7 @@ class IdentityExtensionTests {
 
             val spiedIdentityExtension = initializeSpiedIdentityExtension()
 
-            val configurationSharedStateIdentity = ConfigurationSharedStateIdentity()
-            configurationSharedStateIdentity.getConfigurationProperties(
+            val configurationSharedStateIdentity = ConfigurationSharedStateIdentity(
                 mapOf(
                     "experienceCloud.org" to "orgid"
                 )

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
@@ -301,12 +301,11 @@ class IdentityExtensionTests {
     fun `readyForSyncIdentifiers() sets latest valid config and returns true on valid configuration`() {
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
 
-        val config = mapOf<String, Any>("experienceCloud.org" to "orgid", "global.privacy" to "optedin")
+        val config = mapOf<String, Any>("experienceCloud.org" to "orgid", "global.privacy" to "optedout")
         val result = spiedIdentityExtension.readyForSyncIdentifiers(config)
 
         assertTrue(result)
         assertNotNull(spiedIdentityExtension.latestValidConfig)
-        assertTrue(spiedIdentityExtension.latestValidConfig.canSyncIdentifiersWithCurrentConfiguration())
     }
 
     @Test

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
@@ -993,9 +993,16 @@ class IdentityExtensionTests {
 
     @Test
     fun `handleSyncIdentifiers() - returns false on cached state is OPTED_OUT`() {
+        val state = ConfigurationSharedStateIdentity()
+        state.getConfigurationProperties(
+            mapOf(
+                "experienceCloud.org" to "orgid",
+                "global.privacy" to "optedout"
+            )
+        )
         val spiedIdentityExtension = initializeSpiedIdentityExtension()
         spiedIdentityExtension.setPrivacyStatus(MobilePrivacyStatus.OPT_OUT)
-        spiedIdentityExtension.latestValidConfig = ConfigurationSharedStateIdentity()
+        spiedIdentityExtension.latestValidConfig = state
         assertFalse(
             spiedIdentityExtension.handleSyncIdentifiers(
                 Event.Builder("event", "type", "source").build(),
@@ -1014,7 +1021,6 @@ class IdentityExtensionTests {
             mapOf(
                 "experienceCloud.org" to "orgid",
                 "global.privacy" to "optedout"
-
             )
         )
         spiedIdentityExtension.latestValidConfig = state
@@ -1036,7 +1042,6 @@ class IdentityExtensionTests {
             mapOf(
                 "experienceCloud.org" to "orgid",
                 "global.privacy" to "optedout"
-
             )
         )
         spiedIdentityExtension.latestValidConfig = state

--- a/code/integration-tests/src/androidTest/java/com/adobe/marketing/mobile/integration/identity/IdentityIntegrationTests.kt
+++ b/code/integration-tests/src/androidTest/java/com/adobe/marketing/mobile/integration/identity/IdentityIntegrationTests.kt
@@ -218,27 +218,11 @@ class IdentityIntegrationTests {
 
     @Test(timeout = 5_000)
     fun testIdentitySendsForceSyncRequestOnLaunchOnValidConfig() {
-        SDKHelper.resetSDK()
-        ServiceProviderModifier.reset()
-
-        overrideNetworkService()
-
-        MobileCore.setApplication(ApplicationProvider.getApplicationContext())
-        MobileCore.setLogLevel(LoggingMode.VERBOSE)
         val countDownLatchNetworkMonitor = CountDownLatch(1)
         networkMonitor = { url ->
             if (url.contains("https://test.com/id")) {
                 countDownLatchNetworkMonitor.countDown()
             }
-        }
-        val countDownLatchLaunch = CountDownLatch(1)
-        MobileCore.registerExtensions(
-            listOf(
-                IdentityExtension::class.java,
-                MonitorExtension::class.java
-            )
-        ) {
-            countDownLatchLaunch.countDown()
         }
 
         // Set invalid configuration (no org id)
@@ -252,8 +236,6 @@ class IdentityIntegrationTests {
         val configurationLatch = CountDownLatch(1)
         configurationAwareness { configurationLatch.countDown() }
         configurationLatch.await()
-
-        assertTrue(countDownLatchLaunch.await(TEST_TIMEOUT, TimeUnit.MILLISECONDS))
 
         // No force sync request is sent on invalid configuration
         assertFalse(countDownLatchNetworkMonitor.await(TEST_TIMEOUT, TimeUnit.MILLISECONDS))

--- a/code/integration-tests/src/androidTest/java/com/adobe/marketing/mobile/integration/identity/IdentityIntegrationTests.kt
+++ b/code/integration-tests/src/androidTest/java/com/adobe/marketing/mobile/integration/identity/IdentityIntegrationTests.kt
@@ -216,6 +216,74 @@ class IdentityIntegrationTests {
         countDownLatchSecondNetworkMonitor.await()
     }
 
+    @Test(timeout = 5_000)
+    fun testIdentitySendsForceSyncRequestOnLaunchOnValidConfig() {
+        SDKHelper.resetSDK()
+        ServiceProviderModifier.reset()
+
+        overrideNetworkService()
+
+        MobileCore.setApplication(ApplicationProvider.getApplicationContext())
+        MobileCore.setLogLevel(LoggingMode.VERBOSE)
+        val countDownLatchNetworkMonitor = CountDownLatch(1)
+        networkMonitor = { url ->
+            if (url.contains("https://test.com/id")) {
+                countDownLatchNetworkMonitor.countDown()
+            }
+        }
+        val countDownLatchLaunch = CountDownLatch(1)
+        MobileCore.registerExtensions(
+            listOf(
+                IdentityExtension::class.java,
+                MonitorExtension::class.java
+            )
+        ) {
+            countDownLatchLaunch.countDown()
+        }
+
+        // Set invalid configuration (no org id)
+        MobileCore.updateConfiguration(
+            mapOf(
+                "experienceCloud.server" to "test.com",
+                "global.privacy" to "optedin"
+            )
+        )
+
+        val configurationLatch = CountDownLatch(1)
+        configurationAwareness { configurationLatch.countDown() }
+        configurationLatch.await()
+
+        assertTrue(countDownLatchLaunch.await(TEST_TIMEOUT, TimeUnit.MILLISECONDS))
+
+        // No force sync request is sent on invalid configuration
+        assertFalse(countDownLatchNetworkMonitor.await(TEST_TIMEOUT, TimeUnit.MILLISECONDS))
+
+        val countDownLatchSecondNetworkMonitor = CountDownLatch(1)
+        networkMonitor = { url ->
+            if (url.contains("https://test.com/id")) {
+                assertTrue(url.contains("d_orgid=orgid"))
+                assertTrue(url.contains("d_mid="))
+                countDownLatchSecondNetworkMonitor.countDown()
+            }
+        }
+
+        // Set valid configuration
+        MobileCore.updateConfiguration(
+            mapOf(
+                "experienceCloud.org" to "orgid",
+                "experienceCloud.server" to "test.com",
+                "global.privacy" to "optedin"
+            )
+        )
+
+        val configurationLatch2 = CountDownLatch(1)
+        configurationAwareness { configurationLatch2.countDown() }
+        configurationLatch2.await()
+
+        // Expect force sync after valid configuration update
+        assertTrue("Timeout waiting for force sync network request after updating configuration with valid org id.", countDownLatchSecondNetworkMonitor.await(TEST_TIMEOUT, TimeUnit.MILLISECONDS))
+    }
+
     @Test(timeout = TEST_TIMEOUT)
     fun testOptedout() {
         val countDownLatch = CountDownLatch(1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently, Identity uses the first set Configuration shared state when processing the force sync during boot up. This causes issues when the first Configuration is not valid. Instead, the Identity boot sequence should use the last set Configuration shared state when processing the force sync event. This way, if the first set Configuration state is invalid, then the next set Configuration state can be used to initialize the Identity extension.

- Refactor `readyForSyncIdentifiers` to take in a Map of the configuration state instead of getting the configuration state from an Event. In addition, update the `latestValidConfig` if the configuration state contains a `experienceCloud.org` value. This is similar to the iOS Swift implementation.
- Update `forceSyncIdentifiers` to use the refactored `readyForSyncIdentifiers`, ensuring to pass `null` to `getSharedState()` which will retrieve the last set Configuration state.
- Refactor `handleSyncIdentifiers` to remove the configuration parameter. As `latestValidConfig` is updated for each sync call, `handleSyncIdentifiers` just needs to use it for the configuration state. This is similar to the iOS Swift implementation.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
