### PR TITLE
Add license url and distribution sections to the POM file

### DIFF
--- a/code/core/release.gradle
+++ b/code/core/release.gradle
@@ -32,6 +32,8 @@ publishing {
                 licenses {
                     license {
                         name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'repo'
                     }
                 }
                 developers {

--- a/code/identity/build.gradle
+++ b/code/identity/build.gradle
@@ -111,6 +111,8 @@ publishing {
                 licenses {
                     license {
                         name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'repo'
                     }
                 }
                 developers {

--- a/code/lifecycle/build.gradle
+++ b/code/lifecycle/build.gradle
@@ -104,6 +104,8 @@ publishing {
                 licenses {
                     license {
                         name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'repo'
                     }
                 }
                 developers {

--- a/code/sdk-bom/build.gradle
+++ b/code/sdk-bom/build.gradle
@@ -200,6 +200,8 @@ publishing {
                 licenses {
                     license {
                         name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'repo'
                     }
                 }
                 developers {

--- a/code/signal/build.gradle
+++ b/code/signal/build.gradle
@@ -103,6 +103,8 @@ publishing {
                 licenses {
                     license {
                         name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'repo'
                     }
                 }
                 developers {


### PR DESCRIPTION
The POM reference gives a clear definition of the license section in a POM file => https://maven.apache.org/pom.html#Licenses 
```
<licenses>
  <license>
    <name>Apache-2.0</name>
    <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
    <distribution>repo</distribution>
    <comments>A business-friendly OSS license</comments>
  </license>
</licenses>
```
We are now only including the name section in our POM file. Some artifact license validation tools will not understand which license our artifacts are using because of the missing license url section. For more information, please see this issue report (https://github.com/adobe/aepsdk-core-android/issues/415).
Here are POM examples from other open-source artifacts:
- kotlin-stdlib (https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/1.8.10/kotlin-stdlib-1.8.10.pom)
```
<licenses>
<license>
<name>The Apache License, Version 2.0</name>
<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
</license>
</licenses>
```
- firebase-common (https://mvnrepository.com/artifact/com.google.firebase/firebase-common/20.3.2)
```
<licenses>
    <license>
      <name>The Apache Software License, Version 2.0</name>
      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
    </license>
  </licenses>
```
- firebase-analytics-ktx (https://mvnrepository.com/artifact/com.google.firebase/firebase-analytics-ktx/17.3.0)
```
<licenses>
    <license>
      <name>Android Software Development Kit License</name>
      <url>https://developer.android.com/studio/terms.html</url>
      <distribution>repo</distribution>
    </license>
  </licenses>
```

This PR updates the Gradle script to add the `url` and `distribution` sections to the generated POM file, if you run `generatePomFileForReleasePublication` gradle task, we will see the POM license section as below: 
```
<licenses>
<license>
<name>The Apache License, Version 2.0</name>
<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
<distribution>repo</distribution>
</license>
</licenses>
```