### PR TITLE
Merge to Staging for Core v2.1.1 Identity v2.0.2 release

### DIFF
--- a/code/core/release.gradle
+++ b/code/core/release.gradle
@@ -32,6 +32,8 @@ publishing {
                 licenses {
                     license {
                         name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'repo'
                     }
                 }
                 developers {

--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/CoreConstants.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/CoreConstants.kt
@@ -13,7 +13,7 @@ package com.adobe.marketing.mobile.internal
 
 internal object CoreConstants {
     const val LOG_TAG = "MobileCore"
-    const val VERSION = "2.1.0"
+    const val VERSION = "2.1.1"
 
     object EventDataKeys {
         /**

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
@@ -119,8 +119,15 @@ public final class MobileCore {
         ServiceProvider.getInstance().getAppContextService().setApplication(application);
         App.INSTANCE.registerActivityResumedListener(MobileCore::collectLaunchInfo);
 
-        V4ToV5Migration migrationTool = new V4ToV5Migration();
-        migrationTool.migrate();
+        try {
+            V4ToV5Migration migrationTool = new V4ToV5Migration();
+            migrationTool.migrate();
+        } catch (Exception e) {
+            Log.error(
+                    CoreConstants.LOG_TAG,
+                    LOG_TAG,
+                    "V4 to V5 migration failed - " + e.getLocalizedMessage());
+        }
 
         // Register configuration extension
         EventHub.Companion.getShared().registerExtension(ConfigurationExtension.class);

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -6,7 +6,7 @@ android.useAndroidX=true
 #
 #Maven artifacts
 #Core extension
-coreExtensionVersion=2.1.0
+coreExtensionVersion=2.1.1
 coreExtensionName=core
 coreExtensionAARName=core-phone-release.aar
 mavenRepoName=AdobeMobileCoreSdk

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -20,7 +20,7 @@ lifecycleExtensionVersion=2.0.1
 lifecycleExtensionName=lifecycle
 lifecycleExtensionAARName=lifecycle-phone-release.aar
 #Identity extension
-identityExtensionVersion=2.0.1
+identityExtensionVersion=2.0.2
 identityExtensionName=identity
 identityExtensionAARName=identity-phone-release.aar
 

--- a/code/identity/build.gradle
+++ b/code/identity/build.gradle
@@ -111,6 +111,8 @@ publishing {
                 licenses {
                     license {
                         name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'repo'
                     }
                 }
                 developers {

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/ConfigurationSharedStateIdentity.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/ConfigurationSharedStateIdentity.java
@@ -11,9 +11,10 @@
 
 package com.adobe.marketing.mobile.identity;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.adobe.marketing.mobile.MobilePrivacyStatus;
 import com.adobe.marketing.mobile.identity.IdentityConstants.Defaults;
-import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.StringUtils;
 import java.util.Map;
@@ -27,53 +28,32 @@ import java.util.Map;
  */
 final class ConfigurationSharedStateIdentity {
 
-    private static final String LOG_SOURCE = "ConfigurationSharedStateIdentity";
-
     /** {@link String} containing value of the customer's Experience Cloud Organization ID */
-    String orgID;
+    private final String orgID;
 
     /** {@link MobilePrivacyStatus} value containing the current opt status of the user */
-    MobilePrivacyStatus privacyStatus;
+    private final MobilePrivacyStatus privacyStatus;
 
     /** {@link String} containing the host value for the Experience Cloud Server */
-    String marketingCloudServer;
-
-    /**
-     * Constructor sets default values for {@link #privacyStatus}, and {@link #marketingCloudServer}
-     */
-    ConfigurationSharedStateIdentity() {
-        this.orgID = null;
-        this.privacyStatus = Defaults.DEFAULT_MOBILE_PRIVACY;
-        this.marketingCloudServer = Defaults.SERVER;
-    }
+    private final String experienceCloudServer;
 
     /**
      * Extracts data from the provided shared state data and sets the internal configuration
-     * appropriately
+     * appropriately. Sets default values for {@link #privacyStatus}, and {@link
+     * #experienceCloudServer} if provided shared state does not contain valid values.
      *
      * @param sharedState EventData representing a {@code Configuration} shared state
      */
-    void getConfigurationProperties(final Map<String, Object> sharedState) {
-        if (sharedState == null) {
-            Log.debug(
-                    IdentityConstants.LOG_TAG,
-                    LOG_SOURCE,
-                    "getConfigurationProperties : Using default configurations because config"
-                            + " state was null.");
-            return;
-        }
-
+    ConfigurationSharedStateIdentity(final Map<String, Object> sharedState) {
         this.orgID =
                 DataReader.optString(sharedState, IdentityConstants.JSON_CONFIG_ORGID_KEY, null);
-        this.marketingCloudServer =
+        String server =
                 DataReader.optString(
                         sharedState,
                         IdentityConstants.JSON_EXPERIENCE_CLOUD_SERVER_KEY,
                         Defaults.SERVER);
 
-        if (StringUtils.isNullOrEmpty(this.marketingCloudServer)) {
-            this.marketingCloudServer = Defaults.SERVER;
-        }
+        this.experienceCloudServer = StringUtils.isNullOrEmpty(server) ? Defaults.SERVER : server;
 
         this.privacyStatus =
                 MobilePrivacyStatus.fromString(
@@ -81,6 +61,33 @@ final class ConfigurationSharedStateIdentity {
                                 sharedState,
                                 IdentityConstants.JSON_CONFIG_PRIVACY_KEY,
                                 Defaults.DEFAULT_MOBILE_PRIVACY.getValue()));
+    }
+
+    /**
+     * The Experience Cloud organization ID.
+     *
+     * @return the Experience Cloud organization ID or null if one wasn't set.
+     */
+    @Nullable String getOrgID() {
+        return orgID;
+    }
+
+    /**
+     * The privacy status.
+     *
+     * @return the privacy status; defaults to {@link Defaults#DEFAULT_MOBILE_PRIVACY}.
+     */
+    @NonNull MobilePrivacyStatus getPrivacyStatus() {
+        return privacyStatus;
+    }
+
+    /**
+     * The Experience Cloud server.
+     *
+     * @return the Experience Cloud server; defaults to {@link Defaults#SERVER}
+     */
+    @NonNull String getExperienceCloudServer() {
+        return experienceCloudServer;
     }
 
     /**

--- a/code/identity/src/phone/java/com/adobe/marketing/mobile/Identity.java
+++ b/code/identity/src/phone/java/com/adobe/marketing/mobile/Identity.java
@@ -26,7 +26,7 @@ import java.util.Map;
 public class Identity {
 
     private static final String CLASS_NAME = "Identity";
-    private static final String EXTENSION_VERSION = "2.0.1";
+    private static final String EXTENSION_VERSION = "2.0.2";
     private static final String REQUEST_IDENTITY_EVENT_NAME = "IdentityRequestIdentity";
     private static final int PUBLIC_API_TIME_OUT_MILLISECOND = 500; // ms
     private static final String LOG_TAG = "Identity";

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/IdentityAPITests.java
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/IdentityAPITests.java
@@ -36,7 +36,7 @@ public class IdentityAPITests {
 
     @Test
     public void test_extensionVersion() {
-        assertEquals("2.0.1", Identity.extensionVersion());
+        assertEquals("2.0.2", Identity.extensionVersion());
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/identity/ConfigurationSharedStateIdentityTest.java
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/identity/ConfigurationSharedStateIdentityTest.java
@@ -14,30 +14,24 @@ package com.adobe.marketing.mobile.identity;
 import static org.junit.Assert.*;
 
 import com.adobe.marketing.mobile.MobilePrivacyStatus;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 public class ConfigurationSharedStateIdentityTest {
 
-    private ConfigurationSharedStateIdentity configurationSharedStateIdentity;
-
-    @Before
-    public void setup() {
-        configurationSharedStateIdentity = new ConfigurationSharedStateIdentity();
-    }
-
     @Test
     public void testConstructor_ShouldSetDefault() {
-        verifyDefaultValues();
+        verifyDefaultValues(new ConfigurationSharedStateIdentity(Collections.emptyMap()));
     }
 
     @Test
     public void testExtractConfigurationProperties_ShouldLetDefaultValuesBe_When_NullSharedState() {
-        configurationSharedStateIdentity.getConfigurationProperties(null);
-        verifyDefaultValues();
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(null);
+        verifyDefaultValues(configurationSharedStateIdentity);
     }
 
     // org id
@@ -46,8 +40,9 @@ public class ConfigurationSharedStateIdentityTest {
         Map<String, Object> testSharedData = new HashMap<>();
         testSharedData.put(IdentityTestConstants.JSON_CONFIG_ORGID_KEY, "test-org-id");
 
-        configurationSharedStateIdentity.getConfigurationProperties(testSharedData);
-        assertEquals(configurationSharedStateIdentity.orgID, "test-org-id");
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
+        assertEquals(configurationSharedStateIdentity.getOrgID(), "test-org-id");
     }
 
     @Test
@@ -55,8 +50,9 @@ public class ConfigurationSharedStateIdentityTest {
         Map<String, Object> testSharedData = new HashMap<>();
         testSharedData.put("random-key", "random-value");
 
-        configurationSharedStateIdentity.getConfigurationProperties(testSharedData);
-        assertNull(configurationSharedStateIdentity.orgID, null);
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
+        assertNull(configurationSharedStateIdentity.getOrgID(), null);
     }
 
     // privacy
@@ -65,9 +61,10 @@ public class ConfigurationSharedStateIdentityTest {
         Map<String, Object> testSharedData = new HashMap<>();
         testSharedData.put(IdentityTestConstants.JSON_CONFIG_PRIVACY_KEY, "optedin");
 
-        configurationSharedStateIdentity.getConfigurationProperties(testSharedData);
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
         Assert.assertEquals(
-                configurationSharedStateIdentity.privacyStatus, MobilePrivacyStatus.OPT_IN);
+                configurationSharedStateIdentity.getPrivacyStatus(), MobilePrivacyStatus.OPT_IN);
     }
 
     @Test
@@ -75,8 +72,10 @@ public class ConfigurationSharedStateIdentityTest {
         Map<String, Object> testSharedData = new HashMap<>();
         testSharedData.put(IdentityTestConstants.JSON_CONFIG_PRIVACY_KEY, "invalidValue");
 
-        configurationSharedStateIdentity.getConfigurationProperties(testSharedData);
-        assertEquals(configurationSharedStateIdentity.privacyStatus, MobilePrivacyStatus.UNKNOWN);
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
+        assertEquals(
+                configurationSharedStateIdentity.getPrivacyStatus(), MobilePrivacyStatus.UNKNOWN);
     }
 
     @Test
@@ -84,8 +83,10 @@ public class ConfigurationSharedStateIdentityTest {
         Map<String, Object> testSharedData = new HashMap<>();
         testSharedData.put("random-key", "random-value");
 
-        configurationSharedStateIdentity.getConfigurationProperties(testSharedData);
-        assertEquals(configurationSharedStateIdentity.privacyStatus, MobilePrivacyStatus.UNKNOWN);
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
+        assertEquals(
+                configurationSharedStateIdentity.getPrivacyStatus(), MobilePrivacyStatus.UNKNOWN);
     }
 
     @Test
@@ -93,31 +94,36 @@ public class ConfigurationSharedStateIdentityTest {
         Map<String, Object> testSharedData = new HashMap<>();
         testSharedData.put(IdentityTestConstants.JSON_CONFIG_PRIVACY_KEY, "opted-whatever");
 
-        configurationSharedStateIdentity.getConfigurationProperties(testSharedData);
-        assertEquals(configurationSharedStateIdentity.privacyStatus, MobilePrivacyStatus.UNKNOWN);
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
+        assertEquals(
+                configurationSharedStateIdentity.getPrivacyStatus(), MobilePrivacyStatus.UNKNOWN);
     }
 
-    // marketing server
+    // experience cloud server
     @Test
     public void
-            testExtractConfigurationProperties_SetsMarketingServer_When_NonNullMarketingServer() {
+            testExtractConfigurationProperties_SetsExperienceCloudServer_When_NonNullExperienceCloudServer() {
         Map<String, Object> testSharedData = new HashMap<>();
         testSharedData.put(
                 IdentityTestConstants.JSON_EXPERIENCE_CLOUD_SERVER_KEY, "my-custom-server");
 
-        configurationSharedStateIdentity.getConfigurationProperties(testSharedData);
-        assertEquals(configurationSharedStateIdentity.marketingCloudServer, "my-custom-server");
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
+        assertEquals(
+                configurationSharedStateIdentity.getExperienceCloudServer(), "my-custom-server");
     }
 
     @Test
     public void
-            testExtractConfigurationProperties_SetsMarketingServerToDefault_When_NullMarketingServer() {
+            testExtractConfigurationProperties_SetsExperienceCloudServerToDefault_When_NullExperienceCloudServer() {
         Map<String, Object> testSharedData = new HashMap<>();
         testSharedData.put("random-key", "random-value");
 
-        configurationSharedStateIdentity.getConfigurationProperties(testSharedData);
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
         assertEquals(
-                configurationSharedStateIdentity.marketingCloudServer,
+                configurationSharedStateIdentity.getExperienceCloudServer(),
                 IdentityTestConstants.Defaults.SERVER);
     }
 
@@ -125,78 +131,125 @@ public class ConfigurationSharedStateIdentityTest {
     @Test
     public void
             testShouldSyncIdentifiersWithCurrentConfiguration_ShouldReturnFalse_When_NullOrgID() {
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(null);
         assertFalse(configurationSharedStateIdentity.canSyncIdentifiersWithCurrentConfiguration());
     }
 
     @Test
     public void
             testShouldSyncIdentifiersWithCurrentConfiguration_ShouldReturnFalse_When_EmptyOrgID() {
-        configurationSharedStateIdentity.orgID = "";
+        Map<String, Object> testSharedData = new HashMap<>();
+        testSharedData.put(IdentityTestConstants.JSON_CONFIG_ORGID_KEY, "");
+
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
         assertFalse(configurationSharedStateIdentity.canSyncIdentifiersWithCurrentConfiguration());
     }
 
     @Test
     public void
             testShouldSyncIdentifiersWithCurrentConfiguration_ShouldReturnFalse_When_PrivacyOptedOut() {
-        configurationSharedStateIdentity.privacyStatus = MobilePrivacyStatus.OPT_OUT;
+        Map<String, Object> testSharedData = new HashMap<>();
+        testSharedData.put(
+                IdentityTestConstants.JSON_CONFIG_PRIVACY_KEY,
+                MobilePrivacyStatus.OPT_OUT.getValue());
+
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
         assertFalse(configurationSharedStateIdentity.canSyncIdentifiersWithCurrentConfiguration());
     }
 
     @Test
     public void
             testShouldSyncIdentifiersWithCurrentConfiguration_ShouldReturnFalse_When_PrivacyOptedOut_NonEmptyOrgID() {
-        configurationSharedStateIdentity.privacyStatus = MobilePrivacyStatus.OPT_OUT;
-        configurationSharedStateIdentity.orgID = "non-empty-org-id";
+        Map<String, Object> testSharedData = new HashMap<>();
+        testSharedData.put(IdentityTestConstants.JSON_CONFIG_ORGID_KEY, "non-empty-org-id");
+        testSharedData.put(
+                IdentityTestConstants.JSON_CONFIG_PRIVACY_KEY,
+                MobilePrivacyStatus.OPT_OUT.getValue());
+
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
         assertFalse(configurationSharedStateIdentity.canSyncIdentifiersWithCurrentConfiguration());
     }
 
     @Test
     public void
             testShouldSyncIdentifiersWithCurrentConfiguration_ShouldReturnFalse_When_PrivacyOptedIn_EmptyOrgID() {
-        configurationSharedStateIdentity.privacyStatus = MobilePrivacyStatus.OPT_IN;
-        configurationSharedStateIdentity.orgID = "";
+        Map<String, Object> testSharedData = new HashMap<>();
+        testSharedData.put(IdentityTestConstants.JSON_CONFIG_ORGID_KEY, "");
+        testSharedData.put(
+                IdentityTestConstants.JSON_CONFIG_PRIVACY_KEY,
+                MobilePrivacyStatus.OPT_IN.getValue());
+
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
         assertFalse(configurationSharedStateIdentity.canSyncIdentifiersWithCurrentConfiguration());
     }
 
     @Test
     public void
             testShouldSyncIdentifiersWithCurrentConfiguration_ShouldReturnFalse_When_PrivacyOptedIn_NullOrgID() {
-        configurationSharedStateIdentity.privacyStatus = MobilePrivacyStatus.OPT_IN;
-        configurationSharedStateIdentity.orgID = null;
+        Map<String, Object> testSharedData = new HashMap<>();
+        testSharedData.put(
+                IdentityTestConstants.JSON_CONFIG_PRIVACY_KEY,
+                MobilePrivacyStatus.OPT_IN.getValue());
+
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
         assertFalse(configurationSharedStateIdentity.canSyncIdentifiersWithCurrentConfiguration());
     }
 
     @Test
     public void
             testShouldSyncIdentifiersWithCurrentConfiguration_ShouldReturnFalse_When_PrivacyUnknown_NullOrgID() {
-        configurationSharedStateIdentity.privacyStatus = MobilePrivacyStatus.UNKNOWN;
-        configurationSharedStateIdentity.orgID = null;
+        Map<String, Object> testSharedData = new HashMap<>();
+        testSharedData.put(
+                IdentityTestConstants.JSON_CONFIG_PRIVACY_KEY,
+                MobilePrivacyStatus.UNKNOWN.getValue());
+
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
         assertFalse(configurationSharedStateIdentity.canSyncIdentifiersWithCurrentConfiguration());
     }
 
     @Test
     public void
             testShouldSyncIdentifiersWithCurrentConfiguration_ShouldReturnTrue_When_PrivacyUnknown_NonNullOrgID() {
-        configurationSharedStateIdentity.privacyStatus = MobilePrivacyStatus.UNKNOWN;
-        configurationSharedStateIdentity.orgID = "non-empty-org-id";
+        Map<String, Object> testSharedData = new HashMap<>();
+        testSharedData.put(IdentityTestConstants.JSON_CONFIG_ORGID_KEY, "non-empty-org-id");
+        testSharedData.put(
+                IdentityTestConstants.JSON_CONFIG_PRIVACY_KEY,
+                MobilePrivacyStatus.UNKNOWN.getValue());
+
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
         assertTrue(configurationSharedStateIdentity.canSyncIdentifiersWithCurrentConfiguration());
     }
 
     @Test
     public void
             testShouldSyncIdentifiersWithCurrentConfiguration_ShouldReturnTrue_When_PrivacyOptedIn_NonNullOrgID() {
-        configurationSharedStateIdentity.privacyStatus = MobilePrivacyStatus.OPT_IN;
-        configurationSharedStateIdentity.orgID = "non-empty-org-id";
+        Map<String, Object> testSharedData = new HashMap<>();
+        testSharedData.put(IdentityTestConstants.JSON_CONFIG_ORGID_KEY, "non-empty-org-id");
+        testSharedData.put(
+                IdentityTestConstants.JSON_CONFIG_PRIVACY_KEY,
+                MobilePrivacyStatus.OPT_IN.getValue());
+
+        ConfigurationSharedStateIdentity configurationSharedStateIdentity =
+                new ConfigurationSharedStateIdentity(testSharedData);
         assertTrue(configurationSharedStateIdentity.canSyncIdentifiersWithCurrentConfiguration());
     }
 
-    private void verifyDefaultValues() {
-        assertNull(configurationSharedStateIdentity.orgID);
+    private void verifyDefaultValues(
+            ConfigurationSharedStateIdentity configurationSharedStateIdentity) {
+        assertNull(configurationSharedStateIdentity.getOrgID());
         Assert.assertEquals(
-                configurationSharedStateIdentity.privacyStatus,
+                configurationSharedStateIdentity.getPrivacyStatus(),
                 IdentityTestConstants.Defaults.DEFAULT_MOBILE_PRIVACY);
         assertEquals(
-                configurationSharedStateIdentity.marketingCloudServer,
+                configurationSharedStateIdentity.getExperienceCloudServer(),
                 IdentityTestConstants.Defaults.SERVER);
     }
 }

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityExtensionTests.kt
@@ -109,7 +109,7 @@ class IdentityExtensionTests {
     @Test
     fun `get extension version`() {
         val identityExtension = initializeSpiedIdentityExtension()
-        assertEquals("2.0.1", identityExtension.version)
+        assertEquals("2.0.2", identityExtension.version)
     }
 
     @Test

--- a/code/lifecycle/build.gradle
+++ b/code/lifecycle/build.gradle
@@ -104,6 +104,8 @@ publishing {
                 licenses {
                     license {
                         name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'repo'
                     }
                 }
                 developers {

--- a/code/sdk-bom/build.gradle
+++ b/code/sdk-bom/build.gradle
@@ -200,6 +200,8 @@ publishing {
                 licenses {
                     license {
                         name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'repo'
                     }
                 }
                 developers {

--- a/code/signal/build.gradle
+++ b/code/signal/build.gradle
@@ -103,6 +103,8 @@ publishing {
                 licenses {
                     license {
                         name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'repo'
                     }
                 }
                 developers {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Merge to staging for Core 2.1.1 and Identity 2.0.2 releases:

- Core: Fix application crash when Core boots.
- Identity: Fix issue where Identity extension does not boot when initial Configuration does not contain a valid Experience Cloud organization ID.
- Add Apache license URL to POM

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
