### PR TITLE
Event history fixes

### DIFF
--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/util/MapExtensions.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/util/MapExtensions.kt
@@ -22,30 +22,37 @@ import org.json.JSONObject
  */
 @JvmSynthetic
 internal fun Map<String, Any?>.fnv1a32(masks: Array<String>? = null): Long {
-    val flattenedMap = this.flattening()
+    // remove null or empty values before flattening
+    val flattenedMap = this.filterNullOrEmptyValues().flattening()
     val kvPairs = StringBuilder()
     var innerMasks = masks
     if (innerMasks?.isEmpty() == true) innerMasks = null
     innerMasks?.let {
         it.sortedArray().forEach { mask ->
-            // we want to ignore null values
             if (mask.isNotEmpty() && flattenedMap[mask] != null) {
-                val mapValue = flattenedMap[mask].toString()
-                // we want to ignore empty strings
-                if (mapValue != "") {
-                    kvPairs.append(mask).append(":").append(mapValue)
-                }
+                kvPairs.append(mask).append(":").append(flattenedMap[mask].toString())
             }
         }
     } ?: run {
         flattenedMap.toSortedMap().forEach { entry ->
-            // we want to ignore null values or empty strings
-            if (entry.value != null && entry.value.toString() != "") {
-                kvPairs.append(entry.key).append(":").append(entry.value.toString())
-            }
+            kvPairs.append(entry.key).append(":").append(entry.value.toString())
         }
     }
     return StringEncoder.convertStringToDecimalHash(kvPairs.toString())
+}
+
+/**
+ * Removes null or empty string values from a map.
+ *
+ * @return the [Map] with null and empty string values removed
+ */
+@JvmSynthetic
+internal fun Map<String, Any?>.filterNullOrEmptyValues(): Map<String, Any?> {
+    val filteredMap = HashMap<String, Any>()
+    for ((key, value) in this) {
+        if (value != null && value != "") filteredMap[key] = value
+    }
+    return filteredMap
 }
 
 /**

--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/util/MapExtensions.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/util/MapExtensions.kt
@@ -12,6 +12,7 @@
 package com.adobe.marketing.mobile.internal.util
 
 import com.adobe.marketing.mobile.internal.util.UrlEncoder.urlEncode
+import com.adobe.marketing.mobile.util.StringUtils
 import org.json.JSONObject
 
 /**
@@ -28,8 +29,10 @@ internal fun Map<String, Any?>.fnv1a32(masks: Array<String>? = null): Long {
     if (innerMasks?.isEmpty() == true) innerMasks = null
     innerMasks?.let {
         it.sortedArray().forEach { mask ->
-            if (mask.isNotEmpty() && flattenedMap.containsKey(mask)) {
-                kvPairs.append(mask).append(":").append(flattenedMap[mask].toString())
+            val mapValue = flattenedMap[mask].toString()
+            // we want to ignore null or empty values within the map
+            if (mask.isNotEmpty() && mapValue != "null" && mapValue != "") {
+                kvPairs.append(mask).append(":").append(mapValue)
             }
         }
     } ?: run {

--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/util/MapExtensions.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/util/MapExtensions.kt
@@ -28,15 +28,21 @@ internal fun Map<String, Any?>.fnv1a32(masks: Array<String>? = null): Long {
     if (innerMasks?.isEmpty() == true) innerMasks = null
     innerMasks?.let {
         it.sortedArray().forEach { mask ->
-            val mapValue = flattenedMap[mask].toString()
-            // we want to ignore null or empty values within the map
-            if (mask.isNotEmpty() && mapValue != "null" && mapValue != "") {
-                kvPairs.append(mask).append(":").append(mapValue)
+            // we want to ignore null values
+            if (mask.isNotEmpty() && flattenedMap[mask] != null) {
+                val mapValue = flattenedMap[mask].toString()
+                // we want to ignore empty strings
+                if (mapValue != "") {
+                    kvPairs.append(mask).append(":").append(mapValue)
+                }
             }
         }
     } ?: run {
         flattenedMap.toSortedMap().forEach { entry ->
-            kvPairs.append(entry.key).append(":").append(entry.value.toString())
+            // we want to ignore null values or empty strings
+            if (entry.value != null && entry.value.toString() != "") {
+                kvPairs.append(entry.key).append(":").append(entry.value.toString())
+            }
         }
     }
     return StringEncoder.convertStringToDecimalHash(kvPairs.toString())

--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/util/MapExtensions.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/util/MapExtensions.kt
@@ -42,15 +42,20 @@ internal fun Map<String, Any?>.fnv1a32(masks: Array<String>? = null): Long {
 }
 
 /**
- * Removes null or empty string values from a map.
+ * Recursively removes null or empty string values from a map.
  *
  * @return the [Map] with null and empty string values removed
  */
 @JvmSynthetic
 internal fun Map<String, Any?>.filterNullOrEmptyValues(): Map<String, Any?> {
-    val filteredMap = HashMap<String, Any>()
+    val filteredMap = mutableMapOf<String, Any?>()
     for ((key, value) in this) {
-        if (value != null && value != "") filteredMap[key] = value
+        if (value is Map<*, *>) {
+            @Suppress("UNCHECKED_CAST")
+            filteredMap[key] = (value as Map<String, Any?>).filterNullOrEmptyValues()
+        } else {
+            if (value != null && value != "") filteredMap[key] = value
+        }
     }
     return filteredMap
 }

--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/util/MapExtensions.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/util/MapExtensions.kt
@@ -12,7 +12,6 @@
 package com.adobe.marketing.mobile.internal.util
 
 import com.adobe.marketing.mobile.internal.util.UrlEncoder.urlEncode
-import com.adobe.marketing.mobile.util.StringUtils
 import org.json.JSONObject
 
 /**

--- a/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/HistoricalEventsQuerying.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/HistoricalEventsQuerying.kt
@@ -32,7 +32,7 @@ internal fun historicalEventsQuerying(
         var eventCounts = 0
         extensionApi.getHistoricalEvents(
             requests.toTypedArray(),
-            searchType == SEARCH_TYPE_ANY
+            searchType != SEARCH_TYPE_ANY
         ) {
             latch.countDown()
             eventCounts = it

--- a/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/HistoricalEventsQuerying.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/HistoricalEventsQuerying.kt
@@ -18,7 +18,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 private const val LOG_TAG = "historicalEventsQuerying"
-private const val SEARCH_TYPE_ANY = "any"
+private const val SEARCH_TYPE_ORDERED = "ordered"
 private const val ASYNC_TIMEOUT = 1000L
 
 @JvmSynthetic
@@ -32,7 +32,7 @@ internal fun historicalEventsQuerying(
         var eventCounts = 0
         extensionApi.getHistoricalEvents(
             requests.toTypedArray(),
-            searchType != SEARCH_TYPE_ANY
+            searchType == SEARCH_TYPE_ORDERED
         ) {
             latch.countDown()
             eventCounts = it

--- a/code/core/src/test/java/com/adobe/marketing/mobile/internal/util/MapUtilsTests.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/internal/util/MapUtilsTests.java
@@ -307,7 +307,8 @@ public class MapUtilsTests {
     }
 
     @Test
-    public void testGetFnv1aHash_NullAndEmptyMapValuesPresent_WithKeysForNullAndEmptyValuesInMask() {
+    public void
+            testGetFnv1aHash_NullAndEmptyMapValuesPresent_WithKeysForNullAndEmptyValuesInMask() {
         // setup
         final Map<String, Object> map =
                 new HashMap<String, Object>() {

--- a/code/core/src/test/java/com/adobe/marketing/mobile/internal/util/MapUtilsTests.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/internal/util/MapUtilsTests.java
@@ -327,6 +327,32 @@ public class MapUtilsTests {
     }
 
     @Test
+    public void testGetFnv1aHash_NullAndEmptyMapValuesPresentInInnerMap_WithAllKeysInMask() {
+        // setup
+        final Map<String, Object> inner =
+                new HashMap<String, Object>() {
+                    {
+                        put("a", "1");
+                        put("b", "2");
+                        put("c", "");
+                        put("d", null);
+                    }
+                };
+        final Map<String, Object> map =
+                new HashMap<String, Object>() {
+                    {
+                        put("inner", inner);
+                    }
+                };
+        // test
+        final long hash =
+                MapUtilsKt.convertMapToFnv1aHash(map, new String[] {"inner.a", "inner.b"});
+        // verify flattened map string "inner.a:1inner.b:2"
+        final long expectedHash = 3328417429L;
+        assertEquals(expectedHash, hash);
+    }
+
+    @Test
     public void testGetFnv1aHash_NullAndEmptyMapValuesPresent_WithNoMask() {
         // setup
         final Map<String, Object> map =

--- a/code/core/src/test/java/com/adobe/marketing/mobile/internal/util/MapUtilsTests.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/internal/util/MapUtilsTests.java
@@ -288,6 +288,65 @@ public class MapUtilsTests {
     }
 
     @Test
+    public void testGetFnv1aHash_NullAndEmptyMapValuesPresent_WithAllKeysInMask() {
+        // setup
+        final Map<String, Object> map =
+                new HashMap<String, Object>() {
+                    {
+                        put("a", "1");
+                        put("b", "2");
+                        put("c", "");
+                        put("d", null);
+                    }
+                };
+        // test
+        final long hash = MapUtilsKt.convertMapToFnv1aHash(map, new String[] {"a", "b", "c", "d"});
+        // verify flattened map string "a:1b:2"
+        final long expectedHash = 3371500665L;
+        assertEquals(expectedHash, hash);
+    }
+
+    @Test
+    public void testGetFnv1aHash_NullAndEmptyMapValuesPresent_WithKeysForNullAndEmptyValuesInMask() {
+        // setup
+        final Map<String, Object> map =
+                new HashMap<String, Object>() {
+                    {
+                        put("a", "1");
+                        put("b", "2");
+                        put("c", "");
+                        put("d", null);
+                    }
+                };
+        // test
+        final long hash = MapUtilsKt.convertMapToFnv1aHash(map, new String[] {"c", "d"});
+        // verify 0 / no hash generated due to mask keys being present for null and empty values
+        final long expectedHash = 0;
+        assertEquals(expectedHash, hash);
+    }
+
+    @Test
+    public void testGetFnv1aHash_NullAndEmptyMapValuesPresent_WithNoMask() {
+        // setup
+        final Map<String, Object> map =
+                new HashMap<String, Object>() {
+                    {
+                        put("a", "1");
+                        put("b", "2");
+                        put("c", "");
+                        put("d", null);
+                        put("e", 3);
+                        put("f", "4");
+                    }
+                };
+        // test
+        final long hash = MapUtilsKt.convertMapToFnv1aHash(map, null);
+        // verify flattened map string "a:1b:2e:3f:4"
+        final long expectedHash = 3916945161L;
+        assertEquals(expectedHash, hash);
+    }
+
+    @Test
     public void testGetFnv1aHash_NoMask_VerifyEventDataMapSortedWithCaseSensitivity() {
         // setup
         final Map<String, Object> map =

--- a/code/core/src/test/java/com/adobe/marketing/mobile/internal/util/MapUtilsTests.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/internal/util/MapUtilsTests.java
@@ -353,6 +353,60 @@ public class MapUtilsTests {
     }
 
     @Test
+    public void testGetFnv1aHash_NullAndEmptyMapValuesPresentInMultipleNestedInnerMaps() {
+        // setup
+        final Map<String, Object> nestedNestedInner =
+                new HashMap<String, Object>() {
+                    {
+                        put("k", "5");
+                        put("l", "6");
+                        put("m", "");
+                        put("n", null);
+                    }
+                };
+        final Map<String, Object> nestedInner =
+                new HashMap<String, Object>() {
+                    {
+                        put("f", "3");
+                        put("g", "4");
+                        put("h", "");
+                        put("i", null);
+                        put("nestedNestedInner", nestedNestedInner);
+                    }
+                };
+        final Map<String, Object> inner =
+                new HashMap<String, Object>() {
+                    {
+                        put("a", "1");
+                        put("b", "2");
+                        put("c", "");
+                        put("d", null);
+                        put("nestedInner", nestedInner);
+                    }
+                };
+        final Map<String, Object> map =
+                new HashMap<String, Object>() {
+                    {
+                        put("inner", inner);
+                    }
+                };
+        // test
+        final long hash =
+                MapUtilsKt.convertMapToFnv1aHash(
+                        map,
+                        new String[] {
+                            "inner.a",
+                            "inner.b",
+                            "inner.nestedInner.g",
+                            "inner.nestedInner.nestedNestedInner.l"
+                        });
+        // verify flattened map string
+        // "inner.a:1inner.b:2inner.nestedInner.g:4inner.nestedInner.nestedNestedInner.l:6"
+        final long expectedHash = 4160127196L;
+        assertEquals(expectedHash, hash);
+    }
+
+    @Test
     public void testGetFnv1aHash_NullAndEmptyMapValuesPresent_WithNoMask() {
         // setup
         final Map<String, Object> map =

--- a/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/json/JSONConditionTests.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/json/JSONConditionTests.kt
@@ -15,16 +15,32 @@ import com.adobe.marketing.mobile.ExtensionApi
 import com.adobe.marketing.mobile.rulesengine.ComparisonExpression
 import com.adobe.marketing.mobile.rulesengine.Evaluable
 import com.adobe.marketing.mobile.rulesengine.LogicalExpression
+import com.adobe.marketing.mobile.rulesengine.OperandFunction
 import com.adobe.marketing.mobile.test.util.buildJSONObject
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.mockito.junit.MockitoJUnitRunner
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @RunWith(MockitoJUnitRunner.Silent::class)
 class JSONConditionTests {
+    fun ComparisonExpression<*, *>.getLhs(): Any? {
+        return javaClass.getDeclaredField("lhs").let {
+            it.isAccessible = true
+            return@let it.get(this)
+        }
+    }
+
+    fun OperandFunction<Object>.getFunctionParameters(): Any {
+        return javaClass.getDeclaredField("functionParameters").let {
+            it.isAccessible = true
+            return@let it.get(this)
+        }
+    }
+
     private lateinit var extensionApi: ExtensionApi
 
     @Before
@@ -170,5 +186,70 @@ class JSONConditionTests {
         val evaluable = jsonCondition.toEvaluable()
         assertTrue(evaluable is Evaluable)
         assertTrue(evaluable is LogicalExpression)
+    }
+
+    @Test
+    fun testMatcherWithHistoricalTypeAndNoSearchTypeDefaultsToSearchTypeAny() {
+        val jsonConditionString = """
+        {
+          "type": "historical",
+          "definition" : {
+            "events" : [
+                {
+                    "key1": "value1",
+                    "key2": "value2",
+                    "key3": true,
+                }
+            ],
+            "from": 123456789,
+            "to": 234567890,
+            "matcher" : "ge",
+            "value" : 1
+          }  
+        }
+        """.trimIndent()
+        val jsonCondition = JSONCondition.build(buildJSONObject(jsonConditionString), extensionApi)
+        assertTrue(jsonCondition is HistoricalCondition)
+        val evaluable = jsonCondition.toEvaluable()
+        assertTrue(evaluable is Evaluable)
+        assertTrue(evaluable is ComparisonExpression<*, *>)
+        val lhs = evaluable.getLhs() as OperandFunction<Object>
+        val parameters = lhs.getFunctionParameters() as Array<Any>
+        assertEquals("any", parameters.get(1))
+    }
+
+    @Test
+    fun testMatcherWithHistoricalTypeAndSearchTypeIsOrdered() {
+        val jsonConditionString = """
+        {
+          "type": "historical",
+          "definition" : {
+            "events" : [
+                {
+                    "key1": "value1",
+                    "key2": "value2",
+                    "key3": true,
+                },
+                {
+                    "key4": "value3",
+                    "key5": "value4"
+                }
+            ],
+            "searchType": "ordered",
+            "from": 123456789,
+            "to": 234567890,
+            "matcher" : "ge",
+            "value" : 1
+          }  
+        }
+        """.trimIndent()
+        val jsonCondition = JSONCondition.build(buildJSONObject(jsonConditionString), extensionApi)
+        assertTrue(jsonCondition is HistoricalCondition)
+        val evaluable = jsonCondition.toEvaluable()
+        assertTrue(evaluable is Evaluable)
+        assertTrue(evaluable is ComparisonExpression<*, *>)
+        val lhs = evaluable.getLhs() as OperandFunction<Object>
+        val parameters = lhs.getFunctionParameters() as Array<Any>
+        assertEquals("ordered", parameters.get(1))
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- fix searchType logic within the HistoricalEventsQuerying. if we have search type == any, we don't want to do an ordered search.
- fix fnv1a hash creation within MapExtensions. we want to check for empty map values (null or empty string) and not include them when creating the hash.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
