### PR TITLE
Create WebView object prior to passing the AEPMessage object to the MessagingDelegate to resolve WebView javascript handler issues

### DIFF
--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/AEPMessage.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/AEPMessage.java
@@ -116,6 +116,13 @@ class AEPMessage implements FullscreenMessage {
                     "Message couldn't be created because the FullscreenMessageDelegate was null.");
         }
 
+        final Activity currentActivity =
+                ServiceProvider.getInstance().getAppContextService().getCurrentActivity();
+        if (currentActivity == null) {
+            throw new MessageCreationException(
+                    "Message creation failed, the current activity is null");
+        }
+
         // create webview
         final Runnable createWebviewRunnable =
                 () -> {
@@ -144,12 +151,7 @@ class AEPMessage implements FullscreenMessage {
 
         final RunnableFuture<Void> createWebviewTask =
                 new FutureTask<>(createWebviewRunnable, null);
-        final Activity currentActivity =
-                ServiceProvider.getInstance().getAppContextService().getCurrentActivity();
-        if (currentActivity == null) {
-            throw new MessageCreationException(
-                    "Message creation failed, the current activity is null");
-        }
+        
         currentActivity.runOnUiThread(createWebviewTask);
 
         try {

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/AEPMessage.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/AEPMessage.java
@@ -388,6 +388,15 @@ class AEPMessage implements FullscreenMessage {
 
     /** Tears down views and listeners used to display the {@link AEPMessage}. */
     void cleanup() {
+        if (webView == null) {
+            Log.debug(
+                    ServiceConstants.LOG_TAG,
+                    TAG,
+                    "Webview creation failed, cleanup will not be done as no message was"
+                            + " displayed.");
+            return;
+        }
+
         Log.trace(ServiceConstants.LOG_TAG, TAG, "Cleaning the AEPMessage.");
 
         // notify message listeners
@@ -504,6 +513,7 @@ class AEPMessage implements FullscreenMessage {
                     "Exception occurred when creating the webview: %s",
                     exception.getLocalizedMessage());
             listener.onShowFailure();
+            createWebviewTask.cancel(true);
             return null;
         }
     }

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/AEPMessage.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/AEPMessage.java
@@ -151,7 +151,7 @@ class AEPMessage implements FullscreenMessage {
 
         final RunnableFuture<Void> createWebviewTask =
                 new FutureTask<>(createWebviewRunnable, null);
-        
+
         currentActivity.runOnUiThread(createWebviewTask);
 
         try {

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/AEPMessage.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/AEPMessage.java
@@ -127,7 +127,7 @@ class AEPMessage implements FullscreenMessage {
 
     @Override
     @Nullable public WebView getWebView() {
-        return webView != null ? webView : createWebView();
+        return webView;
     }
 
     @Override

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageFragment.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageFragment.java
@@ -66,7 +66,7 @@ public class MessageFragment extends android.app.Fragment implements View.OnTouc
         // determine if the tap occurred outside the webview
         if ((motionEventAction == MotionEvent.ACTION_DOWN
                         || motionEventAction == MotionEvent.ACTION_BUTTON_PRESS)
-                && view.getId() != message.webView.getId()) {
+                && view.getId() != message.getWebView().getId()) {
             Log.trace(
                     ServiceConstants.LOG_TAG,
                     TAG,
@@ -91,7 +91,7 @@ public class MessageFragment extends android.app.Fragment implements View.OnTouc
         }
 
         // determine if the tapped view is the webview
-        if (view.getId() == message.webView.getId()) {
+        if (view.getId() == message.getWebView().getId()) {
             // if we have no gestures just pass the touch event to the webview
             if (message.getMessageSettings().getGestures() == null
                     || message.getMessageSettings().getGestures().isEmpty()) {

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageFragment.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageFragment.java
@@ -17,6 +17,7 @@ import android.os.Bundle;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.View;
+import android.webkit.WebView;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.services.ServiceConstants;
 import com.adobe.marketing.mobile.services.ServiceProvider;
@@ -61,12 +62,23 @@ public class MessageFragment extends android.app.Fragment implements View.OnTouc
             return true;
         }
 
+        final WebView webView = message.getWebView();
+        if (webView == null) {
+            Log.debug(
+                    ServiceConstants.LOG_TAG,
+                    TAG,
+                    UNEXPECTED_NULL_VALUE
+                            + " (webview), unable to handle the touch event on "
+                            + view.getClass().getSimpleName());
+            return true;
+        }
+
         final int motionEventAction = motionEvent.getAction();
 
         // determine if the tap occurred outside the webview
         if ((motionEventAction == MotionEvent.ACTION_DOWN
                         || motionEventAction == MotionEvent.ACTION_BUTTON_PRESS)
-                && view.getId() != message.getWebView().getId()) {
+                && view.getId() != webView.getId()) {
             Log.trace(
                     ServiceConstants.LOG_TAG,
                     TAG,
@@ -91,7 +103,7 @@ public class MessageFragment extends android.app.Fragment implements View.OnTouc
         }
 
         // determine if the tapped view is the webview
-        if (view.getId() == message.getWebView().getId()) {
+        if (view.getId() == webView.getId()) {
             // if we have no gestures just pass the touch event to the webview
             if (message.getMessageSettings().getGestures() == null
                     || message.getMessageSettings().getGestures().isEmpty()) {

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageWebViewRunner.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageWebViewRunner.java
@@ -57,6 +57,7 @@ class MessageWebViewRunner implements Runnable {
     private MessageSettings settings;
     private int messageHeight, messageWidth, originX, originY;
     private Map<String, String> assetMap = Collections.emptyMap();
+    private WebView messageWebView;
 
     /**
      * Constructor.
@@ -125,7 +126,8 @@ class MessageWebViewRunner implements Runnable {
             }
 
             // load the in-app message in the webview
-            message.webView.loadDataWithBaseURL(
+            messageWebView = message.getWebView();
+            messageWebView.loadDataWithBaseURL(
                     BASE_URL,
                     message.getMessageHtml(),
                     MIME_TYPE,
@@ -134,12 +136,12 @@ class MessageWebViewRunner implements Runnable {
 
             message.rootViewGroup.setOnTouchListener(message.getMessageFragment());
             message.fragmentFrameLayout.setOnTouchListener(message.getMessageFragment());
-            message.webView.setOnTouchListener(message.getMessageFragment());
+            messageWebView.setOnTouchListener(message.getMessageFragment());
 
             // if swipe gestures are provided disable the scrollbars
             if (!MapUtils.isNullOrEmpty(settings.getGestures())) {
-                message.webView.setVerticalScrollBarEnabled(false);
-                message.webView.setHorizontalScrollBarEnabled(false);
+                messageWebView.setVerticalScrollBarEnabled(false);
+                messageWebView.setHorizontalScrollBarEnabled(false);
             }
 
             // setup onTouchListeners for the webview and the rootview.
@@ -156,7 +158,7 @@ class MessageWebViewRunner implements Runnable {
                 return;
             }
 
-            final WebSettings webSettings = message.webView.getSettings();
+            final WebSettings webSettings = messageWebView.getSettings();
 
             // Disallow need for a user gesture to play media.
             webSettings.setMediaPlaybackRequiresUserGesture(false);
@@ -221,7 +223,7 @@ class MessageWebViewRunner implements Runnable {
             case BOTTOM:
                 displayAnimation =
                         new TranslateAnimation(
-                                0, 0, message.baseRootViewHeight * 2, message.webView.getTop());
+                                0, 0, message.baseRootViewHeight * 2, messageWebView.getTop());
                 break;
             case CENTER:
                 displayAnimation =
@@ -285,7 +287,7 @@ class MessageWebViewRunner implements Runnable {
                         settings.getCornerRadius(),
                         context.getResources().getDisplayMetrics());
         webViewFrame.setRadius(calculatedRadius);
-        webViewFrame.addView(message.webView);
+        webViewFrame.addView(messageWebView);
 
         // setup a display animation for the CardView
         if (!message.isMessageVisible()) {

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageWebViewRunner.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageWebViewRunner.java
@@ -127,6 +127,15 @@ class MessageWebViewRunner implements Runnable {
 
             // load the in-app message in the webview
             messageWebView = message.getWebView();
+            if (messageWebView == null) {
+                Log.warning(
+                        ServiceConstants.LOG_TAG,
+                        TAG,
+                        "Failed to show the message, the webview is null.");
+                message.cleanup();
+                return;
+            }
+
             messageWebView.loadDataWithBaseURL(
                     BASE_URL,
                     message.getMessageHtml(),

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageWebViewRunner.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageWebViewRunner.java
@@ -21,6 +21,7 @@ import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
 import android.view.animation.DecelerateInterpolator;
 import android.view.animation.TranslateAnimation;
+import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.widget.FrameLayout;
 import androidx.cardview.widget.CardView;
@@ -155,8 +156,10 @@ class MessageWebViewRunner implements Runnable {
                 return;
             }
 
+            final WebSettings webSettings = message.webView.getSettings();
+
             // Disallow need for a user gesture to play media.
-            message.webView.getSettings().setMediaPlaybackRequiresUserGesture(false);
+            webSettings.setMediaPlaybackRequiresUserGesture(false);
 
             final Context appContext =
                     ServiceProvider.getInstance().getAppContextService().getApplicationContext();
@@ -167,13 +170,13 @@ class MessageWebViewRunner implements Runnable {
             }
 
             if (cacheDirectory != null) {
-                message.webView.getSettings().setDatabaseEnabled(true);
+                webSettings.setDatabaseEnabled(true);
             }
 
             // if we are re-showing after an orientation change, no need to animate
             final MessageSettings messageSettings = message.getSettings();
 
-            createMessageFrameAndAddMessageToRootView(messageSettings);
+            createMessageFrameAndAddMessageToRootView(messageSettings, webSettings);
             message.viewed();
         } catch (final Exception ex) {
             Log.warning(
@@ -248,16 +251,18 @@ class MessageWebViewRunner implements Runnable {
      *
      * @param settings The {@link MessageSettings} object containing customization settings for the
      *     {@link AEPMessage}.
+     * @param webSettings The {@link WebSettings} for the in-app {@code WebView}
      */
-    private void createMessageFrameAndAddMessageToRootView(final MessageSettings settings) {
+    private void createMessageFrameAndAddMessageToRootView(
+            final MessageSettings settings, final WebSettings webSettings) {
         FrameLayout.LayoutParams params =
                 generateLayoutParams(messageHeight, messageWidth, originX, originY);
 
         // if we have non fullscreen messages, fill the webview
         final int fullScreenMessageHeight = 100;
         if (settings.getHeight() != fullScreenMessageHeight) {
-            message.webView.getSettings().setLoadWithOverviewMode(true);
-            message.webView.getSettings().setUseWideViewPort(true);
+            webSettings.setLoadWithOverviewMode(true);
+            webSettings.setUseWideViewPort(true);
         }
 
         // apply round corners to a CardView then add the webview

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/AEPMessageTests.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/AEPMessageTests.java
@@ -76,6 +76,8 @@ public class AEPMessageTests {
 
     @Mock private CardView mockCardView;
 
+    @Mock private WebView mockWebView;
+
     @Mock private WebSettings mockWebSettings;
 
     @Mock private MotionEvent mockMotionEvent;
@@ -521,6 +523,7 @@ public class AEPMessageTests {
                         Assert.fail(ex.getMessage());
                     }
 
+                    message.webView = mockWebView;
                     message.rootViewGroup = mockViewGroup;
                     message.fragmentFrameLayout = mockFrameLayout;
                     message.messageFragment = mockMessageFragment;
@@ -573,6 +576,7 @@ public class AEPMessageTests {
                         Assert.fail(ex.getMessage());
                     }
 
+                    message.webView = mockWebView;
                     message.rootViewGroup = mockViewGroup;
                     message.fragmentFrameLayout = mockFrameLayout;
                     message.messageFragment = mockMessageFragment;
@@ -629,6 +633,7 @@ public class AEPMessageTests {
                         Assert.fail(ex.getMessage());
                     }
 
+                    message.webView = mockWebView;
                     message.rootViewGroup = mockViewGroup;
                     message.fragmentFrameLayout = mockFrameLayout;
                     message.messageWebViewRunner = mockMessageWebViewRunner;
@@ -686,6 +691,7 @@ public class AEPMessageTests {
                         Assert.fail(ex.getMessage());
                     }
 
+                    message.webView = mockWebView;
                     message.rootViewGroup = mockViewGroup;
                     message.fragmentFrameLayout = mockFrameLayout;
                     message.messageWebViewRunner = mockMessageWebViewRunner;

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/AEPMessageTests.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/AEPMessageTests.java
@@ -523,7 +523,7 @@ public class AEPMessageTests {
                         Assert.fail(ex.getMessage());
                     }
 
-                    message.webView = mockWebView;
+                    message.setWebView(mockWebView);
                     message.rootViewGroup = mockViewGroup;
                     message.fragmentFrameLayout = mockFrameLayout;
                     message.messageFragment = mockMessageFragment;
@@ -576,7 +576,7 @@ public class AEPMessageTests {
                         Assert.fail(ex.getMessage());
                     }
 
-                    message.webView = mockWebView;
+                    message.setWebView(mockWebView);
                     message.rootViewGroup = mockViewGroup;
                     message.fragmentFrameLayout = mockFrameLayout;
                     message.messageFragment = mockMessageFragment;
@@ -633,7 +633,7 @@ public class AEPMessageTests {
                         Assert.fail(ex.getMessage());
                     }
 
-                    message.webView = mockWebView;
+                    message.setWebView(mockWebView);
                     message.rootViewGroup = mockViewGroup;
                     message.fragmentFrameLayout = mockFrameLayout;
                     message.messageWebViewRunner = mockMessageWebViewRunner;
@@ -691,7 +691,7 @@ public class AEPMessageTests {
                         Assert.fail(ex.getMessage());
                     }
 
-                    message.webView = mockWebView;
+                    message.setWebView(mockWebView);
                     message.rootViewGroup = mockViewGroup;
                     message.fragmentFrameLayout = mockFrameLayout;
                     message.messageWebViewRunner = mockMessageWebViewRunner;

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/MessageFragmentTests.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/MessageFragmentTests.java
@@ -183,12 +183,12 @@ public class MessageFragmentTests {
     public void
             testOnTouchListener_TouchOccurredOutsideWebview_And_UITakeoverFalse_ThenMessageDismissed() {
         // setup
-        mockAEPMessage.webView = mockWebView;
         messageFragment.webViewGestureListener = mockWebViewGestureListener;
         messageFragment.gestureDetector = mockGestureDetector;
         Mockito.when(mockAEPMessageSettings.getUITakeover()).thenReturn(false);
         Mockito.when(mockWebView.getId()).thenReturn(12345);
         Mockito.when(mockViewGroup.getId()).thenReturn(67890);
+        Mockito.when(mockAEPMessage.getWebView()).thenReturn(mockWebView);
         // call onCreate to setup the gestures
         messageFragment.onCreate(mockSavedInstanceState);
         // test
@@ -205,12 +205,12 @@ public class MessageFragmentTests {
     public void
             testOnTouchListener_TouchOccurredOutsideWebview_And_UITakeoverTrue_ThenMessageNotDismissed() {
         // setup
-        mockAEPMessage.webView = mockWebView;
         messageFragment.webViewGestureListener = mockWebViewGestureListener;
         messageFragment.gestureDetector = mockGestureDetector;
         Mockito.when(mockAEPMessageSettings.getUITakeover()).thenReturn(true);
         Mockito.when(mockWebView.getId()).thenReturn(12345);
         Mockito.when(mockViewGroup.getId()).thenReturn(67890);
+        Mockito.when(mockAEPMessage.getWebView()).thenReturn(mockWebView);
         // call onCreate to setup the gestures
         messageFragment.onCreate(mockSavedInstanceState);
         // test

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/MessageWebViewRunnerTests.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/MessageWebViewRunnerTests.java
@@ -103,7 +103,7 @@ public class MessageWebViewRunnerTests {
         mockMessageWebViewRunner.webViewFrame = mockCardView;
         mockAEPMessage.messageWebViewRunner = mockMessageWebViewRunner;
         when(mockWebview.getSettings()).thenReturn(mockWebSettings);
-        mockAEPMessage.webView = mockWebview;
+        when(mockAEPMessage.getWebView()).thenReturn(mockWebview);
     }
 
     @Test

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/MessageWebViewRunnerTests.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/MessageWebViewRunnerTests.java
@@ -11,7 +11,6 @@
 
 package com.adobe.marketing.mobile.services.ui;
 
-import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.when;
 
@@ -48,6 +47,8 @@ public class MessageWebViewRunnerTests {
 
     @Mock private MessageWebViewRunner mockMessageWebViewRunner;
 
+    @Mock private WebView mockWebview;
+
     @Mock private CardView mockCardView;
 
     @Mock private FrameLayout mockFrameLayout;
@@ -66,7 +67,6 @@ public class MessageWebViewRunnerTests {
     private MessageSettings aepMessageSettings;
 
     private HashMap<MessageGesture, String> gestureMap = new HashMap<>();
-    private WebView mockWebview;
 
     @Before
     public void setup() throws Exception {
@@ -102,20 +102,14 @@ public class MessageWebViewRunnerTests {
         mockAEPMessage.fragmentFrameLayout = mockFrameLayout;
         mockMessageWebViewRunner.webViewFrame = mockCardView;
         mockAEPMessage.messageWebViewRunner = mockMessageWebViewRunner;
-        mockWebview = null;
+        when(mockWebview.getSettings()).thenReturn(mockWebSettings);
+        mockAEPMessage.webView = mockWebview;
     }
 
     @Test
     public void testRunnable_WithValidAEPMessage_ThenMessageShown() {
-        try (MockedConstruction<WebView> constructionMock =
-                        mockConstruction(
-                                WebView.class,
-                                (mock, context) -> {
-                                    when(mock.getSettings()).thenReturn(mockWebSettings);
-                                    mockWebview = mock;
-                                });
-                MockedConstruction<CardView> cardViewMockedConstruction =
-                        mockConstruction(CardView.class)) {
+        try (MockedConstruction<CardView> cardViewMockedConstruction =
+                mockConstruction(CardView.class)) {
             // test
             messageFragmentRunner = new MessageWebViewRunner(mockAEPMessage);
             messageFragmentRunner.run();
@@ -131,15 +125,8 @@ public class MessageWebViewRunnerTests {
     @Test
     public void
             testRunnable_WithValidAEPMessage_And_MessageAnimationStartsFromTop_ThenMessageShown() {
-        try (MockedConstruction<WebView> constructionMock =
-                        mockConstruction(
-                                WebView.class,
-                                (mock, context) -> {
-                                    when(mock.getSettings()).thenReturn(mockWebSettings);
-                                    mockWebview = mock;
-                                });
-                MockedConstruction<CardView> cardViewMockedConstruction =
-                        mockConstruction(CardView.class)) {
+        try (MockedConstruction<CardView> cardViewMockedConstruction =
+                mockConstruction(CardView.class)) {
             // setup
             aepMessageSettings.setDisplayAnimation(MessageAnimation.TOP);
             when(mockAEPMessage.getSettings()).thenReturn(aepMessageSettings);
@@ -158,15 +145,8 @@ public class MessageWebViewRunnerTests {
     @Test
     public void
             testRunnable_WithValidAEPMessage_And_MessageAnimationStartsFromLeft_ThenMessageShown() {
-        try (MockedConstruction<WebView> constructionMock =
-                        mockConstruction(
-                                WebView.class,
-                                (mock, context) -> {
-                                    when(mock.getSettings()).thenReturn(mockWebSettings);
-                                    mockWebview = mock;
-                                });
-                MockedConstruction<CardView> cardViewMockedConstruction =
-                        mockConstruction(CardView.class)) {
+        try (MockedConstruction<CardView> cardViewMockedConstruction =
+                mockConstruction(CardView.class)) {
             // setup
             aepMessageSettings.setDisplayAnimation(MessageAnimation.LEFT);
             when(mockAEPMessage.getSettings()).thenReturn(aepMessageSettings);
@@ -185,15 +165,8 @@ public class MessageWebViewRunnerTests {
     @Test
     public void
             testRunnable_WithValidAEPMessage_And_MessageAnimationStartsFromRight_ThenMessageShown() {
-        try (MockedConstruction<WebView> constructionMock =
-                        mockConstruction(
-                                WebView.class,
-                                (mock, context) -> {
-                                    when(mock.getSettings()).thenReturn(mockWebSettings);
-                                    mockWebview = mock;
-                                });
-                MockedConstruction<CardView> cardViewMockedConstruction =
-                        mockConstruction(CardView.class)) {
+        try (MockedConstruction<CardView> cardViewMockedConstruction =
+                mockConstruction(CardView.class)) {
             // setup
             aepMessageSettings.setDisplayAnimation(MessageAnimation.RIGHT);
             when(mockAEPMessage.getSettings()).thenReturn(aepMessageSettings);
@@ -212,15 +185,8 @@ public class MessageWebViewRunnerTests {
     @Test
     public void
             testRunnable_WithValidAEPMessage_And_MessageAnimationStartsFromBottom_ThenMessageShown() {
-        try (MockedConstruction<WebView> constructionMock =
-                        mockConstruction(
-                                WebView.class,
-                                (mock, context) -> {
-                                    when(mock.getSettings()).thenReturn(mockWebSettings);
-                                    mockWebview = mock;
-                                });
-                MockedConstruction<CardView> cardViewMockedConstruction =
-                        mockConstruction(CardView.class)) {
+        try (MockedConstruction<CardView> cardViewMockedConstruction =
+                mockConstruction(CardView.class)) {
             // setup
             aepMessageSettings.setDisplayAnimation(MessageAnimation.BOTTOM);
             when(mockAEPMessage.getSettings()).thenReturn(aepMessageSettings);
@@ -238,15 +204,8 @@ public class MessageWebViewRunnerTests {
 
     @Test
     public void testRunnable_WithValidAEPMessage_And_MessageAnimationFadesIn_ThenMessageShown() {
-        try (MockedConstruction<WebView> constructionMock =
-                        mockConstruction(
-                                WebView.class,
-                                (mock, context) -> {
-                                    when(mock.getSettings()).thenReturn(mockWebSettings);
-                                    mockWebview = mock;
-                                });
-                MockedConstruction<CardView> cardViewMockedConstruction =
-                        mockConstruction(CardView.class)) {
+        try (MockedConstruction<CardView> cardViewMockedConstruction =
+                mockConstruction(CardView.class)) {
             // setup
             aepMessageSettings.setDisplayAnimation(MessageAnimation.FADE);
             when(mockAEPMessage.getSettings()).thenReturn(aepMessageSettings);
@@ -264,15 +223,8 @@ public class MessageWebViewRunnerTests {
 
     @Test
     public void testRunnable_WithValidAEPMessage_And_NoMessageAnimation_ThenMessageShown() {
-        try (MockedConstruction<WebView> constructionMock =
-                        mockConstruction(
-                                WebView.class,
-                                (mock, context) -> {
-                                    when(mock.getSettings()).thenReturn(mockWebSettings);
-                                    mockWebview = mock;
-                                });
-                MockedConstruction<CardView> cardViewMockedConstruction =
-                        mockConstruction(CardView.class)) {
+        try (MockedConstruction<CardView> cardViewMockedConstruction =
+                mockConstruction(CardView.class)) {
             // setup
             aepMessageSettings.setDisplayAnimation(MessageAnimation.NONE);
             when(mockAEPMessage.getSettings()).thenReturn(aepMessageSettings);
@@ -290,15 +242,8 @@ public class MessageWebViewRunnerTests {
 
     @Test
     public void testRunnable_WithValidAEPMessage_And_NonFullscreenMessage_ThenMessageShown() {
-        try (MockedConstruction<WebView> constructionMock =
-                        mockConstruction(
-                                WebView.class,
-                                (mock, context) -> {
-                                    when(mock.getSettings()).thenReturn(mockWebSettings);
-                                    mockWebview = mock;
-                                });
-                MockedConstruction<CardView> cardViewMockedConstruction =
-                        mockConstruction(CardView.class)) {
+        try (MockedConstruction<CardView> cardViewMockedConstruction =
+                mockConstruction(CardView.class)) {
             // setup
             aepMessageSettings.setHeight(50);
             when(mockAEPMessage.getSettings()).thenReturn(aepMessageSettings);
@@ -316,15 +261,8 @@ public class MessageWebViewRunnerTests {
 
     @Test
     public void testRunnable_WithValidAEPMessage_And_MessageHorizontalAlignLeftThenMessageShown() {
-        try (MockedConstruction<WebView> constructionMock =
-                        mockConstruction(
-                                WebView.class,
-                                (mock, context) -> {
-                                    when(mock.getSettings()).thenReturn(mockWebSettings);
-                                    mockWebview = mock;
-                                });
-                MockedConstruction<CardView> cardViewMockedConstruction =
-                        mockConstruction(CardView.class)) {
+        try (MockedConstruction<CardView> cardViewMockedConstruction =
+                mockConstruction(CardView.class)) {
             // setup
             aepMessageSettings.setHorizontalAlign(MessageAlignment.LEFT);
             when(mockAEPMessage.getSettings()).thenReturn(aepMessageSettings);
@@ -342,15 +280,8 @@ public class MessageWebViewRunnerTests {
 
     @Test
     public void testRunnable_WithValidAEPMessage_And_MessageHorizontalAlignRightThenMessageShown() {
-        try (MockedConstruction<WebView> constructionMock =
-                        mockConstruction(
-                                WebView.class,
-                                (mock, context) -> {
-                                    when(mock.getSettings()).thenReturn(mockWebSettings);
-                                    mockWebview = mock;
-                                });
-                MockedConstruction<CardView> cardViewMockedConstruction =
-                        mockConstruction(CardView.class)) {
+        try (MockedConstruction<CardView> cardViewMockedConstruction =
+                mockConstruction(CardView.class)) {
             // setup
             aepMessageSettings.setHorizontalAlign(MessageAlignment.RIGHT);
             when(mockAEPMessage.getSettings()).thenReturn(aepMessageSettings);
@@ -368,15 +299,8 @@ public class MessageWebViewRunnerTests {
 
     @Test
     public void testRunnable_WithValidAEPMessage_And_MessageVerticalAlignBottomThenMessageShown() {
-        try (MockedConstruction<WebView> constructionMock =
-                        mockConstruction(
-                                WebView.class,
-                                (mock, context) -> {
-                                    when(mock.getSettings()).thenReturn(mockWebSettings);
-                                    mockWebview = mock;
-                                });
-                MockedConstruction<CardView> cardViewMockedConstruction =
-                        mockConstruction(CardView.class)) {
+        try (MockedConstruction<CardView> cardViewMockedConstruction =
+                mockConstruction(CardView.class)) {
             // setup
             aepMessageSettings.setVerticalAlign(MessageAlignment.BOTTOM);
             when(mockAEPMessage.getSettings()).thenReturn(aepMessageSettings);
@@ -394,15 +318,8 @@ public class MessageWebViewRunnerTests {
 
     @Test
     public void testRunnable_WithValidAEPMessage_And_MessageVerticalAlignCenterThenMessageShown() {
-        try (MockedConstruction<WebView> constructionMock =
-                        mockConstruction(
-                                WebView.class,
-                                (mock, context) -> {
-                                    when(mock.getSettings()).thenReturn(mockWebSettings);
-                                    mockWebview = mock;
-                                });
-                MockedConstruction<CardView> cardViewMockedConstruction =
-                        mockConstruction(CardView.class)) {
+        try (MockedConstruction<CardView> cardViewMockedConstruction =
+                mockConstruction(CardView.class)) {
             // setup
             aepMessageSettings.setVerticalAlign(MessageAlignment.CENTER);
             when(mockAEPMessage.getSettings()).thenReturn(aepMessageSettings);
@@ -420,15 +337,8 @@ public class MessageWebViewRunnerTests {
 
     @Test
     public void testRunnable_WithValidAEPMessage_And_BuildVersionLessThanAPI17_ThenMessageShown() {
-        try (MockedConstruction<WebView> constructionMock =
-                        mockConstruction(
-                                WebView.class,
-                                (mock, context) -> {
-                                    when(mock.getSettings()).thenReturn(mockWebSettings);
-                                    mockWebview = mock;
-                                });
-                MockedConstruction<CardView> cardViewMockedConstruction =
-                        mockConstruction(CardView.class)) {
+        try (MockedConstruction<CardView> cardViewMockedConstruction =
+                mockConstruction(CardView.class)) {
             // setup
             messageFragmentRunner = new MessageWebViewRunner(mockAEPMessage);
             // test
@@ -444,22 +354,14 @@ public class MessageWebViewRunnerTests {
 
     @Test
     public void testRunnable_WithValidAEPMessage_And_NullRootViewGroup_ThenMessageNotShown() {
-        try (MockedConstruction<WebView> constructionMock =
-                        mockConstruction(
-                                WebView.class,
-                                (mock, context) -> {
-                                    when(mock.getSettings()).thenReturn(mockWebSettings);
-                                    mockWebview = mock;
-                                });
-                MockedConstruction<CardView> cardViewMockedConstruction =
-                        mockConstruction(CardView.class)) {
+        try (MockedConstruction<CardView> cardViewMockedConstruction =
+                mockConstruction(CardView.class)) {
             // setup
             mockAEPMessage.rootViewGroup = null;
             messageFragmentRunner = new MessageWebViewRunner(mockAEPMessage);
             // test
             messageFragmentRunner.run();
             // verify
-            assertNull(mockWebview);
             Mockito.verify(mockViewGroup, Mockito.times(0)).setOnTouchListener(mockMessageFragment);
             Mockito.verify(mockAEPMessage, Mockito.times(0)).isMessageVisible();
             Mockito.verify(mockAEPMessage, Mockito.times(1)).cleanup();
@@ -469,22 +371,14 @@ public class MessageWebViewRunnerTests {
     @Test
     public void
             testRunnable_WithValidAEPMessage_And_RootviewHasWidthEqualToZero_ThenMessageNotShown() {
-        try (MockedConstruction<WebView> constructionMock =
-                        mockConstruction(
-                                WebView.class,
-                                (mock, context) -> {
-                                    when(mock.getSettings()).thenReturn(mockWebSettings);
-                                    mockWebview = mock;
-                                });
-                MockedConstruction<CardView> cardViewMockedConstruction =
-                        mockConstruction(CardView.class)) {
+        try (MockedConstruction<CardView> cardViewMockedConstruction =
+                mockConstruction(CardView.class)) {
             // setup
             when(mockViewGroup.getWidth()).thenReturn(0);
             messageFragmentRunner = new MessageWebViewRunner(mockAEPMessage);
             // test
             messageFragmentRunner.run();
             // verify
-            assertNull(mockWebview);
             Mockito.verify(mockViewGroup, Mockito.times(0)).setOnTouchListener(mockMessageFragment);
             Mockito.verify(mockAEPMessage, Mockito.times(0)).isMessageVisible();
             Mockito.verify(mockAEPMessage, Mockito.times(1)).cleanup();
@@ -494,22 +388,14 @@ public class MessageWebViewRunnerTests {
     @Test
     public void
             testRunnable_WithValidAEPMessage_And_RootviewHasHeightEqualToZero_ThenMessageNotShown() {
-        try (MockedConstruction<WebView> constructionMock =
-                        mockConstruction(
-                                WebView.class,
-                                (mock, context) -> {
-                                    when(mock.getSettings()).thenReturn(mockWebSettings);
-                                    mockWebview = mock;
-                                });
-                MockedConstruction<CardView> cardViewMockedConstruction =
-                        mockConstruction(CardView.class)) {
+        try (MockedConstruction<CardView> cardViewMockedConstruction =
+                mockConstruction(CardView.class)) {
             // setup
             when(mockViewGroup.getHeight()).thenReturn(0);
             messageFragmentRunner = new MessageWebViewRunner(mockAEPMessage);
             // test
             messageFragmentRunner.run();
             // verify
-            assertNull(mockWebview);
             Mockito.verify(mockViewGroup, Mockito.times(0)).setOnTouchListener(mockMessageFragment);
             Mockito.verify(mockAEPMessage, Mockito.times(0)).isMessageVisible();
             Mockito.verify(mockAEPMessage, Mockito.times(1)).cleanup();
@@ -518,22 +404,14 @@ public class MessageWebViewRunnerTests {
 
     @Test
     public void testRunnable_WithInvalidAEPMessage_ThenMessageNotShown() {
-        try (MockedConstruction<WebView> constructionMock =
-                        mockConstruction(
-                                WebView.class,
-                                (mock, context) -> {
-                                    when(mock.getSettings()).thenReturn(mockWebSettings);
-                                    mockWebview = mock;
-                                });
-                MockedConstruction<CardView> cardViewMockedConstruction =
-                        mockConstruction(CardView.class)) {
+        try (MockedConstruction<CardView> cardViewMockedConstruction =
+                mockConstruction(CardView.class)) {
             // setup
             when(mockAEPMessage.getMessageHtml()).thenReturn(null);
             messageFragmentRunner = new MessageWebViewRunner(mockAEPMessage);
             // test
             messageFragmentRunner.run();
             // verify
-            assertNull(mockWebview);
             Mockito.verify(mockViewGroup, Mockito.times(0)).setOnTouchListener(mockMessageFragment);
             Mockito.verify(mockAEPMessage, Mockito.times(0)).isMessageVisible();
             Mockito.verify(mockAEPMessage, Mockito.times(1)).cleanup();

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/WebViewGestureListenerTests.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/WebViewGestureListenerTests.java
@@ -74,7 +74,7 @@ public class WebViewGestureListenerTests {
         listener.setAccessible(true);
         listener.set(mockAEPMessage, mockFullscreenMessageDelegate);
 
-        mockAEPMessage.webView = mockWebView;
+        mockAEPMessage.setWebView(mockWebView);
         mockMessageWebViewRunner.webViewFrame = mockCardView;
         mockAEPMessage.messageWebViewRunner = mockMessageWebViewRunner;
         mockAEPMessage.baseRootViewHeight = 3000;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
Create the WebView object prior to passing the AEPMessage object to the MessagingDelegate. This allows the WebView to be available before the MessagingDelegate.shouldShowMessage function gets called. This matches the behavior on the iOS side and allows javascript code present in the in-app html to access javascript handlers set on the WebView.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
