### PR TITLE
Skip unsupported types during Event data cloning

### DIFF
--- a/code/core/src/androidTest/java/com/adobe/marketing/mobile/EventCoderTests.java
+++ b/code/core/src/androidTest/java/com/adobe/marketing/mobile/EventCoderTests.java
@@ -12,6 +12,7 @@
 package com.adobe.marketing.mobile;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
 
@@ -203,8 +204,10 @@ public class EventCoderTests {
                         .build();
 
         Event decodedEvent = EventCoder.decode(EventCoder.encode(event));
-        assertNull(event.getEventData());
-        assertNull(decodedEvent.getEventData());
+        assertNotNull(event.getEventData());
+        assertTrue(event.getEventData().isEmpty());
+        assertNotNull(decodedEvent.getEventData());
+        assertTrue(decodedEvent.getEventData().isEmpty());
     }
 
     @Test

--- a/code/core/src/main/java/com/adobe/marketing/mobile/util/CloneFailedException.java
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/util/CloneFailedException.java
@@ -11,11 +11,22 @@
 
 package com.adobe.marketing.mobile.util;
 
+import androidx.annotation.NonNull;
+
 /**
  * Exception thrown by {@link EventDataUtils} to indicate that an exception occurred during deep
  * clone.
  */
 public class CloneFailedException extends Exception {
+
+    private final Reason reason;
+
+    /** Enum to indicate the reason for the exception. */
+    enum Reason {
+        MAX_DEPTH_REACHED,
+        UNSUPPORTED_TYPE,
+        UNKNOWN
+    }
 
     /**
      * Constructor.
@@ -23,6 +34,35 @@ public class CloneFailedException extends Exception {
      * @param message {@code String} message for the exception
      */
     public CloneFailedException(final String message) {
+        this(message, Reason.UNKNOWN);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param reason the {@link Reason} for the exception
+     */
+    public CloneFailedException(@NonNull final Reason reason) {
+        this(reason.toString(), reason);
+    }
+
+    /**
+     * Private constructor to unify public constructors and allow cascading.
+     *
+     * @param message {@code String} message for the exception
+     * @param reason the {@link Reason} for the exception
+     */
+    private CloneFailedException(@NonNull final String message, @NonNull final Reason reason) {
         super(message);
+        this.reason = reason;
+    }
+
+    /**
+     * Returns the {@link Reason} for the exception.
+     *
+     * @return rteturns the {@link Reason} for the exception
+     */
+    @NonNull public Reason getReason() {
+        return reason;
     }
 }

--- a/code/core/src/test/java/com/adobe/marketing/mobile/internal/eventhub/EventHubTests.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/internal/eventhub/EventHubTests.kt
@@ -1060,7 +1060,9 @@ internal class EventHubTests {
             )
         }
 
-        verifySharedState(SharedStateType.STANDARD, event1, SharedStateResult(SharedStateStatus.SET, null))
+        // Verify that the state does not contain custom object
+        val expectedSharedState: Map<String, Any?> = mutableMapOf("One" to 1)
+        verifySharedState(SharedStateType.STANDARD, event1, SharedStateResult(SharedStateStatus.SET, expectedSharedState))
     }
 
     @Test
@@ -1352,7 +1354,9 @@ internal class EventHubTests {
 
         resolver?.resolve(stateAtEvent1)
 
-        verifySharedState(SharedStateType.STANDARD, event1, SharedStateResult(SharedStateStatus.SET, null))
+        // Verify that the state does not contain custom object
+        val expectedSharedState: Map<String, Any?> = mutableMapOf("One" to 1)
+        verifySharedState(SharedStateType.STANDARD, event1, SharedStateResult(SharedStateStatus.SET, expectedSharedState))
     }
 
     @Test

--- a/code/core/src/test/java/com/adobe/marketing/mobile/util/CloneFailedExceptionTest.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/util/CloneFailedExceptionTest.java
@@ -1,0 +1,42 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.util;
+
+import static org.junit.Assert.assertEquals;
+
+public class CloneFailedExceptionTest {
+
+    void testConstructorWithStringMessage() {
+        final CloneFailedException cloneFailedException = new CloneFailedException("Message");
+        assertEquals("Message", cloneFailedException.getMessage());
+        assertEquals(CloneFailedException.Reason.UNKNOWN, cloneFailedException.getReason());
+    }
+
+    void testConstructorWithReason() {
+        final CloneFailedException cloneFailedMaxDepth =
+                new CloneFailedException(CloneFailedException.Reason.MAX_DEPTH_REACHED);
+        assertEquals(
+                CloneFailedException.Reason.MAX_DEPTH_REACHED.toString(),
+                cloneFailedMaxDepth.getMessage());
+        assertEquals(
+                CloneFailedException.Reason.MAX_DEPTH_REACHED, cloneFailedMaxDepth.getReason());
+
+        final CloneFailedException cloneFailedUnsupportedType =
+                new CloneFailedException(CloneFailedException.Reason.UNSUPPORTED_TYPE);
+        assertEquals(
+                CloneFailedException.Reason.UNSUPPORTED_TYPE.toString(),
+                cloneFailedUnsupportedType.getMessage());
+        assertEquals(
+                CloneFailedException.Reason.UNSUPPORTED_TYPE,
+                cloneFailedUnsupportedType.getReason());
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently when event data is set and unsupported types are encountered the entire event data is set to be empty.

There are some cases where we automatically collect data from activity launches and it is not always the case that the intent has supported types. One such case is being seen with deep links collected during target previews where the event data is being relied upon to show a preview.

**Resolution:**
Skip unsupported types during Event data cloning that is internally used for capturing event data.
This has the following effect on the current behavior:
- Events were previously set with custom data will change from null to empty map/partially populated maps with supported data. 
- Consequently shared states that were set with custom data types will change from null to empty map/partially populated maps with supported data.

Both of these effects are non destructive in terms of how data is being handled currently.

<!--- Describe your changes in detail -->

## Related Issue
MOB-18911 , https://github.com/adobe/aepsdk-core-android/issues/395
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Unit tests, integration tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
