### PR TITLE
Report lifecycle shared state timestamps in milliseconds

### DIFF
--- a/code/lifecycle/src/androidTest/java/com/adobe/marketing/mobile/lifecycle/LifecycleFunctionalTest.java
+++ b/code/lifecycle/src/androidTest/java/com/adobe/marketing/mobile/lifecycle/LifecycleFunctionalTest.java
@@ -209,7 +209,7 @@ public class LifecycleFunctionalTest {
                         put(MAX_SESSION_LENGTH, MAX_SESSION_LENGTH_SECONDS);
                         put(
                                 SESSION_START_TIMESTAMP,
-                                TimeUnit.MILLISECONDS.toSeconds(currentTimestampMillis));
+                                roundedToNearestSecond(currentTimestampMillis));
                         put(SESSION_EVENT, LIFECYCLE_START);
                         put(LIFECYCLE_CONTEXT_DATA, expectedContextData);
                     }
@@ -220,7 +220,7 @@ public class LifecycleFunctionalTest {
                         put(MAX_SESSION_LENGTH, MAX_SESSION_LENGTH_SECONDS);
                         put(
                                 SESSION_START_TIMESTAMP,
-                                TimeUnit.MILLISECONDS.toSeconds(currentTimestampMillis));
+                                roundedToNearestSecond(currentTimestampMillis));
                         put(LIFECYCLE_CONTEXT_DATA, expectedContextData);
                     }
                 };
@@ -287,14 +287,14 @@ public class LifecycleFunctionalTest {
         Map<String, Object> firstSessionStartSharedState =
                 mockExtensionApi.createdSharedState.get(0);
         assertEquals(
-                TimeUnit.MILLISECONDS.toSeconds(firstSessionStartTimeMillis),
+                roundedToNearestSecond(firstSessionStartTimeMillis),
                 firstSessionStartSharedState.get(SESSION_START_TIMESTAMP));
 
         Map<String, Object> secondSessionStartSharedState =
                 mockExtensionApi.createdSharedState.get(1);
         // Adjusted start time =  previous start time + new start time - previous pause time
         assertEquals(
-                TimeUnit.MILLISECONDS.toSeconds(
+                roundedToNearestSecond(
                         firstSessionStartTimeMillis
                                 + secondSessionStartTimeMillis
                                 - firstSessionPauseTimeMillis),
@@ -410,14 +410,14 @@ public class LifecycleFunctionalTest {
                     {
                         put(
                                 PREVIOUS_SESSION_START_TIMESTAMP,
-                                TimeUnit.MILLISECONDS.toSeconds(firstSessionStartTimeMillis));
+                                roundedToNearestSecond(firstSessionStartTimeMillis));
                         put(
                                 PREVIOUS_SESSION_PAUSE_TIMESTAMP,
-                                TimeUnit.MILLISECONDS.toSeconds(firstSessionPauseTimeMillis));
+                                roundedToNearestSecond(firstSessionPauseTimeMillis));
                         put(MAX_SESSION_LENGTH, MAX_SESSION_LENGTH_SECONDS);
                         put(
                                 SESSION_START_TIMESTAMP,
-                                TimeUnit.MILLISECONDS.toSeconds(secondSessionStartTimeMillis));
+                                roundedToNearestSecond(secondSessionStartTimeMillis));
                         put(SESSION_EVENT, LIFECYCLE_START);
                         put(LIFECYCLE_CONTEXT_DATA, expectedContextData);
                     }
@@ -429,7 +429,7 @@ public class LifecycleFunctionalTest {
                         put(MAX_SESSION_LENGTH, MAX_SESSION_LENGTH_SECONDS);
                         put(
                                 SESSION_START_TIMESTAMP,
-                                TimeUnit.MILLISECONDS.toSeconds(secondSessionStartTimeMillis));
+                                roundedToNearestSecond(secondSessionStartTimeMillis));
                         put(LIFECYCLE_CONTEXT_DATA, expectedContextData);
                     }
                 };
@@ -577,14 +577,14 @@ public class LifecycleFunctionalTest {
                     {
                         put(
                                 PREVIOUS_SESSION_START_TIMESTAMP,
-                                TimeUnit.MILLISECONDS.toSeconds(firstSessionStartTimeMillis));
+                                roundedToNearestSecond(firstSessionStartTimeMillis));
                         put(
                                 PREVIOUS_SESSION_PAUSE_TIMESTAMP,
-                                TimeUnit.MILLISECONDS.toSeconds(firstSessionPauseTimeMillis));
+                                roundedToNearestSecond(firstSessionPauseTimeMillis));
                         put(MAX_SESSION_LENGTH, MAX_SESSION_LENGTH_SECONDS);
                         put(
                                 SESSION_START_TIMESTAMP,
-                                TimeUnit.MILLISECONDS.toSeconds(secondSessionStartTimeMillis));
+                                roundedToNearestSecond(secondSessionStartTimeMillis));
                         put(SESSION_EVENT, LIFECYCLE_START);
                         put(LIFECYCLE_CONTEXT_DATA, expectedContextData);
                     }
@@ -595,7 +595,7 @@ public class LifecycleFunctionalTest {
                         put(MAX_SESSION_LENGTH, MAX_SESSION_LENGTH_SECONDS);
                         put(
                                 SESSION_START_TIMESTAMP,
-                                TimeUnit.MILLISECONDS.toSeconds(secondSessionStartTimeMillis));
+                                roundedToNearestSecond(secondSessionStartTimeMillis));
                         put(LIFECYCLE_CONTEXT_DATA, expectedContextData);
                     }
                 };
@@ -811,5 +811,9 @@ public class LifecycleFunctionalTest {
                 (Map<String, String>)
                         mockExtensionApi2.createdSharedState.get(1).get(LIFECYCLE_CONTEXT_DATA);
         assertEquals(expectedContextData, secondSessionStartResponseEventContextData);
+    }
+
+    private long roundedToNearestSecond(long timestampMills) {
+        return TimeUnit.MILLISECONDS.toSeconds(timestampMills) * 1000;
     }
 }

--- a/code/lifecycle/src/phone/java/com/adobe/marketing/mobile/Lifecycle.java
+++ b/code/lifecycle/src/phone/java/com/adobe/marketing/mobile/Lifecycle.java
@@ -13,6 +13,7 @@ package com.adobe.marketing.mobile;
 
 import com.adobe.marketing.mobile.lifecycle.LifecycleExtension;
 import com.adobe.marketing.mobile.services.Log;
+import java.util.List;
 
 public class Lifecycle {
 

--- a/code/lifecycle/src/test/java/com/adobe/marketing/mobile/lifecycle/LifecycleV1ExtensionTest.java
+++ b/code/lifecycle/src/test/java/com/adobe/marketing/mobile/lifecycle/LifecycleV1ExtensionTest.java
@@ -170,7 +170,7 @@ public class LifecycleV1ExtensionTest {
                     .createSharedState(
                             lifecycleSharedState.capture(), lifecycleStartEventCaptor.capture());
             assertEquals(lifecycleStartEvent, lifecycleStartEventCaptor.getValue());
-            assertEquals(1234L, lifecycleSharedState.getValue().get(SESSION_START_TIMESTAMP));
+            assertEquals(1234000L, lifecycleSharedState.getValue().get(SESSION_START_TIMESTAMP));
             assertEquals(
                     MAX_SESSION_LENGTH_SECONDS,
                     lifecycleSharedState.getValue().get(MAX_SESSION_LENGTH));
@@ -222,7 +222,7 @@ public class LifecycleV1ExtensionTest {
                             lifecycleSharedState.capture(), lifecycleStartEventCaptor.capture());
             assertEquals(lifecycleStartEvent, lifecycleStartEventCaptor.getValue());
             assertEquals(
-                    TimeUnit.MILLISECONDS.toSeconds(currentTimestampInMilliSeconds),
+                    roundedToNearestSecond(currentTimestampInMilliSeconds),
                     lifecycleSharedState.getValue().get(SESSION_START_TIMESTAMP));
             assertEquals(
                     MAX_SESSION_LENGTH_SECONDS,
@@ -236,12 +236,12 @@ public class LifecycleV1ExtensionTest {
             assertEquals(contextData, lifecycleResponseEventData.get(LIFECYCLE_CONTEXT_DATA));
             assertEquals(LIFECYCLE_START, lifecycleResponseEventData.get(SESSION_EVENT));
             assertEquals(
-                    TimeUnit.MILLISECONDS.toSeconds(currentTimestampInMilliSeconds),
+                    roundedToNearestSecond(currentTimestampInMilliSeconds),
                     lifecycleResponseEventData.get(SESSION_START_TIMESTAMP));
             assertEquals(
                     MAX_SESSION_LENGTH_SECONDS, lifecycleResponseEventData.get(MAX_SESSION_LENGTH));
-            assertEquals(111L, lifecycleResponseEventData.get(PREVIOUS_SESSION_START_TIMESTAMP));
-            assertEquals(222L, lifecycleResponseEventData.get(PREVIOUS_SESSION_PAUSE_TIMESTAMP));
+            assertEquals(111000L, lifecycleResponseEventData.get(PREVIOUS_SESSION_START_TIMESTAMP));
+            assertEquals(222000L, lifecycleResponseEventData.get(PREVIOUS_SESSION_PAUSE_TIMESTAMP));
             assertEquals(
                     lifecycleStartEvent.getUniqueIdentifier(),
                     lifecycleResponseEvent.getValue().getParentID());
@@ -448,5 +448,9 @@ public class LifecycleV1ExtensionTest {
                     lifecycleSharedState.getValue().get(MAX_SESSION_LENGTH));
             assertEquals(bootData, lifecycleSharedState.getValue().get(LIFECYCLE_CONTEXT_DATA));
         }
+    }
+
+    private long roundedToNearestSecond(long timestampMills) {
+        return TimeUnit.MILLISECONDS.toSeconds(timestampMills) * 1000;
     }
 }


### PR DESCRIPTION
https://github.com/adobe/aepsdk-core-android/issues/474

Updated Lifecycle extension to share the following timestamps in milliseconds
- `previoussessionpausetimestampmillis`
- `previoussessionstarttimestampmillis`
- `starttimestampmillis`

Lifecycle extension still persists all the timestamps in seconds and only converts it milliseconds when dispatching events. Updating these timestamps in persistence will require a significant change, as it involves migrating existing data.

At present, we do not make use of the values from `previoussessionpausetimestampmillis` and `previoussessionstarttimestampmillis`. Additionally, the `starttimestampmillis` is utilized by analytics to calculate the timeSinceLaunch metric. However, with the deprecation of mobile services, we should also consider removing the usage of timeSinceLaunch from Analytics.