### PR TITLE
In-app fixes from #480

### DIFF
--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageFragment.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageFragment.java
@@ -17,7 +17,9 @@ import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
 import android.os.Bundle;
+import android.util.TypedValue;
 import android.view.GestureDetector;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -379,6 +381,16 @@ public class MessageFragment extends android.app.DialogFragment implements View.
                     UNEXPECTED_NULL_VALUE);
             return;
         }
+
+        // use a gradient drawable to set the rounded corners on the message
+        final GradientDrawable roundedDrawable = new GradientDrawable();
+        final float calculatedRadius =
+                TypedValue.applyDimension(
+                        TypedValue.COMPLEX_UNIT_DIP,
+                        message.getMessageSettings().getCornerRadius(),
+                        dialog.getContext().getResources().getDisplayMetrics());
+        roundedDrawable.setCornerRadius(calculatedRadius);
+        webViewFrame.setBackground(roundedDrawable);
 
         dialog.setContentView(webViewFrame, params);
         webViewFrame.setOnTouchListener(this);

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageWebViewUtil.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageWebViewUtil.java
@@ -13,7 +13,6 @@ package com.adobe.marketing.mobile.services.ui;
 
 import android.content.Context;
 import android.graphics.Color;
-import android.util.TypedValue;
 import android.view.ViewGroup;
 import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
@@ -114,16 +113,10 @@ class MessageWebViewUtil {
                     StandardCharsets.UTF_8.name(),
                     null);
 
-            // use CardView to apply rounded corners
+            // use CardView so rounded corners can be applied
             final CardView webViewFrame = new CardView(context);
-            final float calculatedRadius =
-                    TypedValue.applyDimension(
-                            TypedValue.COMPLEX_UNIT_DIP,
-                            settings.getCornerRadius(),
-                            context.getResources().getDisplayMetrics());
-            webViewFrame.setRadius(calculatedRadius);
 
-            // set a display animation for the ewbview
+            // set a display animation for the webview
             final Animation animation = setupDisplayAnimation(message, webView);
             if (animation == null) {
                 Log.debug(


### PR DESCRIPTION
This is a replica of #480 with some modifications
to increase chances of showing a message.

- Handle FragmentManager exceptions gracefully.
- Fix corner rounding for AEPMessages. When the switch to DialogFragment was made, using a CardView alone was no longer sufficient to set rounded corners on the CardView. Use GradientDrawable in conjunction with CardView to set the rounded corners.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
