### PR TITLE
staging -> main (Core 2.2.2)

### DIFF
--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/CoreConstants.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/CoreConstants.kt
@@ -13,7 +13,7 @@ package com.adobe.marketing.mobile.internal
 
 internal object CoreConstants {
     const val LOG_TAG = "MobileCore"
-    const val VERSION = "2.2.1"
+    const val VERSION = "2.2.2"
 
     object EventDataKeys {
         /**

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageFragment.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageFragment.java
@@ -122,7 +122,10 @@ public class MessageFragment extends android.app.DialogFragment implements View.
             return;
         }
 
-        message.viewed();
+        Log.trace(
+                ServiceConstants.LOG_TAG,
+                TAG,
+                "Fragment attached to host activity. Notifying MessageMonitor.");
 
         if (messagesMonitor != null) {
             messagesMonitor.displayed();
@@ -167,6 +170,14 @@ public class MessageFragment extends android.app.DialogFragment implements View.
     public void onActivityCreated(final Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         final Dialog dialog = getDialog();
+
+        if (messagesMonitor != null) {
+            Log.trace(
+                    ServiceConstants.LOG_TAG,
+                    TAG,
+                    "Host activity created. Notifying MessageMonitor.");
+            messagesMonitor.displayed();
+        }
 
         if (dialog != null) {
             dialog.setCancelable(false);

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageWebViewUtil.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageWebViewUtil.java
@@ -14,6 +14,7 @@ package com.adobe.marketing.mobile.services.ui;
 import android.content.Context;
 import android.graphics.Color;
 import android.view.ViewGroup;
+import android.view.ViewParent;
 import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
 import android.view.animation.DecelerateInterpolator;
@@ -105,6 +106,13 @@ class MessageWebViewUtil {
 
             // load the in-app message in the webview
             final WebView webView = message.getWebView();
+
+            // If the WebView was a child of another view, remove it from that previous view
+            final ViewParent previousParent = webView.getParent();
+            if (previousParent != null) {
+                Log.debug(ServiceConstants.LOG_TAG, TAG, "Removing from old parent view.");
+                ((ViewGroup) previousParent).removeView(webView);
+            }
 
             webView.loadDataWithBaseURL(
                     BASE_URL,

--- a/code/core/src/test/java/com/adobe/marketing/mobile/MobileCoreTests.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/MobileCoreTests.kt
@@ -35,7 +35,7 @@ import kotlin.test.assertTrue
 @RunWith(MockitoJUnitRunner.Silent::class)
 class MobileCoreTests {
 
-    private var EXTENSION_VERSION = "2.2.1"
+    private var EXTENSION_VERSION = "2.2.2"
 
     @Mock
     private lateinit var mockedEventHub: EventHub

--- a/code/core/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtensionTests.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtensionTests.kt
@@ -59,7 +59,7 @@ import kotlin.test.assertTrue
 @RunWith(MockitoJUnitRunner.Silent::class)
 class ConfigurationExtensionTests {
 
-    private var EXTENSION_VERSION = "2.2.1"
+    private var EXTENSION_VERSION = "2.2.2"
 
     @Mock
     private lateinit var mockServiceProvider: ServiceProvider

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/AEPMessageTests.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/AEPMessageTests.java
@@ -18,6 +18,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
@@ -126,6 +127,16 @@ public class AEPMessageTests {
                         })
                 .when(mockActivity)
                 .runOnUiThread(any(FutureTask.class));
+
+        // Trigger activity.runOnUiThread() immediately
+        doAnswer(
+                        invocation -> {
+                            Runnable r = invocation.getArgument(0);
+                            r.run();
+                            return null;
+                        })
+                .when(mockActivity)
+                .runOnUiThread(any(Runnable.class));
     }
 
     // AEPMessage creation tests
@@ -197,6 +208,10 @@ public class AEPMessageTests {
         Mockito.verify(mockMessageMonitor, Mockito.times(1))
                 .show(any(FullscreenMessage.class), eq(true));
         Mockito.verify(mockMessageMonitor, Mockito.times(1)).displayed();
+
+        // Verify that the message delegates are notified
+        Mockito.verify(mockFullscreenMessageDelegate).onShow(message);
+        Mockito.verify(mockMessagingDelegate).onShow(message);
     }
 
     @Test
@@ -230,6 +245,10 @@ public class AEPMessageTests {
         Mockito.verify(mockMessageMonitor, Mockito.times(1))
                 .show(any(FullscreenMessage.class), eq(true));
         Mockito.verify(mockMessageMonitor, Mockito.times(0)).displayed();
+
+        // Verify that the message delegates are never notified about showing
+        Mockito.verify(mockFullscreenMessageDelegate, never()).onShow(message);
+        Mockito.verify(mockMessagingDelegate, never()).onShow(message);
     }
 
     @Test
@@ -268,6 +287,10 @@ public class AEPMessageTests {
         // verify
         Mockito.verify(mockMessageMonitor, Mockito.times(0)).displayed();
         Mockito.verify(mockFullscreenMessageDelegate, Mockito.times(1)).onShowFailure();
+
+        // Verify that the message delegates are never notified about showing
+        Mockito.verify(mockFullscreenMessageDelegate, never()).onShow(message);
+        Mockito.verify(mockMessagingDelegate, never()).onShow(message);
     }
 
     @Test
@@ -303,6 +326,9 @@ public class AEPMessageTests {
         message.show(false);
         // verify
         Mockito.verify(mockMessageMonitor, Mockito.times(1)).displayed();
+
+        // Verify that the message delegate is notified about showing
+        Mockito.verify(mockFullscreenMessageDelegate).onShow(message);
     }
 
     @Test
@@ -372,11 +398,25 @@ public class AEPMessageTests {
                 .thenReturn(mockActivity)
                 .thenReturn(mockUpdatedActivity);
 
+        // Trigger mockUpdatedActivity.runOnUiThread() immediately
+        doAnswer(
+                        invocation -> {
+                            Runnable r = invocation.getArgument(0);
+                            r.run();
+                            return null;
+                        })
+                .when(mockUpdatedActivity)
+                .runOnUiThread(any(Runnable.class));
+
         // test
         message.show(false);
         // verify
         Mockito.verify(mockUpdatedActivity).runOnUiThread(any());
         Mockito.verify(mockMessageMonitor, Mockito.times(1)).displayed();
+
+        // Verify that the message delegates are never notified about showing
+        Mockito.verify(mockFullscreenMessageDelegate).onShow(message);
+        Mockito.verify(mockMessagingDelegate).onShow(message);
     }
 
     // openUrl tests

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/MessageFragmentTests.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/MessageFragmentTests.java
@@ -110,8 +110,10 @@ public class MessageFragmentTests {
 
         // test
         messageFragment.onAttach(mockContext);
+
         // verify
-        Mockito.verify(mockAEPMessage, Mockito.times(1)).viewed();
+        // verify that should not be called on attach
+        Mockito.verify(mockAEPMessage, Mockito.times(0)).viewed();
         Mockito.verify(mockMessagesMonitor, Mockito.times(1)).displayed();
     }
 

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -6,7 +6,7 @@ android.useAndroidX=true
 #
 #Maven artifacts
 #Core extension
-coreExtensionVersion=2.2.1
+coreExtensionVersion=2.2.2
 coreExtensionName=core
 coreExtensionAARName=core-phone-release.aar
 mavenRepoName=AdobeMobileCoreSdk

--- a/code/sdk-bom/build.gradle
+++ b/code/sdk-bom/build.gradle
@@ -108,8 +108,8 @@ task bom_release_notes() {
         def markdownTable = StringBuilder.newInstance()
         def oldBomVersion = rootProject.bomVersion.toString()
         def newBomVersion = nextBomVersion()
-        markdownTable <<= "| Extension artifact | BOM (${oldBomVersion}) | BOM (${newBomVersion}) | \n"
-        markdownTable <<= "|-----|-----|-----| \n"
+        markdownTable <<= "| Extension artifact | BOM (${oldBomVersion}) | BOM (${newBomVersion}) |\n"
+        markdownTable <<= "|-----|-----|-----|\n"
         def changedExtension = []
         def unchangedExtension = []
         newMap.each { entity ->
@@ -117,18 +117,18 @@ task bom_release_notes() {
             if (oldMap.containsKey(entity.key)) {
                 def oldValue = oldMap.remove(entity.key)
                 if (oldValue == entity.value) {
-                    unchangedExtension.add("| ${extensionName} | ${oldValue} | ${entity.value} | \n")
+                    unchangedExtension.add("| ${extensionName} | ${oldValue} | ${entity.value} |\n")
                 }else{
-                    changedExtension.add("| **${extensionName}** | **${oldValue}** | **${entity.value}**| \n")
+                    changedExtension.add("| **${extensionName}** | **${oldValue}** | **${entity.value}**|\n")
                 }
             }else{
-                markdownTable <<= "| **${extensionName}** |  | **${entity.value}** | \n"
+                markdownTable <<= "| **${extensionName}** |  | **${entity.value}** |\n"
             }
         }
         if(changedExtension.size() >0) {
             markdownTable <<= changedExtension.sort().join()
             markdownTable <<= unchangedExtension.sort().join()
-            oldMap.each{markdownTable <<= "| **com.adobe.marketing.mobile:${it.key}** | **${it.value}** |  | \n"}
+            oldMap.each{markdownTable <<= "| **com.adobe.marketing.mobile:${it.key}** | **${it.value}** |  |\n"}
             println(newMap)
             println("----")
             println(oldMap)


### PR DESCRIPTION
- Fixed an issue in API 22 and below where the in-app message would sometimes take over the screen, rendering the app unresponsive.
- Fixed an issue where the `onShow` method in `FullscreenMessageDelegate` and `MessagingDelegate` was being notified multiple times after displaying an in-app message. 
- Improved the handling of in-app messages during orientation changes.