### PR TITLE
Update Android minSDK and Kotlin version to adopt Jetpack Compose [MOB-18949]

### DIFF
--- a/code/build.gradle
+++ b/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        kotlin_version = '1.4.0'
+        kotlin_version = '1.5.10'
         dokka_version = '1.7.10'
     }
     repositories {
@@ -39,11 +39,11 @@ allprojects {
 }
 
 ext {
-    minSdkVersion = 19
+    minSdkVersion = 21
     targetSdkVersion = 33
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
     kotlinJvmTarget = JavaVersion.VERSION_1_8
-    kotlinLanguageVersion = "1.4"
-    kotlinApiVersion = "1.4"
+    kotlinLanguageVersion = "1.5"
+    kotlinApiVersion = "1.5"
 }

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     ext {
-        kotlin_version = '1.5.10'
+        kotlin_version = '1.5.21'
+        compose_version = '1.0.2'
         dokka_version = '1.7.10'
     }
     repositories {
@@ -14,7 +15,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jacoco:org.jacoco.core:0.8.7"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
         classpath 'org.jetbrains.kotlinx:binary-compatibility-validator:0.11.1'
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:${dokka_version}"        
         classpath 'androidx.benchmark:benchmark-gradle-plugin:1.2.0-alpha06'

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
-        kotlin_version = '1.5.21'
-        compose_version = '1.0.2'
+        kotlin_version = '1.5.31'
+        compose_version = '1.0.5'
         dokka_version = '1.7.10'
     }
     repositories {
@@ -42,6 +42,7 @@ allprojects {
 ext {
     minSdkVersion = 21
     targetSdkVersion = 33
+    compileSdkVersion = 33
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
     kotlinJvmTarget = JavaVersion.VERSION_1_8

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -42,7 +42,6 @@ allprojects {
 ext {
     minSdkVersion = 21
     targetSdkVersion = 33
-    compileSdkVersion = 33
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
     kotlinJvmTarget = JavaVersion.VERSION_1_8

--- a/code/core/api/core.api
+++ b/code/core/api/core.api
@@ -327,6 +327,7 @@ public final class com/adobe/marketing/mobile/WrapperType : java/lang/Enum {
 }
 
 public final class com/adobe/marketing/mobile/launch/rulesengine/LaunchRule : com/adobe/marketing/mobile/rulesengine/Rule {
+	public static final field $stable I
 	public fun <init> (Lcom/adobe/marketing/mobile/rulesengine/Evaluable;Ljava/util/List;)V
 	public final fun component1 ()Lcom/adobe/marketing/mobile/rulesengine/Evaluable;
 	public final fun component2 ()Ljava/util/List;
@@ -351,6 +352,7 @@ public class com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesEngine {
 }
 
 public final class com/adobe/marketing/mobile/launch/rulesengine/RuleConsequence {
+	public static final field $stable I
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
@@ -392,6 +394,7 @@ public class com/adobe/marketing/mobile/launch/rulesengine/download/RulesLoader 
 }
 
 public final class com/adobe/marketing/mobile/launch/rulesengine/json/JSONRulesParser {
+	public static final field $stable I
 	public static final field INSTANCE Lcom/adobe/marketing/mobile/launch/rulesengine/json/JSONRulesParser;
 	public static final fun parse (Ljava/lang/String;Lcom/adobe/marketing/mobile/ExtensionApi;)Ljava/util/List;
 }
@@ -1069,6 +1072,7 @@ public class com/adobe/marketing/mobile/util/SQLiteUtils {
 }
 
 public class com/adobe/marketing/mobile/util/SerialWorkDispatcher {
+	public static final field $stable I
 	public fun <init> (Ljava/lang/String;Lcom/adobe/marketing/mobile/util/SerialWorkDispatcher$WorkHandler;)V
 	protected fun canWork ()Z
 	public final fun getState ()Lcom/adobe/marketing/mobile/util/SerialWorkDispatcher$State;
@@ -1104,6 +1108,7 @@ public final class com/adobe/marketing/mobile/util/StringUtils {
 }
 
 public final class com/adobe/marketing/mobile/util/TimeUtils {
+	public static final field $stable I
 	public static final field INSTANCE Lcom/adobe/marketing/mobile/util/TimeUtils;
 	public static final fun getISO8601Date ()Ljava/lang/String;
 	public static final fun getISO8601Date (Ljava/util/Date;)Ljava/lang/String;

--- a/code/core/build.gradle
+++ b/code/core/build.gradle
@@ -22,7 +22,7 @@ apiValidation {
 
 android {
     namespace 'com.adobe.marketing.mobile.core'
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.targetSdkVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion

--- a/code/core/build.gradle
+++ b/code/core/build.gradle
@@ -75,6 +75,12 @@ android {
         languageVersion = rootProject.ext.kotlinLanguageVersion
         apiVersion = rootProject.ext.kotlinApiVersion
     }
+    buildFeatures {
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.0.2'
+    }
 }
 
 apply from: '../checkstyle.gradle'
@@ -111,6 +117,16 @@ dependencies {
     implementation "androidx.cardview:cardview:1.0.0"
     //noinspection GradleDependency
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+
+    // Jetpack Compose runtime
+    implementation "androidx.compose.runtime:runtime:1.0.0"
+    // Material UI 1.x
+    implementation 'androidx.compose.material:material:1.0.0'
+    // Jetpack + Activity integration
+    implementation 'androidx.activity:activity-compose:1.3.0'
+    // Jetpack Compose tooling
+    debugImplementation 'androidx.compose.ui:ui-tooling:1.0.0'
+
     // unit tests
     testImplementation "junit:junit:4.13.2"
     testImplementation "org.mockito:mockito-core:4.5.1"
@@ -123,12 +139,10 @@ dependencies {
     testImplementation 'org.json:json:20160810'
     //noinspection GradleDependency
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_version"
 
     // instrumentation tests
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_version"
 
     dokkaGfmPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:${dokka_version}")
 }

--- a/code/core/build.gradle
+++ b/code/core/build.gradle
@@ -21,11 +21,11 @@ apiValidation {
 }
 
 android {
-    compileSdkVersion rootProject.ext.targetSdkVersion
+    namespace 'com.adobe.marketing.mobile.core'
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
-        //noinspection OldTargetApi
         targetSdkVersion rootProject.ext.targetSdkVersion
         //Include the Proguard rules for Core Extension in the aar
         consumerProguardFiles 'lib-proguard-rules.pro'
@@ -79,7 +79,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.0.2'
+        kotlinCompilerExtensionVersion '1.0.5'
     }
 }
 
@@ -123,7 +123,7 @@ dependencies {
     // Material UI 1.x
     implementation "androidx.compose.material:material:${compose_version}"
     // Jetpack + Activity integration
-    implementation 'androidx.activity:activity-compose:1.3.0'
+    implementation 'androidx.activity:activity-compose:1.5.0'
     // Jetpack Compose tooling
     debugImplementation "androidx.compose.ui:ui-tooling:${compose_version}"
 

--- a/code/core/build.gradle
+++ b/code/core/build.gradle
@@ -16,7 +16,7 @@ apiValidation {
     ]
 
     ignoredClasses += [
-        "com.adobe.marketing.mobile.BuildConfig"
+        "com.adobe.marketing.mobile.core.BuildConfig"
     ]
 }
 

--- a/code/core/build.gradle
+++ b/code/core/build.gradle
@@ -119,13 +119,13 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     // Jetpack Compose runtime
-    implementation "androidx.compose.runtime:runtime:1.0.0"
+    implementation "androidx.compose.runtime:runtime:${compose_version}"
     // Material UI 1.x
-    implementation 'androidx.compose.material:material:1.0.0'
+    implementation "androidx.compose.material:material:${compose_version}"
     // Jetpack + Activity integration
     implementation 'androidx.activity:activity-compose:1.3.0'
     // Jetpack Compose tooling
-    debugImplementation 'androidx.compose.ui:ui-tooling:1.0.0'
+    debugImplementation "androidx.compose.ui:ui-tooling:${compose_version}"
 
     // unit tests
     testImplementation "junit:junit:4.13.2"

--- a/code/core/release.gradle
+++ b/code/core/release.gradle
@@ -15,6 +15,28 @@ def isReleaseBuild() {
 
 def groupIdForPublish = isJitPackBuild()? 'com.github.adobe.aepsdk-core-android': 'com.adobe.marketing.mobile'
 
+// A class to represent a dependency node to be attached to POM
+class DependencyNode {
+    final String groupId
+    final String artifactId
+    final String version
+
+    DependencyNode(final String groupId, final String artifactId, final String version) {
+        this.groupId = groupId
+        this.artifactId = artifactId
+        this.version = version
+    }
+}
+
+// A list of Dependency objects representing dependencies to be attached to POM
+def dependencyList = [
+        new DependencyNode("org.jetbrains.kotlin", "kotlin-stdlib-jdk8", "${rootProject.kotlin_version}"),
+        new DependencyNode("androidx.appcompat", "appcompat", "1.0.0"),
+        new DependencyNode("androidx.compose.runtime", "runtime", "${rootProject.compose_version}"),
+        new DependencyNode("androidx.compose.material", "material", "${rootProject.compose_version}"),
+        new DependencyNode("androidx.activity", "activity-compose", "1.5.0")
+]
+
 version = isReleaseBuild() ? rootProject.coreExtensionVersion : rootProject.coreExtensionVersion+"-SNAPSHOT"
 
 publishing {
@@ -51,20 +73,13 @@ publishing {
                 withXml {
                     def dependenciesNode = asNode().appendNode('dependencies')
 
-                    def kotlinDependencyNode = dependenciesNode.appendNode('dependency')
-                    kotlinDependencyNode.appendNode('groupId', 'org.jetbrains.kotlin')
-                    kotlinDependencyNode.appendNode('artifactId', 'kotlin-stdlib-jdk8')
-                    kotlinDependencyNode.appendNode('version', rootProject.kotlin_version)
-
-                    def cardviewDependencyNode = dependenciesNode.appendNode('dependency')
-                    cardviewDependencyNode.appendNode('groupId', 'androidx.cardview')
-                    cardviewDependencyNode.appendNode('artifactId', 'cardview')
-                    cardviewDependencyNode.appendNode('version', '1.0.0')
-
-                    def appcompatDependencyNode = dependenciesNode.appendNode('dependency')
-                    appcompatDependencyNode.appendNode('groupId', 'androidx.appcompat')
-                    appcompatDependencyNode.appendNode('artifactId', 'appcompat')
-                    appcompatDependencyNode.appendNode('version', '1.0.0')
+                    // loop dependencyList and add each dependency to POM as a node
+                    dependencyList.each { dependency ->
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', dependency.groupId)
+                        dependencyNode.appendNode('artifactId', dependency.artifactId)
+                        dependencyNode.appendNode('version', dependency.version)
+                    }
                 }
             }
         }

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -3,6 +3,8 @@ org.gradle.jvmargs=-Xmx2048m
 android.injected.testOnly=false
 org.gradle.configureondemand=false
 android.useAndroidX=true
+
+## Remove the line below in favor of android publishing DSL when it becomes available in AGP 8.x
 android.disableAutomaticComponentCreation=true
 
 #

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -3,6 +3,8 @@ org.gradle.jvmargs=-Xmx2048m
 android.injected.testOnly=false
 org.gradle.configureondemand=false
 android.useAndroidX=true
+android.disableAutomaticComponentCreation=true
+
 #
 #Maven artifacts
 #Core extension

--- a/code/identity/build.gradle
+++ b/code/identity/build.gradle
@@ -5,11 +5,11 @@ apply plugin: 'signing'
 
 
 android {
-    compileSdkVersion rootProject.ext.targetSdkVersion
+    namespace 'com.adobe.marketing.mobile.identity'
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
-        //noinspection OldTargetApi
         targetSdkVersion rootProject.ext.targetSdkVersion
         //Include the Proguard rules for Core Extension in the aar
         consumerProguardFiles 'lib-proguard-rules.pro'

--- a/code/identity/build.gradle
+++ b/code/identity/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'signing'
 
 android {
     namespace 'com.adobe.marketing.mobile.identity'
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.targetSdkVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion

--- a/code/integration-tests/build.gradle
+++ b/code/integration-tests/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdk 33
 
     defaultConfig {
-        minSdk 19
+        minSdk 21
         targetSdk 33
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/code/integration-tests/build.gradle
+++ b/code/integration-tests/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace 'com.adobe.marketing.mobile.integration'
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.targetSdkVersion
 
     defaultConfig {
         minSdk rootProject.ext.minSdkVersion

--- a/code/integration-tests/build.gradle
+++ b/code/integration-tests/build.gradle
@@ -41,14 +41,14 @@ dependencies {
 
 //    implementation fileTree(include: ['*.aar'], dir: 'libs')
 
-    implementation 'androidx.core:core-ktx:1.8.0'
-    implementation 'androidx.appcompat:appcompat:1.4.2'
+    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation project(path: ':core')
     implementation project(path: ':signal')
     implementation project(path: ':identity')
     implementation project(path: ':lifecycle')
 
-    androidTestImplementation('com.adobe.marketing.mobile:analytics:2.0.0') {
+    androidTestImplementation('com.adobe.marketing.mobile:analytics:2.0.3') {
         transitive = false
     }
 

--- a/code/integration-tests/build.gradle
+++ b/code/integration-tests/build.gradle
@@ -4,11 +4,12 @@ plugins {
 }
 
 android {
-    compileSdk 33
+    namespace 'com.adobe.marketing.mobile.integration'
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        minSdk 21
-        targetSdk 33
+        minSdk rootProject.ext.minSdkVersion
+        targetSdk rootProject.ext.targetSdkVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/code/lifecycle/build.gradle
+++ b/code/lifecycle/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'signing'
 
 android {
     namespace 'com.adobe.marketing.mobile.lifecycle'
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.targetSdkVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion

--- a/code/lifecycle/build.gradle
+++ b/code/lifecycle/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 android {
-    compileSdkVersion rootProject.ext.targetSdkVersion
+    namespace 'com.adobe.marketing.mobile.lifecycle'
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
-        //noinspection OldTargetApi
         targetSdkVersion rootProject.ext.targetSdkVersion
         //Include the Proguard rules for Core Extension in the aar
         consumerProguardFiles 'lib-proguard-rules.pro'

--- a/code/macrobenchmark/build.gradle
+++ b/code/macrobenchmark/build.gradle
@@ -4,7 +4,8 @@ plugins {
 }
 
 android {
-    compileSdk 33
+    namespace 'com.adobe.marketing.mobile.macrobenchmark'
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
@@ -17,7 +18,7 @@ android {
 
     defaultConfig {
         minSdk 26
-        targetSdk 33
+        targetSdk rootProject.ext.targetSdkVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/code/macrobenchmark/build.gradle
+++ b/code/macrobenchmark/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace 'com.adobe.marketing.mobile.macrobenchmark'
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.targetSdkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8

--- a/code/microbenchmark/build.gradle
+++ b/code/microbenchmark/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace 'com.adobe.marketing.mobile.microbenchmark'
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.targetSdkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8

--- a/code/microbenchmark/build.gradle
+++ b/code/microbenchmark/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace 'com.adobe.marketing.mobile.microbenchmark'
-    compileSdk 33
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
@@ -19,7 +19,7 @@ android {
 
     defaultConfig {
         minSdk 26
-        targetSdk 33
+        targetSdk rootProject.ext.targetSdkVersion
 
         testInstrumentationRunner 'androidx.benchmark.junit4.AndroidBenchmarkRunner'
     }

--- a/code/signal/build.gradle
+++ b/code/signal/build.gradle
@@ -5,11 +5,11 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 android {
-    compileSdkVersion rootProject.ext.targetSdkVersion
+    namespace 'com.adobe.marketing.mobile.signal'
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
-        //noinspection OldTargetApi
         targetSdkVersion rootProject.ext.targetSdkVersion
         //Include the Proguard rules for Core Extension in the aar
         consumerProguardFiles 'lib-proguard-rules.pro'

--- a/code/signal/build.gradle
+++ b/code/signal/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'signing'
 
 android {
     namespace 'com.adobe.marketing.mobile.signal'
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.targetSdkVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion

--- a/code/test-third-party-extension/build.gradle
+++ b/code/test-third-party-extension/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 30
+    namespace 'com.adobe.marketing.mobile.sample.thirdparyextension'
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion 19
-        //noinspection OldTargetApi
-        targetSdkVersion 30
+        minSdk rootProject.ext.minSdkVersion
+        targetSdk rootProject.ext.targetSdkVersion
     }
 
     buildTypes {

--- a/code/test-third-party-extension/build.gradle
+++ b/code/test-third-party-extension/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     namespace 'com.adobe.marketing.mobile.sample.thirdparyextension'
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.targetSdkVersion
 
     defaultConfig {
         minSdk rootProject.ext.minSdkVersion

--- a/code/testapp-kotlin/build.gradle
+++ b/code/testapp-kotlin/build.gradle
@@ -4,12 +4,13 @@ plugins {
 }
 
 android {
-    compileSdk 33
+    namespace 'com.adobe.marketing.mobile.testapp.kotlin'
+    compileSdk rootProject.ext.compileSdkVersion
 
     defaultConfig {
         applicationId "com.adobe.marketing.mobile.app.kotlin"
-        minSdk 21
-        targetSdk 33
+        minSdk rootProject.ext.minSdkVersion
+        targetSdk rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
 
@@ -41,7 +42,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.0.2'
+        kotlinCompilerExtensionVersion '1.0.5'
     }
     packagingOptions {
         resources {
@@ -56,7 +57,7 @@ dependencies {
     implementation "androidx.compose.material:material:${compose_version}"
     implementation "androidx.compose.ui:ui-tooling-preview:${compose_version}"
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.0.0'
-    implementation "androidx.activity:activity-compose:1.3.0"
+    implementation "androidx.activity:activity-compose:1.5.0"
     implementation 'androidx.navigation:navigation-compose:2.4.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
 

--- a/code/testapp-kotlin/build.gradle
+++ b/code/testapp-kotlin/build.gradle
@@ -4,8 +4,8 @@ plugins {
 }
 
 android {
-    namespace 'com.adobe.marketing.mobile.testapp.kotlin'
-    compileSdk rootProject.ext.compileSdkVersion
+    namespace 'com.adobe.marketing.mobile.app.kotlin'
+    compileSdk rootProject.ext.targetSdkVersion
 
     defaultConfig {
         applicationId "com.adobe.marketing.mobile.app.kotlin"

--- a/code/testapp-kotlin/build.gradle
+++ b/code/testapp-kotlin/build.gradle
@@ -41,7 +41,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.3.2'
+        kotlinCompilerExtensionVersion '1.0.2'
     }
     packagingOptions {
         resources {
@@ -51,13 +51,13 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation "androidx.compose.ui:ui:1.3.0"
-    implementation "androidx.compose.material:material:1.3.0"
-    implementation "androidx.compose.ui:ui-tooling-preview:1.3.0"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
-    implementation 'androidx.activity:activity-compose:1.6.1'
-    implementation 'androidx.navigation:navigation-compose:2.5.3'
+    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation "androidx.compose.ui:ui:${compose_version}"
+    implementation "androidx.compose.material:material:${compose_version}"
+    implementation "androidx.compose.ui:ui-tooling-preview:${compose_version}"
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.0.0'
+    implementation "androidx.activity:activity-compose:1.3.0"
+    implementation 'androidx.navigation:navigation-compose:2.4.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
 
     implementation project(path: ':core')

--- a/code/testapp/build.gradle
+++ b/code/testapp/build.gradle
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId "com.adobe.testapp"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 33
         versionCode 1
         versionName "2.0.0"

--- a/code/testapp/build.gradle
+++ b/code/testapp/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        applicationId "com.adobe.testapp"
-        minSdkVersion 21
-        targetSdkVersion 33
+        applicationId "com.adobe.marketing.mobile.app"
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "2.0.0"
 

--- a/code/testapp/build.gradle
+++ b/code/testapp/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.targetSdkVersion
 
     defaultConfig {
         applicationId "com.adobe.marketing.mobile.app"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

UIServices provided by `aepsdk-core-android` will now move to Jetpack Compose based UI. To start with this migration uplevel current language and gradle dependencies to ones that support Compose. [Jetpack needs Kotlin 1.5+](https://developer.android.com/jetpack/androidx/releases/compose-kotlin#pre-release_kotlin_compatibility) and is supported on [minSdk versions 21+](https://developer.android.com/jetpack/compose/setup#create-new)
- Change `minSdk` requirement from `API 19` to `API 21`.
- `Android Gradle Plugin 7.3.1` needs at least `Kotlin 1.5.21`. However, `1.5.21` results in incompatibility issues with Android Studio Flamingo onwards. So use `1.5.31` instead.
- Use the mapping between Compose Compiler version and Kotlin version [here](https://developer.android.com/jetpack/androidx/releases/compose-kotlin#pre-release_kotlin_compatibility) and use `kotlinCompilerExtensionVersion 1.0.5` and Compose version 1.0.5
- It is recommended that Kotlin gradle plugin version matches the Kotlin version being used. So down level Kotlin gradle plugin version from `1.7.20` to `1.5.31`
- Add `compose.runtime` `compose.material` and `activity-compose` dependancies to Core for implementation.
- Remove explicit dependency on `org.jetbrains.kotlinx:kotlinx-coroutines-core` for coroutines as they are included with compose libraries.
- To keep the Kotlin gradle version same between the root project and `testapp-kotlin` and `integration-tests` modules, use compose `runtime` , `ui` and `core:ktx` dependancies that are compatible with Compose 1.0.5
- Update the gradle script to add POM dependancies
- Standardize the minSDK, targetSDK, compileSDK versions being used across projects in this repo.



A note on the `public static final field $stable I` api dump update: Looks like this is due to Compose compiler to marking some classes (final objects and final data classes) with this  internally. I am trying to check if there is a way for this to be prevented. 
<!--- Describe your changes in detail -->

## Related Issue
Internal MOB-18949

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
UIServices provided by `aepsdk-core-android` will now move to Jetpack Compose based UI. To start with this migration uplevel current language and gradle dependencies to ones that support Compose.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Unit tests
- Integration tests
- Functional tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
