### PR TITLE
fix map casting exception when attempting to show a local notification

### DIFF
--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/AndroidUIService.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/AndroidUIService.java
@@ -246,7 +246,9 @@ public class AndroidUIService implements UIService {
                 !MapUtils.isNullOrEmpty(notificationSetting.getUserInfo())
                         ? new HashMap<>(notificationSetting.getUserInfo())
                         : null;
-        intent.putExtra(NOTIFICATION_USER_INFO_KEY, userInfo);
+        if (!MapUtils.isNullOrEmpty(userInfo)) {
+            intent.putExtra(NOTIFICATION_USER_INFO_KEY, userInfo);
+        }
         intent.putExtra(NOTIFICATION_SOUND_KEY, notificationSetting.getSound());
         intent.putExtra(NOTIFICATION_TITLE, notificationSetting.getTitle());
 

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/AndroidUIService.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/AndroidUIService.java
@@ -26,6 +26,7 @@ import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.services.ServiceConstants;
 import com.adobe.marketing.mobile.services.ServiceProvider;
 import com.adobe.marketing.mobile.services.ui.internal.MessagesMonitor;
+import com.adobe.marketing.mobile.util.MapUtils;
 import java.lang.reflect.Field;
 import java.security.SecureRandom;
 import java.util.Calendar;
@@ -241,9 +242,11 @@ public class AndroidUIService implements UIService {
         intent.putExtra(NOTIFICATION_REQUEST_CODE_KEY, requestCode);
         intent.putExtra(NOTIFICATION_DEEPLINK_KEY, notificationSetting.getDeeplink());
         intent.putExtra(NOTIFICATION_CONTENT_KEY, notificationSetting.getContent());
-        intent.putExtra(
-                NOTIFICATION_USER_INFO_KEY,
-                (HashMap<String, Object>) notificationSetting.getUserInfo());
+        final HashMap<String, Object> userInfo =
+                !MapUtils.isNullOrEmpty(notificationSetting.getUserInfo())
+                        ? new HashMap<>(notificationSetting.getUserInfo())
+                        : null;
+        intent.putExtra(NOTIFICATION_USER_INFO_KEY, userInfo);
         intent.putExtra(NOTIFICATION_SOUND_KEY, notificationSetting.getSound());
         intent.putExtra(NOTIFICATION_TITLE, notificationSetting.getTitle());
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
A ClassCastException was occurring because the local notification user info map was unmodifiable. To resolve this, a HashMap copy of the local notification user info map should be made instead of casting the existing user info map to a HashMap.
Internal JIRA: MOB-19323
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
