### PR TITLE
Update UI Interfaces with better generic signatures

### DIFF
--- a/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/vnext/Presentation.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/vnext/Presentation.kt
@@ -15,4 +15,4 @@ package com.adobe.marketing.mobile.services.ui.vnext
  * Defines types of [Presentable]s supported by the AEP SDK.
  * Holds the [PresentationEventListener] for the presentation.
  */
-sealed class Presentation<T : Presentation<T>>(val listener: PresentationEventListener<Presentable<T>>)
+sealed class Presentation<T : Presentation<T>>(val listener: PresentationEventListener<T>)

--- a/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/vnext/PresentationEventListener.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/vnext/PresentationEventListener.kt
@@ -15,24 +15,29 @@ package com.adobe.marketing.mobile.services.ui.vnext
  * A notification mechanism for the component that created the associated [Presentable] to receive events
  * about a presentation in response to user interaction, system events, or operations performed programmatically.
  */
-interface PresentationEventListener<T : Presentable<*>> {
+interface PresentationEventListener<T : Presentation<T>> {
     /**
      * Invoked when the presentable is shown.
      * @param presentable the presentable that was shown
      */
-    fun onShow(presentable: T)
+    fun onShow(presentable: Presentable<T>)
 
     /**
      * Invoked when the presentable is hidden.
      * @param presentable the presentable that was hidden
      */
-    fun onHide(presentable: T)
+    fun onHide(presentable: Presentable<T>)
 
     /**
      * Invoked when the presentable is dismissed.
      * @param presentable the presentable that was dismissed
      */
-    fun onDismiss(presentable: T)
+    fun onDismiss(presentable: Presentable<T>)
 
-    fun onError(presentable: T, error: PresentationError)
+    /**
+     * Invoked when an error occurs while managing the presentable.
+     * @param presentable the presentable that encountered the error
+     * @param error the error that occurred
+     */
+    fun onError(presentable: Presentable<T>, error: PresentationError)
 }

--- a/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/vnext/UIService.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/vnext/UIService.kt
@@ -22,7 +22,7 @@ interface UIService {
      *        that should be used for creating the presentation.
      * @return a [Presentable] that is associated with the [presentation].
      */
-    fun <T : Presentation<*>> create(
+    fun <T : Presentation<T>> create(
         presentation: T,
         presentationUtilityProvider: PresentationUtilityProvider
     ): Presentable<T>


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
- UIService#create(..) can accept Presentation<T> instead of a wildcard
- Change PresentationEventListener<T : Presentable<*>> to
  PresentationEventListener<T : Presentation<T>>

<!--- Describe your changes in detail -->

## Related Issue
#525 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Improve signatures of the public interfaces for UI Services

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
