### PR TITLE
Make updateConfiguration API environment aware

### DIFF
--- a/code/core/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationStateManagerTest.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationStateManagerTest.kt
@@ -881,10 +881,6 @@ class ConfigurationStateManagerTest {
     }
 
     @Test
-    fun `Test updateProgrammaticConfig persists config being aware of current environment`() {
-    }
-
-    @Test
     fun `Test mapToEnvironmentAwareKeys when environment is dev and dev keys exist`() {
         // do not use any predefined setup config. We will setup the config manually
         prepareWith(persistedProgrammaticConfig = false, bundledConfig = false)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

#### Problem
Calling MobileCore.updateConfiguration() will update the exact key match for environment prefixed keys. Meaning, calling `MobileCore.updateConfiguration(mapOf("analytics.rsids" to "mynew.rsid"))` will update the `"analytics.rsids"` value instead of the `"__dev__analytics.rsids"` value when the environment is "dev".

#### Expectation
Calling `MobileCore.updateConfiguration()` should update the current environment's configuration key instead of exact key matches, similar to the iOS implementation.

#### Solution
Map the config keys provided during `MobileCore.updateConfiguration()` to their environment aware values before updating/merging the configuration.

This PR also updates the ConfigurationTests to be independent to the method being tested.

<!--- Describe your changes in detail -->

## Related Issue
#539 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Unit tests
- Manual tests with testapp-kotlin

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
