### PR TITLE
Expose getSmallIconResourceID API for AJO Notification Builder

### DIFF
--- a/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
@@ -328,12 +328,21 @@ public final class MobileCore {
     }
 
     /**
-     * Sets the resource Id for small icon.
+     * Sets the resource Id for large icon.
      *
      * @param resourceID the resource Id of the icon
      */
     public static void setLargeIconResourceID(final int resourceID) {
         AppResourceStore.INSTANCE.setLargeIconResourceID(resourceID);
+    }
+
+    /**
+     * Returns the resource Id for large icon if it was set by `setLargeIconResourceID`.
+     *
+     * @return a `int` value if it has been set, otherwise -1
+     */
+    public static int getLargeIconResourceID() {
+        return AppResourceStore.INSTANCE.getLargeIconResourceID();
     }
 
     // ========================================================

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
@@ -319,6 +319,15 @@ public final class MobileCore {
     }
 
     /**
+     * Returns the resource Id for small icon if it was set by `setSmallIconResourceID`.
+     *
+     * @return a `int` value if it has been set, otherwise -1
+     */
+    public static int getSmallIconResourceID() {
+        return AppResourceStore.INSTANCE.getSmallIconResourceID();
+    }
+
+    /**
      * Sets the resource Id for small icon.
      *
      * @param resourceID the resource Id of the icon

--- a/code/core/src/test/java/com/adobe/marketing/mobile/internal/AppResourceStoreTests.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/internal/AppResourceStoreTests.java
@@ -96,6 +96,27 @@ public class AppResourceStoreTests {
     }
 
     @Test
+    public void testGetSmallIconResourceId_ValidIdSet() {
+        // Setup
+        when(mockSharedPreferences.getInt(eq(DATASTORE_KEY_SMALL_ICON), anyInt()))
+                .thenReturn(123456);
+
+        // Test
+        int actualResourceId = AppResourceStore.INSTANCE.getSmallIconResourceID();
+        assertEquals(123456, actualResourceId);
+    }
+
+    @Test
+    public void testGetSmallIconResourceId_NoIdSet() {
+        when(mockSharedPreferences.getInt(eq(DATASTORE_KEY_SMALL_ICON), anyInt()))
+                .thenReturn(-1);
+
+        // Test
+        int actualResourceId = AppResourceStore.INSTANCE.getSmallIconResourceID();
+        assertEquals(actualResourceId,-1);
+    }
+
+    @Test
     public void testSetLargeIconResourceId_ValidIdSetTwice() {
         // Setup
         final int expectedValueStored = 123456;

--- a/code/core/src/test/java/com/adobe/marketing/mobile/internal/AppResourceStoreTests.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/internal/AppResourceStoreTests.java
@@ -15,12 +15,15 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 import android.content.Context;
 import android.content.SharedPreferences;
 import com.adobe.marketing.mobile.services.AppContextService;
 import com.adobe.marketing.mobile.services.ServiceProviderModifier;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,45 +58,16 @@ public class AppResourceStoreTests {
         ServiceProviderModifier.setAppContextService(mockAppContextService);
     }
 
-    @Test
-    public void testSetLargeIconResourceId_ValidIdSet() {
-        // Setup
-        final int expectedValueStored = 123456;
-        when(mockPreferenceEditor.putInt(eq(DATASTORE_KEY_LARGE_ICON), anyInt()))
-                .thenAnswer(
-                        new Answer<SharedPreferences.Editor>() {
-                            @Override
-                            public SharedPreferences.Editor answer(InvocationOnMock invocation)
-                                    throws Throwable {
-                                int actualValueStored = invocation.getArgument(1);
-                                assertEquals(expectedValueStored, actualValueStored);
-                                return mockPreferenceEditor;
-                            }
-                        });
-
-        // Test
-        AppResourceStore.INSTANCE.setLargeIconResourceID(expectedValueStored);
+    @After
+    public void afterEach() {
+        reset(mockSharedPreferences);
+        AppResourceStore.INSTANCE.setLargeIconResourceID(-1);
+        AppResourceStore.INSTANCE.setSmallIconResourceID(-1);
     }
 
-    @Test
-    public void testSetSmallIconResourceId_ValidIdSet() {
-        // Setup
-        final int expectedValueStored = 123456;
-        when(mockPreferenceEditor.putInt(eq(DATASTORE_KEY_SMALL_ICON), anyInt()))
-                .thenAnswer(
-                        new Answer<SharedPreferences.Editor>() {
-                            @Override
-                            public SharedPreferences.Editor answer(InvocationOnMock invocation)
-                                    throws Throwable {
-                                int actualValueStored = invocation.getArgument(1);
-                                assertEquals(expectedValueStored, actualValueStored);
-                                return mockPreferenceEditor;
-                            }
-                        });
-
-        // Test
-        AppResourceStore.INSTANCE.setSmallIconResourceID(expectedValueStored);
-    }
+    // ******************************************************************************************
+    // SmallIconResourceId Tests
+    // ******************************************************************************************
 
     @Test
     public void testGetSmallIconResourceId_ValidIdSet() {
@@ -117,28 +91,6 @@ public class AppResourceStoreTests {
     }
 
     @Test
-    public void testSetLargeIconResourceId_ValidIdSetTwice() {
-        // Setup
-        final int expectedValueStored = 123456;
-        AppResourceStore.INSTANCE.setLargeIconResourceID(111111);
-
-        when(mockPreferenceEditor.putInt(eq(DATASTORE_KEY_LARGE_ICON), anyInt()))
-                .thenAnswer(
-                        new Answer<SharedPreferences.Editor>() {
-                            @Override
-                            public SharedPreferences.Editor answer(InvocationOnMock invocation)
-                                    throws Throwable {
-                                int actualValueStored = invocation.getArgument(1);
-                                assertEquals(expectedValueStored, actualValueStored);
-                                return mockPreferenceEditor;
-                            }
-                        });
-
-        // Test
-        AppResourceStore.INSTANCE.setLargeIconResourceID(expectedValueStored);
-    }
-
-    @Test
     public void testSetSmallIconResourceId_ValidIdSetTwice() {
         // Setup
         final int expectedValueStored = 123456;
@@ -158,5 +110,93 @@ public class AppResourceStoreTests {
 
         // Test
         AppResourceStore.INSTANCE.setSmallIconResourceID(expectedValueStored);
+    }
+
+    @Test
+    public void testSetSmallIconResourceId_ValidIdSet() {
+        // Setup
+        final int expectedValueStored = 123456;
+        AppResourceStore.INSTANCE.setSmallIconResourceID(11111);
+
+        when(mockPreferenceEditor.putInt(eq(DATASTORE_KEY_SMALL_ICON), anyInt()))
+                .thenAnswer(
+                        new Answer<SharedPreferences.Editor>() {
+                            @Override
+                            public SharedPreferences.Editor answer(InvocationOnMock invocation)
+                                    throws Throwable {
+                                int actualValueStored = invocation.getArgument(1);
+                                assertEquals(expectedValueStored, actualValueStored);
+                                return mockPreferenceEditor;
+                            }
+                        });
+
+        // Test
+        AppResourceStore.INSTANCE.setSmallIconResourceID(expectedValueStored);
+    }
+
+    // ******************************************************************************************
+    // LargeIconResourceId Tests
+    // ******************************************************************************************
+
+    @Test
+    public void testLargeIconResourceId_ValidIdSet() {
+        // Setup
+        when(mockSharedPreferences.getInt(eq(DATASTORE_KEY_LARGE_ICON), anyInt()))
+                .thenReturn(123456);
+
+        // Test
+        int actualResourceId = AppResourceStore.INSTANCE.getLargeIconResourceID();
+        assertEquals(123456, actualResourceId);
+    }
+
+    @Test
+    public void testGetLargeIconResourceId_NoIdSet() {
+        when(mockSharedPreferences.getInt(eq(DATASTORE_KEY_LARGE_ICON), anyInt()))
+                .thenReturn(-1);
+
+        // Test
+        int actualResourceId = AppResourceStore.INSTANCE.getLargeIconResourceID();
+        assertEquals(actualResourceId,-1);
+    }
+    @Test
+    public void testSetLargeIconResourceId_ValidIdSet() {
+        // Setup
+        final int expectedValueStored = 123456;
+        when(mockPreferenceEditor.putInt(eq(DATASTORE_KEY_LARGE_ICON), anyInt()))
+                .thenAnswer(
+                        new Answer<SharedPreferences.Editor>() {
+                            @Override
+                            public SharedPreferences.Editor answer(InvocationOnMock invocation)
+                                    throws Throwable {
+                                int actualValueStored = invocation.getArgument(1);
+                                assertEquals(expectedValueStored, actualValueStored);
+                                return mockPreferenceEditor;
+                            }
+                        });
+
+        // Test
+        AppResourceStore.INSTANCE.setLargeIconResourceID(expectedValueStored);
+    }
+
+    @Test
+    public void testSetLargeIconResourceId_ValidIdSetTwice() {
+        // Setup
+        final int expectedValueStored = 123456;
+        AppResourceStore.INSTANCE.setLargeIconResourceID(111111);
+
+        when(mockPreferenceEditor.putInt(eq(DATASTORE_KEY_LARGE_ICON), anyInt()))
+                .thenAnswer(
+                        new Answer<SharedPreferences.Editor>() {
+                            @Override
+                            public SharedPreferences.Editor answer(InvocationOnMock invocation)
+                                    throws Throwable {
+                                int actualValueStored = invocation.getArgument(1);
+                                assertEquals(expectedValueStored, actualValueStored);
+                                return mockPreferenceEditor;
+                            }
+                        });
+
+        // Test
+        AppResourceStore.INSTANCE.setLargeIconResourceID(expectedValueStored);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Included a new API in MobileCore - `getSmallIconResourceID` that returns the smallIconRescourceID, if it has already been set using API `MobileCore.setSmallIconResourceID`

## Motivation and Context

This API will be used by AJO (Messaging extension's) notification builder to use the small Icon that is set in MobileCore.

## How Has This Been Tested?

Unit tests + Manual testing

## Screenshots (if appropriate):

