### PR TITLE
Add support for Alert UI

### DIFF
--- a/code/core/src/androidTest/java/com/adobe/marketing/mobile/services/ui/vnext/alert/views/AlertScreenTests.kt
+++ b/code/core/src/androidTest/java/com/adobe/marketing/mobile/services/ui/vnext/alert/views/AlertScreenTests.kt
@@ -1,0 +1,357 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.services.ui.vnext.alert.views
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.espresso.Espresso
+import com.adobe.marketing.mobile.services.ui.vnext.alert.AlertSettings
+import com.adobe.marketing.mobile.services.ui.vnext.common.PresentationStateManager
+import junit.framework.TestCase.assertTrue
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class AlertScreenTests {
+    @get: Rule
+    val composeTestRule = createComposeRule()
+
+    private val presentationStateManager = PresentationStateManager()
+    private var onPositiveButtonClicked = false
+    private var onNegativeButtonClicked = false
+    private var onBackPressed = false
+
+    @Before
+    fun setUp() {
+    }
+
+    @Test
+    fun testAlertScreenNotDisplayedWhenFirstAttached() {
+        // Setup
+        val alertSettings = AlertSettings.Builder()
+            .title("My Title")
+            .message("My Message")
+            .positiveButtonText("Confirm")
+            .negativeButtonText("Cancel")
+            .build()
+
+        composeTestRule.setContent {
+            AlertScreen(
+                presentationStateManager = presentationStateManager,
+                alertSettings = alertSettings,
+                onPositiveResponse = { onPositiveButtonClicked = true },
+                onNegativeResponse = { onNegativeButtonClicked = true },
+                onBackPressed = { onBackPressed = true }
+            )
+        }
+
+        // Test
+        composeTestRule.onNodeWithTag(AlertTestTags.TITLE_TEXT).assertDoesNotExist()
+        composeTestRule.onNodeWithTag(AlertTestTags.MESSAGE_TEXT).assertDoesNotExist()
+        composeTestRule.onNodeWithTag(AlertTestTags.POSITIVE_BUTTON).assertDoesNotExist()
+        composeTestRule.onNodeWithTag(AlertTestTags.NEGATIVE_BUTTON).assertDoesNotExist()
+    }
+
+    @Test
+    fun testAlertScreenIsDisplayedWhenPresentationVisibilityStateIsTrue() {
+        // Setup
+        val alertSettings = AlertSettings.Builder()
+            .title("My Title")
+            .message("My Message")
+            .positiveButtonText("Confirm")
+            .negativeButtonText("Cancel")
+            .build()
+
+        composeTestRule.setContent {
+            AlertScreen(
+                presentationStateManager = presentationStateManager,
+                alertSettings = alertSettings,
+                onPositiveResponse = { onPositiveButtonClicked = true },
+                onNegativeResponse = { onNegativeButtonClicked = true },
+                onBackPressed = { onBackPressed = true }
+            )
+        }
+
+        // Test
+        presentationStateManager.onShown()
+
+        composeTestRule.onNodeWithTag(AlertTestTags.TITLE_TEXT).assertExists().assertIsDisplayed()
+            .assertTextContains("My Title")
+        composeTestRule.onNodeWithTag(AlertTestTags.MESSAGE_TEXT).assertExists().assertIsDisplayed()
+            .assertTextContains("My Message")
+        composeTestRule.onNodeWithTag(AlertTestTags.POSITIVE_BUTTON).assertExists()
+            .assertTextContains("Confirm")
+        composeTestRule.onNodeWithTag(AlertTestTags.NEGATIVE_BUTTON).assertExists()
+            .assertTextContains("Cancel")
+    }
+
+    @Test
+    fun testAlertScreenDisplaysRightNumberOfButtonsWhenPresentationVisibilityStateIsTrue() {
+        // Setup
+        val alertSettings = AlertSettings.Builder()
+            .title("My Title")
+            .message("My Message")
+            .positiveButtonText("Confirm") // No negative button
+            .build()
+
+        composeTestRule.setContent {
+            AlertScreen(
+                presentationStateManager = presentationStateManager,
+                alertSettings = alertSettings,
+                onPositiveResponse = { onPositiveButtonClicked = true },
+                onNegativeResponse = { onNegativeButtonClicked = true },
+                onBackPressed = { onBackPressed = true }
+            )
+        }
+
+        // Test
+        presentationStateManager.onShown()
+
+        composeTestRule.onNodeWithTag(AlertTestTags.TITLE_TEXT).assertExists().assertIsDisplayed()
+            .assertTextContains("My Title")
+        composeTestRule.onNodeWithTag(AlertTestTags.MESSAGE_TEXT).assertExists().assertIsDisplayed()
+            .assertTextContains("My Message")
+        composeTestRule.onNodeWithTag(AlertTestTags.POSITIVE_BUTTON).assertExists()
+            .assertIsDisplayed().assertTextContains("Confirm")
+        composeTestRule.onNodeWithTag(AlertTestTags.NEGATIVE_BUTTON).assertDoesNotExist()
+    }
+
+    @Test
+    fun testAlertScreenNotifiesOnPositiveResponseWhenPositiveButtonIsClicked() {
+        // Setup
+        val alertSettings = AlertSettings.Builder()
+            .title("My Title")
+            .message("My Message")
+            .positiveButtonText("Confirm")
+            .negativeButtonText("Cancel")
+            .build()
+
+        composeTestRule.setContent {
+            AlertScreen(
+                presentationStateManager = presentationStateManager,
+                alertSettings = alertSettings,
+                onPositiveResponse = { onPositiveButtonClicked = true },
+                onNegativeResponse = { onNegativeButtonClicked = true },
+                onBackPressed = { onBackPressed = true }
+            )
+        }
+
+        // Test
+        presentationStateManager.onShown()
+
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(AlertTestTags.TITLE_TEXT).assertExists().assertIsDisplayed()
+            .assertTextContains("My Title")
+        composeTestRule.onNodeWithTag(AlertTestTags.MESSAGE_TEXT).assertExists().assertIsDisplayed()
+            .assertTextContains("My Message")
+        composeTestRule.onNodeWithTag(AlertTestTags.POSITIVE_BUTTON).assertExists()
+            .assertTextContains("Confirm")
+        composeTestRule.onNodeWithTag(AlertTestTags.NEGATIVE_BUTTON).assertExists()
+            .assertTextContains("Cancel")
+
+        // Click the positive button
+        composeTestRule.onNode(hasTestTag(AlertTestTags.POSITIVE_BUTTON)).assertIsDisplayed()
+            .performClick()
+
+        composeTestRule.waitForIdle()
+
+        // verify
+        assert(onPositiveButtonClicked)
+    }
+
+    @Test
+    fun testAlertScreenNotifiesOnNegativeResponseWhenNegativeButtonIsClicked() {
+        // Setup
+        val alertSettings = AlertSettings.Builder()
+            .title("My Title")
+            .message("My Message")
+            .positiveButtonText("Confirm")
+            .negativeButtonText("Cancel")
+            .build()
+
+        composeTestRule.setContent {
+            AlertScreen(
+                presentationStateManager = presentationStateManager,
+                alertSettings = alertSettings,
+                onPositiveResponse = { onPositiveButtonClicked = true },
+                onNegativeResponse = { onNegativeButtonClicked = true },
+                onBackPressed = { onBackPressed = true }
+            )
+        }
+
+        // Test
+        presentationStateManager.onShown()
+
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(AlertTestTags.TITLE_TEXT).assertExists().assertIsDisplayed()
+            .assertTextContains("My Title")
+        composeTestRule.onNodeWithTag(AlertTestTags.MESSAGE_TEXT).assertExists().assertIsDisplayed()
+            .assertTextContains("My Message")
+        composeTestRule.onNodeWithTag(AlertTestTags.POSITIVE_BUTTON).assertExists()
+            .assertTextContains("Confirm")
+        composeTestRule.onNodeWithTag(AlertTestTags.NEGATIVE_BUTTON).assertExists()
+            .assertTextContains("Cancel")
+
+        // Click the negative button
+        composeTestRule.onNode(hasTestTag(AlertTestTags.NEGATIVE_BUTTON)).assertIsDisplayed()
+            .performClick()
+
+        composeTestRule.waitForIdle()
+
+        // verify
+        assert(onNegativeButtonClicked)
+    }
+
+    @Test
+    fun testAlertScreenNotifiesOnBackPressedWhenBackButtonIsClicked() {
+        // Setup
+        val alertSettings = AlertSettings.Builder()
+            .title("My Title")
+            .message("My Message")
+            .positiveButtonText("Confirm")
+            .negativeButtonText("Cancel")
+            .build()
+
+        composeTestRule.setContent {
+            AlertScreen(
+                presentationStateManager = presentationStateManager,
+                alertSettings = alertSettings,
+                onPositiveResponse = { onPositiveButtonClicked = true },
+                onNegativeResponse = { onNegativeButtonClicked = true },
+                onBackPressed = { onBackPressed = true }
+            )
+        }
+
+        // Test
+        presentationStateManager.onShown()
+
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithTag(AlertTestTags.TITLE_TEXT).assertExists().assertIsDisplayed()
+            .assertTextContains("My Title")
+        composeTestRule.onNodeWithTag(AlertTestTags.MESSAGE_TEXT).assertExists().assertIsDisplayed()
+            .assertTextContains("My Message")
+        composeTestRule.onNodeWithTag(AlertTestTags.POSITIVE_BUTTON).assertExists()
+            .assertTextContains("Confirm")
+        composeTestRule.onNodeWithTag(AlertTestTags.NEGATIVE_BUTTON).assertExists()
+            .assertTextContains("Cancel")
+
+        // Press back button
+        Espresso.pressBack()
+        Espresso.onIdle()
+
+        // verify that onBackPressed is called
+        assertTrue(onBackPressed)
+    }
+
+    @Test
+    fun testAlertScreenIsInvisibleWhenPresentationStateIsHidden() {
+        // Setup
+        val alertSettings = AlertSettings.Builder()
+            .title("My Title")
+            .message("My Message")
+            .positiveButtonText("Confirm")
+            .negativeButtonText("Cancel")
+            .build()
+
+        composeTestRule.setContent {
+            AlertScreen(
+                presentationStateManager = presentationStateManager,
+                alertSettings = alertSettings,
+                onPositiveResponse = { onPositiveButtonClicked = true },
+                onNegativeResponse = { onNegativeButtonClicked = true },
+                onBackPressed = { onBackPressed = true }
+            )
+        }
+
+        // show the alert initially
+        presentationStateManager.onShown()
+
+        // verify that the alert is visible
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(AlertTestTags.TITLE_TEXT).assertExists().assertIsDisplayed()
+            .assertTextContains("My Title")
+        composeTestRule.onNodeWithTag(AlertTestTags.MESSAGE_TEXT).assertExists().assertIsDisplayed()
+            .assertTextContains("My Message")
+        composeTestRule.onNodeWithTag(AlertTestTags.POSITIVE_BUTTON).assertExists()
+            .assertIsDisplayed().assertTextContains("Confirm")
+        composeTestRule.onNodeWithTag(AlertTestTags.NEGATIVE_BUTTON).assertExists()
+            .assertIsDisplayed().assertTextContains("Cancel")
+
+        // hide the alert
+        presentationStateManager.onHidden()
+
+        // verify that the alert is not visible
+        composeTestRule.onNodeWithTag(AlertTestTags.TITLE_TEXT).assertDoesNotExist()
+        composeTestRule.onNodeWithTag(AlertTestTags.MESSAGE_TEXT).assertDoesNotExist()
+        composeTestRule.onNodeWithTag(AlertTestTags.POSITIVE_BUTTON).assertDoesNotExist()
+        composeTestRule.onNodeWithTag(AlertTestTags.NEGATIVE_BUTTON).assertDoesNotExist()
+    }
+
+    @Test
+    fun testAlertScreenIsInvisibleWhenPresentationStateIsDismissed() {
+        // Setup
+        val alertSettings = AlertSettings.Builder()
+            .title("My Title")
+            .message("My Message")
+            .positiveButtonText("Confirm")
+            .negativeButtonText("Cancel")
+            .build()
+
+        composeTestRule.setContent {
+            AlertScreen(
+                presentationStateManager = presentationStateManager,
+                alertSettings = alertSettings,
+                onPositiveResponse = { onPositiveButtonClicked = true },
+                onNegativeResponse = { onNegativeButtonClicked = true },
+                onBackPressed = { onBackPressed = true }
+            )
+        }
+
+        // show the alert initially
+        presentationStateManager.onShown()
+
+        // verify that the alert is visible
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(AlertTestTags.TITLE_TEXT).assertExists().assertIsDisplayed()
+            .assertTextContains("My Title")
+        composeTestRule.onNodeWithTag(AlertTestTags.MESSAGE_TEXT).assertExists().assertIsDisplayed()
+            .assertTextContains("My Message")
+        composeTestRule.onNodeWithTag(AlertTestTags.POSITIVE_BUTTON).assertExists()
+            .assertIsDisplayed().assertTextContains("Confirm")
+        composeTestRule.onNodeWithTag(AlertTestTags.NEGATIVE_BUTTON).assertExists()
+            .assertIsDisplayed().assertTextContains("Cancel")
+
+        // hide the alert
+        presentationStateManager.onDetached()
+
+        // verify that the alert is not visible
+        composeTestRule.onNodeWithTag(AlertTestTags.TITLE_TEXT).assertDoesNotExist()
+        composeTestRule.onNodeWithTag(AlertTestTags.MESSAGE_TEXT).assertDoesNotExist()
+        composeTestRule.onNodeWithTag(AlertTestTags.POSITIVE_BUTTON).assertDoesNotExist()
+        composeTestRule.onNodeWithTag(AlertTestTags.NEGATIVE_BUTTON).assertDoesNotExist()
+    }
+
+    @After
+    fun tearDown() {
+        onBackPressed = false
+        onPositiveButtonClicked = false
+        onNegativeButtonClicked = false
+    }
+}

--- a/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/vnext/Presentation.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/vnext/Presentation.kt
@@ -11,6 +11,8 @@
 
 package com.adobe.marketing.mobile.services.ui.vnext
 
+import com.adobe.marketing.mobile.services.ui.vnext.alert.AlertEventListener
+import com.adobe.marketing.mobile.services.ui.vnext.alert.AlertSettings
 import com.adobe.marketing.mobile.services.ui.vnext.message.InAppMessageEventHandler
 import com.adobe.marketing.mobile.services.ui.vnext.message.InAppMessageEventListener
 import com.adobe.marketing.mobile.services.ui.vnext.message.InAppMessageSettings
@@ -39,3 +41,13 @@ class InAppMessage(
      */
     lateinit var eventHandler: InAppMessageEventHandler
 }
+
+/**
+ * Represents an Alert presentation.
+ * @param settings the settings for the Alert
+ * @param eventListener the listener for the getting notified about Alert lifecycle events
+ */
+class Alert(
+    val settings: AlertSettings,
+    val eventListener: AlertEventListener
+) : Presentation<Alert>(eventListener)

--- a/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/vnext/alert/AlertEventListener.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/vnext/alert/AlertEventListener.kt
@@ -1,0 +1,34 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.services.ui.vnext.alert
+
+import com.adobe.marketing.mobile.services.ui.vnext.Alert
+import com.adobe.marketing.mobile.services.ui.vnext.Presentable
+import com.adobe.marketing.mobile.services.ui.vnext.PresentationEventListener
+
+/**
+ *  Interface for listening to events related to an Alert presentation.
+ */
+interface AlertEventListener : PresentationEventListener<Alert> {
+
+    /**
+     * Called when the clicks the positive button on the alert.
+     * @param alert the alert that was clicked
+     */
+    fun onPositiveResponse(alert: Presentable<Alert>)
+
+    /**
+     * Called when the clicks the negative button on the alert.
+     * @param alert the alert that was clicked
+     */
+    fun onNegativeResponse(alert: Presentable<Alert>)
+}

--- a/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/vnext/alert/AlertSettings.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/vnext/alert/AlertSettings.kt
@@ -1,0 +1,73 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.services.ui.vnext.alert
+
+/**
+ * Settings for an [Alert] presentation.
+ * @param title the title of the alert
+ * @param message the message of the alert
+ * @param positiveButtonText the text for the positive button
+ * @param negativeButtonText the text for the negative button
+ */
+class AlertSettings private constructor(
+    val title: String,
+    val message: String,
+    val positiveButtonText: String?,
+    val negativeButtonText: String?
+) {
+
+    class Builder {
+        private var title: String = ""
+        private var message: String = ""
+        private var positiveButtonText: String? = null
+        private var negativeButtonText: String? = null
+
+        /**
+         * Sets the title of the alert.
+         * @param title the title of the alert
+         */
+        fun title(title: String) = apply { this.title = title }
+
+        /**
+         * Sets the message of the alert.
+         * @param message the message of the alert
+         */
+        fun message(message: String) = apply { this.message = message }
+
+        /**
+         * Sets the text for the positive button.
+         * @param positiveButtonText the text for the positive button
+         */
+        fun positiveButtonText(positiveButtonText: String) =
+            apply { this.positiveButtonText = positiveButtonText }
+
+        /**
+         * Sets the text for the negative button.
+         * @param negativeButtonText the text for the negative button
+         */
+        fun negativeButtonText(negativeButtonText: String) =
+            apply { this.negativeButtonText = negativeButtonText }
+
+        fun build() = run {
+            if (positiveButtonText == null && negativeButtonText == null) {
+                throw IllegalArgumentException("At least one button must be defined.")
+            }
+
+            AlertSettings(
+                title,
+                message,
+                positiveButtonText,
+                negativeButtonText
+            )
+        }
+    }
+}

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/vnext/AEPUIService.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/vnext/AEPUIService.kt
@@ -11,6 +11,7 @@
 
 package com.adobe.marketing.mobile.services.ui.vnext
 
+import com.adobe.marketing.mobile.services.ui.vnext.alert.AlertPresentable
 import com.adobe.marketing.mobile.services.ui.vnext.common.AppLifecycleProvider
 import com.adobe.marketing.mobile.services.ui.vnext.message.InAppMessagePresentable
 import kotlinx.coroutines.CoroutineScope
@@ -38,6 +39,15 @@ class AEPUIService : UIService {
                     presentationUtilityProvider,
                     AppLifecycleProvider.INSTANCE,
                     CoroutineScope(Dispatchers.Main)
+                ) as Presentable<T>
+            }
+
+            is Alert -> {
+                return AlertPresentable(
+                    presentation,
+                    presentationDelegate,
+                    presentationUtilityProvider,
+                    AppLifecycleProvider.INSTANCE
                 ) as Presentable<T>
             }
             else -> {

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/vnext/alert/AlertPresentable.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/vnext/alert/AlertPresentable.kt
@@ -1,0 +1,70 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.services.ui.vnext.alert
+
+import android.content.Context
+import androidx.compose.ui.platform.ComposeView
+import com.adobe.marketing.mobile.services.ui.vnext.Alert
+import com.adobe.marketing.mobile.services.ui.vnext.PresentationDelegate
+import com.adobe.marketing.mobile.services.ui.vnext.PresentationUtilityProvider
+import com.adobe.marketing.mobile.services.ui.vnext.alert.views.AlertScreen
+import com.adobe.marketing.mobile.services.ui.vnext.common.AEPPresentable
+import com.adobe.marketing.mobile.services.ui.vnext.common.AppLifecycleProvider
+
+/**
+ * Represents an Alert presentable.
+ * @param alert the alert that this presentable will be tied to
+ * @param presentationDelegate the presentation delegate to use for notifying lifecycle events
+ * @param presentationUtilityProvider the presentation utility provider to use for performing operations on the presentable
+ * @param appLifecycleProvider the app lifecycle provider to use for listening to lifecycle events
+ */
+internal class AlertPresentable(
+    val alert: Alert,
+    presentationDelegate: PresentationDelegate?,
+    presentationUtilityProvider: PresentationUtilityProvider,
+    appLifecycleProvider: AppLifecycleProvider
+) : AEPPresentable<Alert>(
+    alert,
+    presentationUtilityProvider,
+    presentationDelegate,
+    appLifecycleProvider
+) {
+    override fun getContent(activityContext: Context): ComposeView {
+        return ComposeView(activityContext).apply {
+            setContent {
+                AlertScreen(
+                    presentationStateManager = presentationStateManager,
+                    alertSettings = alert.settings,
+                    onPositiveResponse = {
+                        alert.eventListener.onPositiveResponse(this@AlertPresentable)
+                        dismiss()
+                    },
+                    onNegativeResponse = {
+                        alert.eventListener.onNegativeResponse(this@AlertPresentable)
+                        dismiss()
+                    },
+                    onBackPressed = {
+                        dismiss()
+                    }
+                )
+            }
+        }
+    }
+
+    override fun gateDisplay(): Boolean {
+        return false
+    }
+
+    override fun getPresentation(): Alert {
+        return alert
+    }
+}

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/vnext/alert/views/AlertScreen.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/vnext/alert/views/AlertScreen.kt
@@ -1,0 +1,91 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.services.ui.vnext.alert.views
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.window.DialogProperties
+import com.adobe.marketing.mobile.services.ui.vnext.alert.AlertSettings
+import com.adobe.marketing.mobile.services.ui.vnext.common.PresentationStateManager
+
+/**
+ * Composable function to display an alert dialog.
+ * @param presentationStateManager [PresentationStateManager] to manage the visibility state of the alert dialog.
+ * @param alertSettings [AlertSettings] to configure the alert dialog.
+ * @param onPositiveResponse callback to be invoked when the user clicks on the positive button.
+ * @param onNegativeResponse callback to be invoked when the user clicks on the negative button.
+ * @param onBackPressed callback to be invoked when the user performs back navigation.
+ */
+@Composable
+internal fun AlertScreen(
+    presentationStateManager: PresentationStateManager,
+    alertSettings: AlertSettings,
+    onPositiveResponse: () -> Unit,
+    onNegativeResponse: () -> Unit,
+    onBackPressed: () -> Unit
+) {
+    AnimatedVisibility(
+        visibleState = presentationStateManager.visibilityState,
+        enter = fadeIn()
+    ) {
+        AlertDialog(
+            title = {
+                Text(
+                    text = alertSettings.title,
+                    modifier = Modifier.testTag(AlertTestTags.TITLE_TEXT)
+                )
+            },
+            text = {
+                Text(
+                    text = alertSettings.message,
+                    modifier = Modifier.testTag(AlertTestTags.MESSAGE_TEXT)
+                )
+            },
+            confirmButton = {
+                alertSettings.positiveButtonText?.let { positiveButtonText ->
+                    TextButton(
+                        onClick = { onPositiveResponse() },
+                        modifier = Modifier.testTag(AlertTestTags.POSITIVE_BUTTON)
+                    ) {
+                        Text(text = positiveButtonText)
+                    }
+                }
+            },
+            dismissButton = {
+                alertSettings.negativeButtonText?.let { negativeButtonText ->
+                    TextButton(
+                        onClick = { onNegativeResponse() },
+                        modifier = Modifier.testTag(AlertTestTags.NEGATIVE_BUTTON)
+                    ) {
+                        Text(text = negativeButtonText)
+                    }
+                }
+            },
+            onDismissRequest = {
+                // Slightly roundabout way to dismiss the dialog! DialogProperties determine when a
+                // dismiss request is received. They are set to dismiss on back press and not any clicks outside.
+                // So all dismiss requests are from back press.
+                onBackPressed()
+            },
+            properties = DialogProperties(
+                dismissOnBackPress = true,
+                dismissOnClickOutside = false
+            )
+        )
+    }
+}

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/vnext/alert/views/AlertTestTags.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/vnext/alert/views/AlertTestTags.kt
@@ -1,0 +1,19 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.services.ui.vnext.alert.views
+
+internal object AlertTestTags {
+    internal const val TITLE_TEXT = "titleText"
+    internal const val MESSAGE_TEXT = "messageText"
+    internal const val POSITIVE_BUTTON = "positiveButton"
+    internal const val NEGATIVE_BUTTON = "negativeButton"
+}

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/vnext/alert/AlertSettingsTest.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/vnext/alert/AlertSettingsTest.kt
@@ -1,0 +1,78 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.services.ui.vnext.alert
+
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+import kotlin.test.fail
+
+class AlertSettingsTest {
+    companion object {
+        private const val TITLE = "title"
+        private const val MESSAGE = "message"
+        private const val POSITIVE_BUTTON_TEXT = "positiveButtonText"
+        private const val NEGATIVE_BUTTON_TEXT = "negativeButtonText"
+    }
+
+    @Test
+    fun `Test AlertSettings with happy values`() {
+        val alertSettings = AlertSettings.Builder()
+            .title(TITLE)
+            .message(MESSAGE)
+            .positiveButtonText(POSITIVE_BUTTON_TEXT)
+            .negativeButtonText(NEGATIVE_BUTTON_TEXT)
+            .build()
+        assertEquals(TITLE, alertSettings.title)
+        assertEquals(MESSAGE, alertSettings.message)
+        assertEquals(POSITIVE_BUTTON_TEXT, alertSettings.positiveButtonText)
+        assertEquals(NEGATIVE_BUTTON_TEXT, alertSettings.negativeButtonText)
+    }
+
+    @Test
+    fun `Test AlertSettings with no positive button text`() {
+        val alertSettings = AlertSettings.Builder()
+            .title(TITLE)
+            .message(MESSAGE)
+            .negativeButtonText(NEGATIVE_BUTTON_TEXT)
+            .build()
+        assertEquals(TITLE, alertSettings.title)
+        assertEquals(MESSAGE, alertSettings.message)
+        assertEquals(null, alertSettings.positiveButtonText)
+        assertEquals(NEGATIVE_BUTTON_TEXT, alertSettings.negativeButtonText)
+    }
+
+    @Test
+    fun `Test AlertSettings with no negative button text`() {
+        val alertSettings = AlertSettings.Builder()
+            .title(TITLE)
+            .message(MESSAGE)
+            .positiveButtonText(POSITIVE_BUTTON_TEXT)
+            .build()
+        assertEquals(TITLE, alertSettings.title)
+        assertEquals(MESSAGE, alertSettings.message)
+        assertEquals(POSITIVE_BUTTON_TEXT, alertSettings.positiveButtonText)
+        assertEquals(null, alertSettings.negativeButtonText)
+    }
+
+    @Test
+    fun `Test AlertSettings fails when neither buttons are provided`() {
+        try {
+            AlertSettings.Builder()
+                .title(TITLE)
+                .message(MESSAGE)
+                .build()
+            fail("Expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            assertEquals("At least one button must be defined.", e.message)
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds support for Alert UI in UIServices vNext.
- Added an Alert presentation type that accepts AlertSettings and AlertEventListener.
- AlertScreen is the visual component of the Alert.
- Add tests for settings and composable. Presentable tests will be added with all other presentable integration tests in the test app.

Note that the co-ordination between Alert and InAppMessage will be added as part of #530 

<!--- Describe your changes in detail -->

## Related Issue
#531 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
UIServices vNext needs Alert UI support. Add support using Jetpack AlertDialog.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Unit tests
- Functional Tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
