### PR TITLE
Adds support for error notifications to PresentationEventListeners

### DIFF
--- a/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/vnext/PresentationError.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/vnext/PresentationError.kt
@@ -22,3 +22,41 @@ sealed interface PresentationError
 sealed class ShowFailed(val reason: String) : PresentationError
 sealed class HideFailed(val reason: String) : PresentationError
 sealed class DismissFailed(val reason: String) : PresentationError
+
+// ---- ShowFailed types ---- //
+/**
+ * Represents a failure to show a Presentable because a conflicting presentation is already shown.
+ */
+object ConflictingPresentation : ShowFailed("Conflicting presentation is visible.")
+
+/**
+ * Represents a failure to show a Presentable because there is no activity to show it on.
+ */
+object NoAttachableActivity : ShowFailed("No attachable activity available.")
+
+/**
+ * Represents a failure to show a Presentable because the delegate gate was not met.
+ */
+object DelegateGateNotMet : ShowFailed("PresentationDelegate requirement not met.")
+
+/**
+ * Represents a failure to show a Presentable because it is already shown.
+ */
+object AlreadyShown : ShowFailed("Presentable is already being shown.")
+
+// ---- HideFailed types ---- //
+/**
+ * Represents a failure to hide a Presentable because there is no activity to hide it from.
+ */
+object AlreadyHidden : HideFailed("Presentable is already hidden.")
+
+// ---- DismissFailed types ---- //
+/**
+ * Represents a failure to dismiss a Presentable because there is no activity to dismiss it from.
+ */
+object NoActivityToDetachFrom : DismissFailed("No activity available to detach from.")
+
+/**
+ * Represents a failure to dismiss a Presentable because it is not shown.
+ */
+object AlreadyDismissed : DismissFailed("Presentable is already dismissed.")

--- a/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/vnext/PresentationError.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/vnext/PresentationError.kt
@@ -37,7 +37,7 @@ object NoAttachableActivity : ShowFailed("No attachable activity available.")
 /**
  * Represents a failure to show a Presentable because the delegate gate was not met.
  */
-object DelegateGateNotMet : ShowFailed("PresentationDelegate requirement not met.")
+object DelegateGateNotMet : ShowFailed("PresentationDelegate suppressed the presentation from being shown.")
 
 /**
  * Represents a failure to show a Presentable because it is already shown.

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/vnext/common/AEPPresentable.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/vnext/common/AEPPresentable.kt
@@ -20,6 +20,12 @@ import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.platform.ComposeView
 import com.adobe.marketing.mobile.services.Log
 import com.adobe.marketing.mobile.services.ServiceConstants
+import com.adobe.marketing.mobile.services.ui.vnext.AlreadyDismissed
+import com.adobe.marketing.mobile.services.ui.vnext.AlreadyHidden
+import com.adobe.marketing.mobile.services.ui.vnext.AlreadyShown
+import com.adobe.marketing.mobile.services.ui.vnext.DelegateGateNotMet
+import com.adobe.marketing.mobile.services.ui.vnext.NoActivityToDetachFrom
+import com.adobe.marketing.mobile.services.ui.vnext.NoAttachableActivity
 import com.adobe.marketing.mobile.services.ui.vnext.Presentable
 import com.adobe.marketing.mobile.services.ui.vnext.Presentation
 import com.adobe.marketing.mobile.services.ui.vnext.PresentationDelegate
@@ -103,6 +109,7 @@ internal abstract class AEPPresentable<T : Presentation<T>> :
                     LOG_SOURCE,
                     "Presentable is already shown. Ignoring show request."
                 )
+                presentation.listener.onError(this@AEPPresentable, AlreadyShown)
                 return@launch
             }
 
@@ -113,13 +120,17 @@ internal abstract class AEPPresentable<T : Presentation<T>> :
                     LOG_SOURCE,
                     "Current activity is null. Cannot show presentable."
                 )
+                presentation.listener.onError(this@AEPPresentable, NoAttachableActivity)
                 return@launch
             }
 
             // If all basic conditions are met, check with the delegate if the presentable can be shown
             if (gateDisplay()) { // TODO :should also include PresentationObserver gate
                 val canShow = (presentationDelegate?.canShow(this@AEPPresentable) ?: true)
-                if (!canShow) return@launch
+                if (!canShow) {
+                    presentation.listener.onError(this@AEPPresentable, DelegateGateNotMet)
+                    return@launch
+                }
             }
 
             // Show the presentable on the current activity
@@ -148,6 +159,7 @@ internal abstract class AEPPresentable<T : Presentation<T>> :
                     LOG_SOURCE,
                     "Presentable is already detached. Ignoring dismiss request."
                 )
+                presentation.listener.onError(this@AEPPresentable, AlreadyDismissed)
                 return@launch
             }
 
@@ -158,6 +170,7 @@ internal abstract class AEPPresentable<T : Presentation<T>> :
                     LOG_SOURCE,
                     "Current activity is null. Cannot dismiss presentable."
                 )
+                presentation.listener.onError(this@AEPPresentable, NoActivityToDetachFrom)
                 return@launch
             }
 
@@ -180,6 +193,7 @@ internal abstract class AEPPresentable<T : Presentation<T>> :
                     LOG_SOURCE,
                     "Presentable is already hidden. Ignoring hide request."
                 )
+                presentation.listener.onError(this@AEPPresentable, AlreadyHidden)
                 return@launch
             }
 

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/vnext/common/AEPPresentableTest.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/vnext/common/AEPPresentableTest.kt
@@ -16,7 +16,13 @@ import android.content.Context
 import android.view.ViewGroup
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.platform.ComposeView
+import com.adobe.marketing.mobile.services.ui.vnext.AlreadyDismissed
+import com.adobe.marketing.mobile.services.ui.vnext.AlreadyHidden
+import com.adobe.marketing.mobile.services.ui.vnext.AlreadyShown
+import com.adobe.marketing.mobile.services.ui.vnext.DelegateGateNotMet
 import com.adobe.marketing.mobile.services.ui.vnext.InAppMessage
+import com.adobe.marketing.mobile.services.ui.vnext.NoActivityToDetachFrom
+import com.adobe.marketing.mobile.services.ui.vnext.NoAttachableActivity
 import com.adobe.marketing.mobile.services.ui.vnext.Presentable
 import com.adobe.marketing.mobile.services.ui.vnext.PresentationDelegate
 import com.adobe.marketing.mobile.services.ui.vnext.PresentationUtilityProvider
@@ -150,6 +156,9 @@ internal class AEPPresentableTest {
             // verify that the presentation delegate is called because display is gated
             verify(mockPresentationDelegate).canShow(aepPresentableWithGatedDisplay)
 
+            // verify that the listener is notified of the error
+            verify(mockPresentationListener).onError(aepPresentableWithGatedDisplay, DelegateGateNotMet)
+
             // verify that the lifecycle provider is called to register the listener
             verify(mockAppLifecycleProvider, never()).registerListener(
                 aepPresentableWithGatedDisplay
@@ -250,6 +259,9 @@ internal class AEPPresentableTest {
             // verify that the listener, delegate, and state manager are never notified of anything
             verify(mockPresentationListener, never()).onShow(aepPresentableWithGatedDisplay)
             verify(mockPresentationStateManager, never()).onShown()
+
+            // verify that the listener is notified of the error
+            verify(mockPresentationListener).onError(aepPresentableWithGatedDisplay, AlreadyShown)
         }
     }
 
@@ -312,6 +324,9 @@ internal class AEPPresentableTest {
         // simulate a null activity being the current activity
         `when`(mockPresentationUtilityProvider.getCurrentActivity()).thenReturn(null)
 
+        // simulate DETACHED state when show is called
+        `when`(mockPresentationStateManager.presentableState).thenReturn(mutableStateOf(Presentable.State.DETACHED))
+
         runTest {
             // test
             aepPresentableWithGatedDisplay.show()
@@ -324,10 +339,13 @@ internal class AEPPresentableTest {
             // verify that the presentation delegate is never queried
             verify(mockPresentationDelegate, never()).canShow(aepPresentableWithGatedDisplay)
 
-            // verify that the listener, delegate, and state manager are never notified of anything
+            // verify that the listener, delegate, and state manager are never notified of show
             verify(mockPresentationListener, never()).onShow(aepPresentableWithGatedDisplay)
             verify(mockPresentationDelegate, never()).onShow(aepPresentableWithGatedDisplay)
             verify(mockPresentationStateManager, never()).onShown()
+
+            // verify that the listener is notified of the error
+            verify(mockPresentationListener).onError(aepPresentableWithGatedDisplay, NoAttachableActivity)
         }
     }
 
@@ -346,6 +364,9 @@ internal class AEPPresentableTest {
         // simulate a null activity being the current activity
         `when`(mockPresentationUtilityProvider.getCurrentActivity()).thenReturn(null)
 
+        // simulate VISIBLE state when show is called
+        `when`(mockPresentationStateManager.presentableState).thenReturn(mutableStateOf(Presentable.State.VISIBLE))
+
         runTest {
             // test
             aepPresentableWithGatedDisplay.dismiss()
@@ -353,10 +374,13 @@ internal class AEPPresentableTest {
             // verify that the lifecycle provider listener is unregistered
             verify(mockAppLifecycleProvider).unregisterListener(aepPresentableWithGatedDisplay)
 
-            // verify that the listener, delegate, and state manager are never notified of anything
+            // verify that the listener, delegate, and state manager are never notified of any dismissal
             verify(mockPresentationListener, never()).onDismiss(aepPresentableWithGatedDisplay)
             verify(mockPresentationDelegate, never()).onDismiss(aepPresentableWithGatedDisplay)
             verify(mockPresentationStateManager, never()).onDetached()
+
+            // verify that the listener is notified of the error
+            verify(mockPresentationListener).onError(aepPresentableWithGatedDisplay, NoActivityToDetachFrom)
         }
     }
 
@@ -474,10 +498,13 @@ internal class AEPPresentableTest {
             // verify that viewgroup is never altered
             verify(mockViewGroup, never()).removeView(mockComposeView)
 
-            // verify that the listener, delegate, and state manager are not notified of anything
+            // verify that the listener, delegate, and state manager are not notified of dismissal
             verify(mockPresentationListener, never()).onDismiss(aepPresentableWithGatedDisplay)
             verify(mockPresentationDelegate, never()).onDismiss(aepPresentableWithGatedDisplay)
             verify(mockPresentationStateManager, never()).onDetached()
+
+            // verify that the listener is notified of the error
+            verify(mockPresentationListener).onError(aepPresentableWithGatedDisplay, AlreadyDismissed)
         }
     }
 
@@ -507,6 +534,9 @@ internal class AEPPresentableTest {
             verify(mockPresentationListener, never()).onHide(aepPresentableWithGatedDisplay)
             verify(mockPresentationDelegate, never()).onHide(aepPresentableWithGatedDisplay)
             verify(mockPresentationStateManager, never()).onHidden()
+
+            // verify that the listener is notified of the error
+            verify(mockPresentationListener).onError(aepPresentableWithGatedDisplay, AlreadyHidden)
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Presentable operations can fail due to a few reasons. The PresentationEventListeners should be notified when these cases arise. This PR adds support for error notifications.
Add ShowFailed, HideFailed, DismissFailed error types and invoke listeners where appropriate.

<!--- Describe your changes in detail -->

## Related Issue
#534 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
