### PR TITLE
Fix circular link b/w ServiceProvider and UriService

### DIFF
--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/uri/UriService.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/uri/UriService.kt
@@ -14,7 +14,6 @@ package com.adobe.marketing.mobile.services.uri
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
-import androidx.annotation.VisibleForTesting
 import com.adobe.marketing.mobile.services.Log
 import com.adobe.marketing.mobile.services.ServiceConstants
 import com.adobe.marketing.mobile.services.ServiceProvider
@@ -27,15 +26,7 @@ class UriService : UriOpening {
         private const val LOG_TAG = "UriService"
     }
 
-    private val serviceProvider: ServiceProvider
     private var uriHandler: URIHandler? = null
-
-    constructor() : this(ServiceProvider.getInstance())
-
-    @VisibleForTesting
-    constructor(serviceProvider: ServiceProvider) {
-        this.serviceProvider = serviceProvider
-    }
 
     override fun openUri(uri: String): Boolean {
         if (uri.isNullOrBlank()) {
@@ -43,7 +34,7 @@ class UriService : UriOpening {
             return false
         }
 
-        val currentActivity: Activity = serviceProvider.appContextService.currentActivity
+        val currentActivity: Activity = ServiceProvider.getInstance().appContextService.currentActivity
             ?: kotlin.run {
                 Log.debug(ServiceConstants.LOG_TAG, LOG_TAG, "Cannot open URI: $uri. No current activity found.")
                 return false

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/uri/UriServiceTest.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/uri/UriServiceTest.kt
@@ -17,9 +17,12 @@ import com.adobe.marketing.mobile.services.AppContextService
 import com.adobe.marketing.mobile.services.ServiceProvider
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.MockedStatic
+import org.mockito.Mockito
 import org.mockito.Mockito.any
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
@@ -37,6 +40,8 @@ class UriServiceTest {
     @Mock
     private lateinit var mockServiceProvider: ServiceProvider
 
+    private lateinit var mockedStaticServiceProvider: MockedStatic<ServiceProvider>
+
     @Mock
     private lateinit var mockAppContextService: AppContextService
 
@@ -46,9 +51,11 @@ class UriServiceTest {
     @Before
     fun setUp() {
         MockitoAnnotations.openMocks(this)
+        mockedStaticServiceProvider = Mockito.mockStatic(ServiceProvider::class.java)
+        mockedStaticServiceProvider.`when`<Any> { ServiceProvider.getInstance() }.thenReturn(mockServiceProvider)
 
         `when`(mockServiceProvider.appContextService).thenReturn(mockAppContextService)
-        uriService = UriService(mockServiceProvider)
+        uriService = UriService()
     }
 
     @Test
@@ -137,5 +144,10 @@ class UriServiceTest {
         // verify
         assertTrue(result)
         verify(mockCurrentActivity).startActivity(any<Intent>())
+    }
+
+    @After
+    fun tearDown() {
+        mockedStaticServiceProvider.close()
     }
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
ServiceProvider instantiates UriService but UriService also currently needs ServiceProvider to get AppContextService.
Fix curcularity by using ServiceProvider on demand in UriService instead of a member variable.
<!--- Describe your changes in detail -->

## Related Issue
N/A
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
ServiceProvider instantiates UriService but UriService also currently needs ServiceProvider to get AppContextService.

Fix curcularity by using ServiceProvider on demand in UriService instead of a member variable.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Unit test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
