### PR TITLE
Ensure resources are closed after use in StreamUtils

### DIFF
--- a/code/core/src/main/java/com/adobe/marketing/mobile/util/StreamUtils.java
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/util/StreamUtils.java
@@ -26,7 +26,8 @@ public final class StreamUtils {
     private StreamUtils() {}
 
     /**
-     * Reads the contents of {@code InputStream} as String
+     * Reads the contents of the {@code InputStream} as a String. The input stream provided will be
+     * closed after contents are read.
      *
      * @param inputStream {@link InputStream} to read
      * @return {@link String} representation of the input stream

--- a/code/core/src/main/java/com/adobe/marketing/mobile/util/StreamUtils.java
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/util/StreamUtils.java
@@ -36,11 +36,9 @@ public final class StreamUtils {
             return null;
         }
 
-        final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        final byte[] data = new byte[STREAM_READ_BUFFER_SIZE];
-        int bytesRead;
-
-        try {
+        try (final ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
+            final byte[] data = new byte[STREAM_READ_BUFFER_SIZE];
+            int bytesRead;
             while ((bytesRead = inputStream.read(data, 0, data.length)) != -1) {
                 buffer.write(data, 0, bytesRead);
             }
@@ -53,6 +51,15 @@ public final class StreamUtils {
                     TAG,
                     "Unable to convert InputStream to String," + ex.getLocalizedMessage());
             return null;
+        } finally {
+            try {
+                inputStream.close();
+            } catch (final IOException ex) {
+                Log.trace(
+                        CoreConstants.LOG_TAG,
+                        TAG,
+                        "Unable to close InputStream," + ex.getLocalizedMessage());
+            }
         }
     }
 }

--- a/code/core/src/test/java/com/adobe/marketing/mobile/util/StreamUtilsTests.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/util/StreamUtilsTests.java
@@ -11,12 +11,20 @@
 
 package com.adobe.marketing.mobile.util;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.adobe.marketing.mobile.TestHelper;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public final class StreamUtilsTests {
 
@@ -38,5 +46,14 @@ public final class StreamUtilsTests {
     public void testStreamToString_when_validInputStream() throws Exception {
         InputStream stream = new ByteArrayInputStream("myTestExample".getBytes("UTF-8"));
         assertEquals("myTestExample", StreamUtils.readAsString(stream));
+    }
+
+    @Test
+    public void testStreamUtilsClosesStream_when_invalidInputStream() throws Exception {
+        InputStream stream = Mockito.mock(InputStream.class);
+        when(stream.read(any(), anyInt(), anyInt()))
+                .thenThrow(new IOException("Mocked IO Exception"));
+        assertNull(StreamUtils.readAsString(stream));
+        verify(stream).close();
     }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
`StreamUtils.readAsString()` does not close the input and output streams after reading them resulting in a resource violation in StrictMode when processing downloaded Configuration. Ensure that the resources are wrapped in try with resource block and a finally block as appropriate.

<!--- Describe your changes in detail -->

## Related Issue
#571 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
`StreamUtils.readAsString()` does not close the input and output streams after reading them resulting in a resource violation in StrictMode. Ensure that the resources are wrapped in try with resource block and a finally block as appropriate.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Manual test
   - Enable strict mode in testapp-kotlin  with process death penalty and do a fresh install run and a re-launch of the app to verify that process does not crash.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
