### PR TITLE
PLATIR-33369: Resolve MessageFragment crash

### DIFF
--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageFragment.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageFragment.java
@@ -136,6 +136,16 @@ public class MessageFragment extends android.app.DialogFragment implements View.
         super.onCreate(savedInstanceState);
         setRetainInstance(true);
 
+        // make sure we have a valid message before trying to proceed
+        if (message == null) {
+            Log.debug(
+                    ServiceConstants.LOG_TAG,
+                    TAG,
+                    "%s (Message Fragment), failed to create the fragment.",
+                    UNEXPECTED_NULL_VALUE);
+            return;
+        }
+
         final MessageSettings messageSettings = message.getMessageSettings();
         if (messageSettings == null) {
             Log.debug(
@@ -204,6 +214,16 @@ public class MessageFragment extends android.app.DialogFragment implements View.
         }
 
         removeListeners();
+
+        // make sure we have a valid message before trying to proceed
+        if (message == null) {
+            Log.debug(
+                    ServiceConstants.LOG_TAG,
+                    TAG,
+                    "%s (Message Fragment), failed to detach the fragment.",
+                    UNEXPECTED_NULL_VALUE);
+            return;
+        }
 
         // clean webview parent in case the detach is occurring due to an orientation change
         final WebView webView = message.getWebView();
@@ -297,6 +317,15 @@ public class MessageFragment extends android.app.DialogFragment implements View.
      * android.view.View.OnTouchListener}
      */
     private void addListeners() {
+        if (message == null) {
+            Log.debug(
+                    ServiceConstants.LOG_TAG,
+                    TAG,
+                    "%s (AEPMessage), unable to add listeners.",
+                    UNEXPECTED_NULL_VALUE);
+            return;
+        }
+
         final View contentView = getActivity().findViewById(android.R.id.content);
 
         // if we have an orientation change, wait for it to complete then proceed with webview


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Resolves a crash reported in PLATIR-33369. To fix the crash, null checks have been added to verify that the message object is non null before accessing member methods.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
