### PR TITLE
Fix UI takeover behavior

### DIFF
--- a/code/core/api/core.api
+++ b/code/core/api/core.api
@@ -910,6 +910,7 @@ public class com/adobe/marketing/mobile/services/ui/MessageFragment : android/ap
 	public fun onActivityCreated (Landroid/os/Bundle;)V
 	public fun onAttach (Landroid/content/Context;)V
 	public fun onCreate (Landroid/os/Bundle;)V
+	public fun onCreateDialog (Landroid/os/Bundle;)Landroid/app/Dialog;
 	public fun onDestroyView ()V
 	public fun onDetach ()V
 	public fun onTouch (Landroid/view/View;Landroid/view/MotionEvent;)Z

--- a/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/MessageSettings.java
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/MessageSettings.java
@@ -65,7 +65,7 @@ public class MessageSettings {
         SWIPE_DOWN("swipeDown"),
         SWIPE_LEFT("swipeLeft"),
         SWIPE_RIGHT("swipeRight"),
-        BACKGROUND_TAP("backgroundTap");
+        BACKGROUND_TAP("tapBackground");
 
         private String name;
         private static final Map<String, MessageGesture> gestureStringToGestureEnumMap;

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageFragment.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageFragment.java
@@ -210,30 +210,28 @@ public class MessageFragment extends android.app.DialogFragment implements View.
                 if (!uiTakeoverEnabled) {
                     // only log action up or down events as this logging can get quite
                     // spammy
-                    if (motionEvent.getAction() == MotionEvent.ACTION_DOWN
-                            || motionEvent.getAction() == MotionEvent.ACTION_UP) {
+                    if (motionEvent.getAction() == MotionEvent.ACTION_UP) {
                         Log.trace(
                                 ServiceConstants.LOG_TAG,
                                 TAG,
-                                "UI takeover is false, passing the %s event to the parent"
-                                        + " activity.",
-                                MotionEvent.actionToString(motionEvent.getAction()));
+                                "UI takeover is false, passing the touch event to the parent"
+                                        + " activity.");
                     }
-                    parentActivity.dispatchTouchEvent(motionEvent);
-                    return false;
+                    return parentActivity.dispatchTouchEvent(motionEvent);
+                } else {
+                    // load any behavior url strings on action up only as a touch consists of
+                    // two motion events: an action down and an action up event
+                    if (motionEvent.getAction() == MotionEvent.ACTION_UP) {
+                        Log.trace(
+                                ServiceConstants.LOG_TAG,
+                                TAG,
+                                "UI takeover is true, parent activity UI is inaccessible."
+                                        + " Processing defined background tap behaviors.");
+                        webViewGestureListener.handleGesture(MessageGesture.BACKGROUND_TAP);
+                        return true;
+                    }
                 }
-
-                // load any behavior url strings on action up only as a touch consists of
-                // two motion events: an action down and an action up event
-                if (motionEvent.getAction() == MotionEvent.ACTION_UP) {
-                    Log.trace(
-                            ServiceConstants.LOG_TAG,
-                            TAG,
-                            "UI takeover is true, parent activity UI is inaccessible. Processing"
-                                    + " defined background tap behaviors.");
-                    webViewGestureListener.handleGesture(MessageGesture.BACKGROUND_TAP);
-                }
-                return false;
+                return super.onTouchEvent(motionEvent);
             }
         };
     }

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageFragment.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageFragment.java
@@ -208,7 +208,8 @@ public class MessageFragment extends android.app.DialogFragment implements View.
             @Override
             public boolean onTouchEvent(@NonNull final MotionEvent motionEvent) {
                 if (!uiTakeoverEnabled) {
-                    // only log action up or down events as this logging can get quite spammy
+                    // only log action up or down events as this logging can get quite
+                    // spammy
                     if (motionEvent.getAction() == MotionEvent.ACTION_DOWN
                             || motionEvent.getAction() == MotionEvent.ACTION_UP) {
                         Log.trace(
@@ -219,8 +220,15 @@ public class MessageFragment extends android.app.DialogFragment implements View.
                                 MotionEvent.actionToString(motionEvent.getAction()));
                     }
                     parentActivity.dispatchTouchEvent(motionEvent);
+                    return false;
                 }
-                return super.onTouchEvent(motionEvent);
+
+                // load any behavior url strings on action up only as a touch consists of
+                // two motion events: an action down and an action up event
+                if (motionEvent.getAction() == MotionEvent.ACTION_UP) {
+                    webViewGestureListener.handleGesture(MessageGesture.BACKGROUND_TAP);
+                }
+                return false;
             }
         };
     }

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageFragment.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageFragment.java
@@ -226,6 +226,11 @@ public class MessageFragment extends android.app.DialogFragment implements View.
                 // load any behavior url strings on action up only as a touch consists of
                 // two motion events: an action down and an action up event
                 if (motionEvent.getAction() == MotionEvent.ACTION_UP) {
+                    Log.trace(
+                            ServiceConstants.LOG_TAG,
+                            TAG,
+                            "UI takeover is true, parent activity UI is inaccessible. Processing"
+                                    + " defined background tap behaviors.");
                     webViewGestureListener.handleGesture(MessageGesture.BACKGROUND_TAP);
                 }
                 return false;

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageFragment.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageFragment.java
@@ -11,6 +11,7 @@
 
 package com.adobe.marketing.mobile.services.ui;
 
+import android.app.Activity;
 import android.app.Dialog;
 import android.app.FragmentTransaction;
 import android.content.Context;
@@ -25,6 +26,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.WebView;
 import android.widget.FrameLayout;
+import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import androidx.cardview.widget.CardView;
 import androidx.fragment.app.DialogFragment;
@@ -172,7 +174,55 @@ public class MessageFragment extends android.app.DialogFragment implements View.
                                 .getApplicationContext(),
                         webViewGestureListener);
 
-        setStyle(DialogFragment.STYLE_NORMAL, android.R.style.Theme_Translucent_NoTitleBar);
+        setStyle(DialogFragment.STYLE_NO_FRAME, android.R.style.Theme_Translucent_NoTitleBar);
+    }
+
+    @Override
+    public Dialog onCreateDialog(final Bundle savedInstanceState) {
+        final Activity parentActivity = getActivity();
+        final int fragmentTheme = getTheme();
+        final Dialog defaultDialog = super.onCreateDialog(savedInstanceState);
+
+        if (parentActivity == null || message == null) {
+            Log.trace(
+                    ServiceConstants.LOG_TAG,
+                    TAG,
+                    "%s (%s), returning a default Dialog object.",
+                    parentActivity == null ? "Parent Activity" : "Message",
+                    UNEXPECTED_NULL_VALUE);
+            return defaultDialog;
+        }
+
+        final MessageSettings messageSettings = message.getMessageSettings();
+        if (messageSettings == null) {
+            Log.trace(
+                    ServiceConstants.LOG_TAG,
+                    TAG,
+                    "%s (MessageSettings), returning a default Dialog object.",
+                    UNEXPECTED_NULL_VALUE);
+            return defaultDialog;
+        }
+
+        final boolean uiTakeoverEnabled = messageSettings.getUITakeover();
+        return new Dialog(parentActivity, fragmentTheme) {
+            @Override
+            public boolean onTouchEvent(@NonNull final MotionEvent motionEvent) {
+                if (!uiTakeoverEnabled) {
+                    // only log action up or down events as this logging can get quite spammy
+                    if (motionEvent.getAction() == MotionEvent.ACTION_DOWN
+                            || motionEvent.getAction() == MotionEvent.ACTION_UP) {
+                        Log.trace(
+                                ServiceConstants.LOG_TAG,
+                                TAG,
+                                "UI takeover is false, passing the %s event to the parent"
+                                        + " activity.",
+                                MotionEvent.actionToString(motionEvent.getAction()));
+                    }
+                    parentActivity.dispatchTouchEvent(motionEvent);
+                }
+                return super.onTouchEvent(motionEvent);
+            }
+        };
     }
 
     @Override
@@ -234,13 +284,14 @@ public class MessageFragment extends android.app.DialogFragment implements View.
 
     @Override
     public boolean onTouch(final View view, final MotionEvent motionEvent) {
+        final String viewName = view.getClass().getSimpleName();
         if (message == null) {
             Log.debug(
                     ServiceConstants.LOG_TAG,
                     TAG,
                     "%s (AEPMessage), unable to handle the touch event on %s.",
                     UNEXPECTED_NULL_VALUE,
-                    view.getClass().getSimpleName());
+                    viewName);
             return true;
         }
 
@@ -251,7 +302,7 @@ public class MessageFragment extends android.app.DialogFragment implements View.
                     TAG,
                     "%s (WebView), unable to handle the touch event on %s.",
                     UNEXPECTED_NULL_VALUE,
-                    view.getClass().getSimpleName());
+                    viewName);
             return true;
         }
 
@@ -263,36 +314,6 @@ public class MessageFragment extends android.app.DialogFragment implements View.
                     "%s (MessageSettings), unable to handle the touch event on %s.",
                     UNEXPECTED_NULL_VALUE,
                     view.getClass().getSimpleName());
-            return true;
-        }
-
-        final int motionEventAction = motionEvent.getAction();
-
-        // determine if the tap occurred outside the webview
-        if ((motionEventAction == MotionEvent.ACTION_DOWN
-                        || motionEventAction == MotionEvent.ACTION_BUTTON_PRESS)
-                && view.getId() != webView.getId()) {
-            Log.trace(
-                    ServiceConstants.LOG_TAG,
-                    TAG,
-                    "Detected tap on %s",
-                    view.getClass().getSimpleName());
-
-            final boolean uiTakeoverEnabled = messageSettings.getUITakeover();
-
-            // if ui takeover is false, dismiss the message
-            if (!uiTakeoverEnabled) {
-                Log.trace(
-                        ServiceConstants.LOG_TAG,
-                        TAG,
-                        "UI takeover is false, dismissing the message.");
-                webViewGestureListener.handleGesture(MessageGesture.BACKGROUND_TAP);
-                // perform the tap to allow interaction with ui elements outside the webview
-                return view.onTouchEvent(motionEvent);
-            }
-
-            // ui takeover is true, consume the tap and ignore it
-            Log.trace(ServiceConstants.LOG_TAG, TAG, "UI takeover is true, ignoring the tap.");
             return true;
         }
 
@@ -343,10 +364,6 @@ public class MessageFragment extends android.app.DialogFragment implements View.
 
         final Dialog dialog = getDialog();
         if (dialog != null) {
-            // set this fragment onTouchListener to dismiss the IAM if a touch occurs on the decor
-            // view
-            dialog.getWindow().getDecorView().setOnTouchListener(this);
-
             // handle on back pressed to dismiss the message
             dialog.setOnKeyListener(
                     (dialogInterface, keyCode, event) -> {
@@ -368,7 +385,6 @@ public class MessageFragment extends android.app.DialogFragment implements View.
 
         final Dialog dialog = getDialog();
         if (dialog != null) {
-            dialog.getWindow().getDecorView().setOnTouchListener(null);
             dialog.setOnKeyListener(null);
         }
     }
@@ -392,6 +408,16 @@ public class MessageFragment extends android.app.DialogFragment implements View.
                     TAG,
                     "%s (Message Settings), unable to apply backdrop color.",
                     UNEXPECTED_NULL_VALUE);
+            return;
+        }
+
+        final boolean uiTakeoverEnabled = messageSettings.getUITakeover();
+        // we don't want to dim the background if ui takeover is disabled
+        if (!uiTakeoverEnabled) {
+            Log.trace(
+                    ServiceConstants.LOG_TAG,
+                    TAG,
+                    "Not applying background alpha, ui takeover is disabled.");
             return;
         }
 

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageFragment.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/MessageFragment.java
@@ -321,7 +321,7 @@ public class MessageFragment extends android.app.DialogFragment implements View.
                     TAG,
                     "%s (MessageSettings), unable to handle the touch event on %s.",
                     UNEXPECTED_NULL_VALUE,
-                    view.getClass().getSimpleName());
+                    viewName);
             return true;
         }
 

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/WebViewGestureListener.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/WebViewGestureListener.java
@@ -155,8 +155,10 @@ class WebViewGestureListener extends GestureDetector.SimpleOnGestureListener {
                 break;
             case BACKGROUND_TAP:
                 animation = null;
-                // we are handling a background tap. handle the background tap interaction event
+                // we are handling a background tap. handle the background tap interaction behavior
                 // specified (if any).
+                // if we have no defined background tap behavior then we do not want to dismiss the
+                // message.
                 final String behavior =
                         parentFragment.gestures == null
                                 ? null

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/WebViewGestureListener.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/WebViewGestureListener.java
@@ -113,9 +113,10 @@ class WebViewGestureListener extends GestureDetector.SimpleOnGestureListener {
     }
 
     /**
-     * Generates a dismiss animation using the {@link ObjectAnimator}. The {@link
+     * Generates a dismiss animation if needed using the {@link ObjectAnimator}. The {@link
      * androidx.cardview.widget.CardView} frame will be dismissed at the direction of the detected
-     * swipe {@link MessageGesture}.
+     * swipe {@link MessageGesture}. Background tap gestures will not dismiss the message but any
+     * associated behavior will be
      *
      * @param gesture The detected swipe {@code MessageGesture} that occurred.
      */
@@ -152,7 +153,19 @@ class WebViewGestureListener extends GestureDetector.SimpleOnGestureListener {
                                 webViewFrame.getTop(),
                                 -message.parentViewHeight);
                 break;
-            default: // default, dismiss to bottom if not a background tap
+            case BACKGROUND_TAP:
+                animation = null;
+                // we are handling a background tap. handle the background tap interaction event
+                // specified (if any).
+                final String behavior =
+                        parentFragment.gestures == null
+                                ? null
+                                : parentFragment.gestures.get(gesture);
+                if (!StringUtils.isNullOrEmpty(behavior)) {
+                    message.listener.overrideUrlLoad(message, behavior);
+                }
+                break;
+            default: // default, dismiss to bottom
                 animation =
                         ObjectAnimator.ofFloat(
                                 webViewFrame, "y", webViewFrame.getTop(), message.parentViewHeight);

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/WebViewGestureListener.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/WebViewGestureListener.java
@@ -19,7 +19,6 @@ import android.webkit.WebView;
 import androidx.cardview.widget.CardView;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.services.ServiceConstants;
-import com.adobe.marketing.mobile.services.ui.MessageSettings.MessageAnimation;
 import com.adobe.marketing.mobile.services.ui.MessageSettings.MessageGesture;
 import com.adobe.marketing.mobile.util.StringUtils;
 
@@ -116,22 +115,12 @@ class WebViewGestureListener extends GestureDetector.SimpleOnGestureListener {
     /**
      * Generates a dismiss animation using the {@link ObjectAnimator}. The {@link
      * androidx.cardview.widget.CardView} frame will be dismissed at the direction of the detected
-     * swipe {@link MessageGesture}. If the in-app message was dismissed via a {@code
-     * MessageGesture.BACKGROUND_TAP} then the {@code CardView} will be dismissed using the
-     * dismissal {@link MessageAnimation} specified in the {@link MessageSettings}.
+     * swipe {@link MessageGesture}.
      *
      * @param gesture The detected swipe {@code MessageGesture} that occurred.
      */
     public void handleGesture(final MessageGesture gesture) {
-        if (gesture.equals(MessageSettings.MessageGesture.BACKGROUND_TAP)) {
-            // we are handling a background tap. message will be dismissed via the dismiss animation
-            // specified in the MessageSettings.
-            dismissMessage(gesture, false);
-            return;
-        }
-
         final AEPMessage message = parentFragment.getAEPMessage();
-
         if (message == null) {
             Log.debug(
                     ServiceConstants.LOG_TAG,

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/MessageFragmentTests.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/MessageFragmentTests.java
@@ -148,47 +148,4 @@ public class MessageFragmentTests {
                         ArgumentMatchers.any(AEPMessage.class), ArgumentMatchers.anyString());
         Assert.assertTrue(eventProcessed);
     }
-
-    @Test
-    public void
-            testOnTouchListener_TouchOccurredOutsideWebview_And_UITakeoverFalse_ThenMessageDismissed() {
-        // setup
-        messageFragment.webViewGestureListener = mockWebViewGestureListener;
-        messageFragment.gestureDetector = mockGestureDetector;
-        Mockito.when(mockAEPMessageSettings.getUITakeover()).thenReturn(false);
-        Mockito.when(mockWebView.getId()).thenReturn(12345);
-        Mockito.when(mockViewGroup.getId()).thenReturn(67890);
-        Mockito.when(mockAEPMessage.getWebView()).thenReturn(mockWebView);
-        // call onCreate to setup the gestures
-        messageFragment.onCreate(mockSavedInstanceState);
-        // test
-        boolean eventProcessed = messageFragment.onTouch(mockViewGroup, mockMotionEvent);
-        // verify
-        Mockito.verify(mockFullscreenMessageDelegate, Mockito.times(1))
-                .overrideUrlLoad(
-                        ArgumentMatchers.any(AEPMessage.class), ArgumentMatchers.anyString());
-        // expect false because the touch event was handled by the rootview
-        Assert.assertFalse(eventProcessed);
-    }
-
-    @Test
-    public void
-            testOnTouchListener_TouchOccurredOutsideWebview_And_UITakeoverTrue_ThenMessageNotDismissed() {
-        // setup
-        messageFragment.webViewGestureListener = mockWebViewGestureListener;
-        messageFragment.gestureDetector = mockGestureDetector;
-        Mockito.when(mockAEPMessageSettings.getUITakeover()).thenReturn(true);
-        Mockito.when(mockWebView.getId()).thenReturn(12345);
-        Mockito.when(mockViewGroup.getId()).thenReturn(67890);
-        Mockito.when(mockAEPMessage.getWebView()).thenReturn(mockWebView);
-        // call onCreate to setup the gestures
-        messageFragment.onCreate(mockSavedInstanceState);
-        // test
-        boolean eventProcessed = messageFragment.onTouch(mockViewGroup, mockMotionEvent);
-        // verify
-        Mockito.verify(mockFullscreenMessageDelegate, Mockito.times(0))
-                .overrideUrlLoad(
-                        ArgumentMatchers.any(AEPMessage.class), ArgumentMatchers.anyString());
-        Assert.assertTrue(eventProcessed);
-    }
 }

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/WebViewGestureListenerTests.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/WebViewGestureListenerTests.java
@@ -246,4 +246,40 @@ public class WebViewGestureListenerTests {
                 .overrideUrlLoad(
                         ArgumentMatchers.any(AEPMessage.class), ArgumentMatchers.anyString());
     }
+
+    @Test
+    public void
+            testHandleGesture_BackgroundTap_BackgroundTapBehaviorDefined_Then_MessageDismissed() {
+        // setup
+        Mockito.when(mockMotionEvent.getX()).thenReturn(0f);
+        Mockito.when(mockMotionEvent2.getX()).thenReturn(0f);
+        Mockito.when(mockMotionEvent.getY()).thenReturn(0f);
+        Mockito.when(mockMotionEvent2.getY()).thenReturn(-300.0f);
+        // test
+        gestureListener.handleGesture(MessageGesture.BACKGROUND_TAP);
+        // verify
+        Assert.assertFalse(mockMessageFragment.isDismissedWithGesture());
+        Mockito.verify(mockFullscreenMessageDelegate, Mockito.times(1))
+                .overrideUrlLoad(
+                        ArgumentMatchers.any(AEPMessage.class), ArgumentMatchers.anyString());
+    }
+
+    @Test
+    public void
+            testHandleGesture_BackgroundTap_BackgroundTapBehaviorNotDefined_Then_MessageNotDismissed() {
+        // setup
+        gestureMap.remove(MessageGesture.BACKGROUND_TAP);
+        mockMessageFragment.gestures = gestureMap;
+        Mockito.when(mockMotionEvent.getX()).thenReturn(0f);
+        Mockito.when(mockMotionEvent2.getX()).thenReturn(0f);
+        Mockito.when(mockMotionEvent.getY()).thenReturn(0f);
+        Mockito.when(mockMotionEvent2.getY()).thenReturn(-300.0f);
+        // test
+        gestureListener.handleGesture(MessageGesture.BACKGROUND_TAP);
+        // verify
+        Assert.assertFalse(mockMessageFragment.isDismissedWithGesture());
+        Mockito.verify(mockFullscreenMessageDelegate, Mockito.times(0))
+                .overrideUrlLoad(
+                        ArgumentMatchers.any(AEPMessage.class), ArgumentMatchers.anyString());
+    }
 }

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/WebViewGestureListenerTests.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/WebViewGestureListenerTests.java
@@ -246,20 +246,4 @@ public class WebViewGestureListenerTests {
                 .overrideUrlLoad(
                         ArgumentMatchers.any(AEPMessage.class), ArgumentMatchers.anyString());
     }
-
-    @Test
-    public void testHandleGesture_BackgroundTap_Then_MessageDismissed() {
-        // setup
-        Mockito.when(mockMotionEvent.getX()).thenReturn(0f);
-        Mockito.when(mockMotionEvent2.getX()).thenReturn(0f);
-        Mockito.when(mockMotionEvent.getY()).thenReturn(0f);
-        Mockito.when(mockMotionEvent2.getY()).thenReturn(-300.0f);
-        // test
-        gestureListener.handleGesture(MessageGesture.BACKGROUND_TAP);
-        // verify
-        Assert.assertFalse(mockMessageFragment.isDismissedWithGesture());
-        Mockito.verify(mockFullscreenMessageDelegate, Mockito.times(1))
-                .overrideUrlLoad(
-                        ArgumentMatchers.any(AEPMessage.class), ArgumentMatchers.anyString());
-    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The UI takeover setting was incorrectly implemented on Android. If UI takeover is disabled, taps occurring outside of the in-app webview were dismissing the message. This pr updates the behavior to allow the taps to interact with the underlying app UI if UI takeover is disabled. Additionally, the decor view background will not be dimmed.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
