### PR TITLE
Rename backgroundTap to tapBackground in MessageGesture enum

### DIFF
--- a/code/core/api/core.api
+++ b/code/core/api/core.api
@@ -1030,11 +1030,11 @@ public final class com/adobe/marketing/mobile/services/ui/message/InAppMessageSe
 }
 
 public final class com/adobe/marketing/mobile/services/ui/message/InAppMessageSettings$MessageGesture : java/lang/Enum {
-	public static final field BACKGROUND_TAP Lcom/adobe/marketing/mobile/services/ui/message/InAppMessageSettings$MessageGesture;
 	public static final field SWIPE_DOWN Lcom/adobe/marketing/mobile/services/ui/message/InAppMessageSettings$MessageGesture;
 	public static final field SWIPE_LEFT Lcom/adobe/marketing/mobile/services/ui/message/InAppMessageSettings$MessageGesture;
 	public static final field SWIPE_RIGHT Lcom/adobe/marketing/mobile/services/ui/message/InAppMessageSettings$MessageGesture;
 	public static final field SWIPE_UP Lcom/adobe/marketing/mobile/services/ui/message/InAppMessageSettings$MessageGesture;
+	public static final field TAP_BACKGROUND Lcom/adobe/marketing/mobile/services/ui/message/InAppMessageSettings$MessageGesture;
 	public static fun valueOf (Ljava/lang/String;)Lcom/adobe/marketing/mobile/services/ui/message/InAppMessageSettings$MessageGesture;
 	public static fun values ()[Lcom/adobe/marketing/mobile/services/ui/message/InAppMessageSettings$MessageGesture;
 }

--- a/code/core/src/androidTest/java/com/adobe/marketing/mobile/services/ui/message/views/MessageScreenTests.kt
+++ b/code/core/src/androidTest/java/com/adobe/marketing/mobile/services/ui/message/views/MessageScreenTests.kt
@@ -44,7 +44,7 @@ class MessageScreenTests {
         "swipeUp" to "adbinapp://dismiss",
         "swipeRight" to "adbinapp://dismiss",
         "swipeLeft" to "adbinapp://dismiss",
-        "backgroundTap" to "adbinapp://dismiss"
+        "tapBackground" to "adbinapp://dismiss"
     )
 
     private val HTML_TEXT_SAMPLE = "<html>\n" +
@@ -312,7 +312,7 @@ class MessageScreenTests {
         assertTrue(onCreatedCalled)
         assertFalse(onDisposedCalled)
         assertFalse(onBackPressed)
-        assertTrue(detectedGestures.contains(InAppMessageSettings.MessageGesture.BACKGROUND_TAP))
+        assertTrue(detectedGestures.contains(InAppMessageSettings.MessageGesture.TAP_BACKGROUND))
         assertFalse(detectedGestures.contains(InAppMessageSettings.MessageGesture.SWIPE_DOWN))
     }
 

--- a/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/message/InAppMessageSettings.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/message/InAppMessageSettings.kt
@@ -65,7 +65,7 @@ class InAppMessageSettings private constructor(
         SWIPE_DOWN("swipeDown"),
         SWIPE_LEFT("swipeLeft"),
         SWIPE_RIGHT("swipeRight"),
-        BACKGROUND_TAP("backgroundTap");
+        TAP_BACKGROUND("tapBackground");
 
         internal companion object {
             private val gestureToEnumMap: Map<String, MessageGesture> =

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/mapping/MessageAnimationMapper.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/mapping/MessageAnimationMapper.kt
@@ -103,7 +103,7 @@ internal object MessageAnimationMapper {
             animationSpec = tween(DEFAULT_ANIMATION_DURATION_MS),
             targetOffsetX = { it }
         ),
-        InAppMessageSettings.MessageGesture.BACKGROUND_TAP to fadeOut(
+        InAppMessageSettings.MessageGesture.TAP_BACKGROUND to fadeOut(
             animationSpec = tween(DEFAULT_ANIMATION_DURATION_MS)
         )
     )

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageBackdrop.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageBackdrop.kt
@@ -54,7 +54,7 @@ internal fun MessageBackdrop(
                     indication = null,
                     interactionSource = remember { MutableInteractionSource() },
                     onClick = {
-                        gestureTracker.onGesture(InAppMessageSettings.MessageGesture.BACKGROUND_TAP)
+                        gestureTracker.onGesture(InAppMessageSettings.MessageGesture.TAP_BACKGROUND)
                     }
                 )
                 .testTag(MessageTestTags.MESSAGE_BACKDROP)

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/message/GestureTrackerTest.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/message/GestureTrackerTest.kt
@@ -24,7 +24,7 @@ class GestureTrackerTest {
         InAppMessageSettings.MessageGesture.SWIPE_RIGHT,
         InAppMessageSettings.MessageGesture.SWIPE_UP,
         InAppMessageSettings.MessageGesture.SWIPE_DOWN,
-        InAppMessageSettings.MessageGesture.BACKGROUND_TAP
+        InAppMessageSettings.MessageGesture.TAP_BACKGROUND
     )
 
     @Before

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/core/testapp/ui/inappmessage/InAppMessageCreator.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/core/testapp/ui/inappmessage/InAppMessageCreator.kt
@@ -57,7 +57,7 @@ object InAppMessageCreator {
                 "swipeDown" to "https://adobe.com",
                 "swipeLeft" to "https://adobe.com",
                 "swipeRight" to "https://google.com",
-                "backgroundTap" to "https://google.com"
+                "tapBackground" to "https://google.com"
             )
         )
 


### PR DESCRIPTION
To ensure consistency with iOS and IAM payload values, update `backgroundTap` to `tapBackground` within the MessageGesture enum.