### PR TITLE
Fix crash during composable attachment to android.app.Activity

### DIFF
--- a/code/core/build.gradle.kts
+++ b/code/core/build.gradle.kts
@@ -29,6 +29,8 @@ aepLibrary {
         addMavenDependency("androidx.compose.material", "material", BuildConstants.Versions.COMPOSE_MATERIAL)
         addMavenDependency("androidx.compose.animation", "animation", BuildConstants.Versions.COMPOSE)
         addMavenDependency("androidx.activity", "activity-compose", BuildConstants.Versions.ANDROIDX_ACTIVITY_COMPOSE)
+        // TODO: Add this dependency version from the aep-library plugin
+        addMavenDependency("androidx.lifecycle", "lifecycle-runtime-ktx", "2.3.1")
     }
 }
 
@@ -42,4 +44,9 @@ apiValidation {
     ignoredClasses.addAll(setOf(
             "com.adobe.marketing.mobile.core.BuildConfig"
     ))
+}
+
+dependencies {
+    // TODO: Add this dependency from the aep-library plugin
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.3.1")
 }

--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/util/ActivityCompatOwner.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/util/ActivityCompatOwner.kt
@@ -9,7 +9,7 @@
   governing permissions and limitations under the License.
 */
 
-package com.adobe.marketing.mobile.services.ui.common
+package com.adobe.marketing.mobile.internal.util
 
 import android.app.Activity
 import android.view.View
@@ -30,7 +30,7 @@ import androidx.savedstate.SavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 
 /**
- * Utility class to attach and detach a [ActivityCompatOwner] to an activity.
+ * Utility class to attach and detach an [ActivityCompatOwner] to an activity.
  * Exists to mock and make tests easier to write for the calling component.
  * This component has to be manually tested due the internal threading and lifecycle management
  * of the Android SDK.
@@ -38,7 +38,7 @@ import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 internal class ActivityCompatOwnerUtils {
 
     /**
-     * Attaches a [ActivityCompatOwner] to the given activity if it does not already have a lifecycle owner.
+     * Attaches an [ActivityCompatOwner] to the given activity if it does not already have a lifecycle owner.
      * @param activityToAttach the activity to attach the [ActivityCompatOwner] to
      */
     internal fun attachActivityCompatOwner(activityToAttach: Activity) {
@@ -55,7 +55,7 @@ internal class ActivityCompatOwnerUtils {
     }
 
     /**
-     * Detaches a [ActivityCompatOwner] from the given activity if it has one.
+     * Detaches the [ActivityCompatOwner] from the given activity if it has one.
      * @param activityToDetach the activity to detach the [ActivityCompatOwner] from
      */
     internal fun detachActivityCompatOwner(activityToDetach: Activity) {

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/common/AEPPresentable.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/common/AEPPresentable.kt
@@ -54,6 +54,7 @@ internal abstract class AEPPresentable<T : Presentation<T>> :
     private val mainScope: CoroutineScope
     private val appLifecycleProvider: AppLifecycleProvider
     private val presentationObserver: PresentationObserver
+    private val activityCompatOwnerUtils: ActivityCompatOwnerUtils
     protected val presentationStateManager: PresentationStateManager
 
     @VisibleForTesting internal val contentIdentifier: Int = Random().nextInt()
@@ -75,6 +76,7 @@ internal abstract class AEPPresentable<T : Presentation<T>> :
         presentationDelegate,
         appLifecycleProvider,
         PresentationStateManager(),
+        ActivityCompatOwnerUtils(),
         CoroutineScope(Dispatchers.Main),
         PresentationObserver.INSTANCE
     )
@@ -94,6 +96,7 @@ internal abstract class AEPPresentable<T : Presentation<T>> :
         presentationDelegate: PresentationDelegate?,
         appLifecycleProvider: AppLifecycleProvider,
         presentationStateManager: PresentationStateManager,
+        activityCompatOwnerUtils: ActivityCompatOwnerUtils,
         mainScope: CoroutineScope,
         presentationObserver: PresentationObserver
     ) {
@@ -102,6 +105,7 @@ internal abstract class AEPPresentable<T : Presentation<T>> :
         this.presentationDelegate = presentationDelegate
         this.appLifecycleProvider = appLifecycleProvider
         this.presentationStateManager = presentationStateManager
+        this.activityCompatOwnerUtils = activityCompatOwnerUtils
         this.mainScope = mainScope
         this.presentationObserver = presentationObserver
     }
@@ -315,6 +319,8 @@ internal abstract class AEPPresentable<T : Presentation<T>> :
             return
         }
 
+        activityCompatOwnerUtils.attachActivityCompatOwner(activityToAttach)
+
         // Fetch a new content view from the presentable
         val composeView: ComposeView = getContent(activityToAttach)
         composeView.id = contentIdentifier
@@ -366,6 +372,7 @@ internal abstract class AEPPresentable<T : Presentation<T>> :
         }
         existingComposeView.removeAllViews()
         rootViewGroup.removeView(existingComposeView)
+        activityCompatOwnerUtils.detachActivityCompatOwner(activityToDetach)
         Log.trace(ServiceConstants.LOG_TAG, LOG_SOURCE, "Detached ${contentIdentifier}from $activityToDetach.")
     }
 }

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/common/AEPPresentable.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/common/AEPPresentable.kt
@@ -18,6 +18,7 @@ import android.view.ViewGroup
 import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.platform.ComposeView
+import com.adobe.marketing.mobile.internal.util.ActivityCompatOwnerUtils
 import com.adobe.marketing.mobile.services.Log
 import com.adobe.marketing.mobile.services.ServiceConstants
 import com.adobe.marketing.mobile.services.ui.AlreadyDismissed

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/common/ActivityCompatOwner.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/common/ActivityCompatOwner.kt
@@ -1,0 +1,152 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.services.ui.common
+
+import android.app.Activity
+import android.view.View
+import androidx.activity.OnBackPressedDispatcher
+import androidx.activity.OnBackPressedDispatcherOwner
+import androidx.activity.setViewTreeOnBackPressedDispatcherOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.lifecycle.setViewTreeViewModelStoreOwner
+import androidx.savedstate.SavedStateRegistry
+import androidx.savedstate.SavedStateRegistryController
+import androidx.savedstate.SavedStateRegistryOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+
+/**
+ * Utility class to attach and detach a [ActivityCompatOwner] to an activity.
+ * Exists to mock and make tests easier to write for the calling component.
+ * This component has to be manually tested due the internal threading and lifecycle management
+ * of the Android SDK.
+ */
+internal class ActivityCompatOwnerUtils {
+
+    /**
+     * Attaches a [ActivityCompatOwner] to the given activity if it does not already have a lifecycle owner.
+     * @param activityToAttach the activity to attach the [ActivityCompatOwner] to
+     */
+    internal fun attachActivityCompatOwner(activityToAttach: Activity) {
+        val decorView = activityToAttach.window.decorView
+
+        if (decorView.findViewTreeLifecycleOwner() != null) {
+            // If the activity already has a lifecycle owner, then we don't need to attach a new one
+            return
+        }
+
+        val proxyLifeCycleOwner = ActivityCompatOwner()
+        proxyLifeCycleOwner.onCreate()
+        proxyLifeCycleOwner.attachToView(decorView)
+    }
+
+    /**
+     * Detaches a [ActivityCompatOwner] from the given activity if it has one.
+     * @param activityToDetach the activity to detach the [ActivityCompatOwner] from
+     */
+    internal fun detachActivityCompatOwner(activityToDetach: Activity) {
+        val decorView = activityToDetach.window.decorView
+
+        // If the activity's lifecycle owner is not a ActivityCompatOwner, then there is nothing
+        // to detach
+        val lifecycleOwner = decorView.findViewTreeLifecycleOwner()
+        if (lifecycleOwner !is ActivityCompatOwner) {
+            return
+        }
+
+        lifecycleOwner.detachFromView(decorView)
+        lifecycleOwner.onDestroy()
+    }
+}
+
+/**
+ * A proxy lifecycle owner that is used to attach to an activity's view tree to which a compose view
+ * from the SDK is being attached.
+ * This is required to provide a lifecycle owner to the view tree of an activity that inherits
+ * from android.app.Activity which does not provide a lifecycle owner by default. Not doing so will
+ * result in a crash when trying to attach a compose view. Android recommends using inheriting from
+ * AppCompatActivity or similar which provides a lifecycle owner by default (irrespective of whether
+ * compose is being used or not). This is a best effort to provide a lifecycle owner when this is not
+ * the case.
+ */
+internal class ActivityCompatOwner :
+    LifecycleOwner,
+    ViewModelStoreOwner,
+    SavedStateRegistryOwner,
+    OnBackPressedDispatcherOwner {
+
+    // LifecycleOwner methods
+    private val lifecycleRegistry: LifecycleRegistry = LifecycleRegistry(this)
+    override val lifecycle: Lifecycle
+        get() = lifecycleRegistry
+
+    // ViewModelStore methods
+    private val store = ViewModelStore()
+    override val viewModelStore: ViewModelStore
+        get() = store
+
+    // SavedStateRegistry methods
+    private val savedStateRegistryController = SavedStateRegistryController.create(this)
+    override val savedStateRegistry: SavedStateRegistry
+        get() = savedStateRegistryController.savedStateRegistry
+
+    // OnBackPressedDispatcherOwner methods
+    private val dispatcher = OnBackPressedDispatcher {}
+    override val onBackPressedDispatcher: OnBackPressedDispatcher
+        get() = dispatcher
+
+    /**
+     * Trigger the ON_CREATE lifecycle event for this [ActivityCompatOwner].
+     */
+    internal fun onCreate() {
+        savedStateRegistryController.performRestore(null)
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    }
+
+    /**
+     * Trigger the ON_DESTROY lifecycle event for this [ActivityCompatOwner].
+     */
+    internal fun onDestroy() {
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        store.clear()
+    }
+
+    /**
+     * Attaches this [ActivityCompatOwner] to the given view.
+     * @param view the view to attach this [ActivityCompatOwner] to
+     */
+    internal fun attachToView(view: View?) {
+        view?.apply {
+            setViewTreeLifecycleOwner(this@ActivityCompatOwner)
+            setViewTreeViewModelStoreOwner(this@ActivityCompatOwner)
+            setViewTreeSavedStateRegistryOwner(this@ActivityCompatOwner)
+            setViewTreeOnBackPressedDispatcherOwner(this@ActivityCompatOwner)
+        }
+    }
+
+    /**
+     * Detaches this [ActivityCompatOwner] from the given view.
+     * @param view the view to detach this [ActivityCompatOwner] from
+     */
+    internal fun detachFromView(view: View?) {
+        view?.apply {
+            setViewTreeLifecycleOwner(null)
+            setViewTreeViewModelStoreOwner(null)
+            setViewTreeSavedStateRegistryOwner(null)
+        }
+    }
+}

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/common/AEPPresentableTest.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/common/AEPPresentableTest.kt
@@ -74,6 +74,9 @@ internal class AEPPresentableTest {
     @Mock
     private lateinit var mockPresentationObserver: PresentationObserver
 
+    @Mock
+    private lateinit var mockActivityCompatLifecycleUtils: ActivityCompatOwnerUtils
+
     private var mockMainScope: CoroutineScope = CoroutineScope(Dispatchers.Unconfined)
 
     @Mock
@@ -94,6 +97,7 @@ internal class AEPPresentableTest {
             mockPresentationDelegate,
             mockAppLifecycleProvider,
             mockPresentationStateManager,
+            mockActivityCompatLifecycleUtils,
             mockMainScope,
             mockPresentationObserver
         )
@@ -141,6 +145,7 @@ internal class AEPPresentableTest {
             mockPresentationDelegate,
             mockAppLifecycleProvider,
             mockPresentationStateManager,
+            mockActivityCompatLifecycleUtils,
             mockMainScope,
             mockPresentationObserver
         )
@@ -190,6 +195,7 @@ internal class AEPPresentableTest {
             null, // simulate null presentation delegate
             mockAppLifecycleProvider,
             mockPresentationStateManager,
+            mockActivityCompatLifecycleUtils,
             mockMainScope,
             mockPresentationObserver
         )
@@ -231,6 +237,7 @@ internal class AEPPresentableTest {
             mockPresentationDelegate,
             mockAppLifecycleProvider,
             mockPresentationStateManager,
+            mockActivityCompatLifecycleUtils,
             mockMainScope,
             mockPresentationObserver
         )
@@ -283,6 +290,7 @@ internal class AEPPresentableTest {
             mockPresentationDelegate,
             mockAppLifecycleProvider,
             mockPresentationStateManager,
+            mockActivityCompatLifecycleUtils,
             mockMainScope,
             mockPresentationObserver
         )
@@ -331,6 +339,7 @@ internal class AEPPresentableTest {
             mockPresentationDelegate,
             mockAppLifecycleProvider,
             mockPresentationStateManager,
+            mockActivityCompatLifecycleUtils,
             mockMainScope,
             mockPresentationObserver
         )
@@ -372,6 +381,7 @@ internal class AEPPresentableTest {
             mockPresentationDelegate,
             mockAppLifecycleProvider,
             mockPresentationStateManager,
+            mockActivityCompatLifecycleUtils,
             mockMainScope,
             mockPresentationObserver,
             conflictLogic = { visible ->
@@ -426,6 +436,7 @@ internal class AEPPresentableTest {
             mockPresentationDelegate,
             mockAppLifecycleProvider,
             mockPresentationStateManager,
+            mockActivityCompatLifecycleUtils,
             mockMainScope,
             mockPresentationObserver,
             conflictLogic = { visible ->
@@ -483,6 +494,7 @@ internal class AEPPresentableTest {
             mockPresentationDelegate,
             mockAppLifecycleProvider,
             mockPresentationStateManager,
+            mockActivityCompatLifecycleUtils,
             mockMainScope,
             mockPresentationObserver
         )
@@ -521,6 +533,7 @@ internal class AEPPresentableTest {
             mockPresentationDelegate,
             mockAppLifecycleProvider,
             mockPresentationStateManager,
+            mockActivityCompatLifecycleUtils,
             mockMainScope,
             mockPresentationObserver
         )
@@ -566,6 +579,7 @@ internal class AEPPresentableTest {
             mockPresentationDelegate,
             mockAppLifecycleProvider,
             mockPresentationStateManager,
+            mockActivityCompatLifecycleUtils,
             mockMainScope,
             mockPresentationObserver
         )
@@ -611,6 +625,7 @@ internal class AEPPresentableTest {
             mockPresentationDelegate,
             mockAppLifecycleProvider,
             mockPresentationStateManager,
+            mockActivityCompatLifecycleUtils,
             mockMainScope,
             mockPresentationObserver
         )
@@ -651,6 +666,7 @@ internal class AEPPresentableTest {
             mockPresentationDelegate,
             mockAppLifecycleProvider,
             mockPresentationStateManager,
+            mockActivityCompatLifecycleUtils,
             mockMainScope,
             mockPresentationObserver
         )
@@ -685,6 +701,7 @@ internal class AEPPresentableTest {
             mockPresentationDelegate,
             mockAppLifecycleProvider,
             mockPresentationStateManager,
+            mockActivityCompatLifecycleUtils,
             mockMainScope,
             mockPresentationObserver
         )
@@ -716,6 +733,7 @@ internal class AEPPresentableTest {
             mockPresentationDelegate,
             mockAppLifecycleProvider,
             mockPresentationStateManager,
+            mockActivityCompatLifecycleUtils,
             mockMainScope,
             mockPresentationObserver
         )
@@ -757,6 +775,7 @@ internal class AEPPresentableTest {
             mockPresentationDelegate,
             mockAppLifecycleProvider,
             mockPresentationStateManager,
+            mockActivityCompatLifecycleUtils,
             mockMainScope,
             mockPresentationObserver
         )
@@ -798,6 +817,7 @@ internal class AEPPresentableTest {
             mockPresentationDelegate,
             mockAppLifecycleProvider,
             mockPresentationStateManager,
+            mockActivityCompatLifecycleUtils,
             mockMainScope,
             mockPresentationObserver
         )
@@ -839,6 +859,7 @@ internal class AEPPresentableTest {
             mockPresentationDelegate,
             mockAppLifecycleProvider,
             mockPresentationStateManager,
+            mockActivityCompatLifecycleUtils,
             mockMainScope,
             mockPresentationObserver
         )
@@ -876,6 +897,7 @@ internal class AEPPresentableTest {
             mockPresentationDelegate,
             mockAppLifecycleProvider,
             mockPresentationStateManager,
+            mockActivityCompatLifecycleUtils,
             mockMainScope,
             mockPresentationObserver
         )
@@ -910,6 +932,7 @@ internal class AEPPresentableTest {
         presentationDelegate: PresentationDelegate?,
         appLifecycleProvider: AppLifecycleProvider,
         presentationStateManager: PresentationStateManager,
+        activityCompatOwnerUtils: ActivityCompatOwnerUtils,
         mainScope: CoroutineScope,
         presentationObserver: PresentationObserver,
         val conflictLogic: (visiblePresentations: List<Presentation<*>>) -> Boolean = { false }
@@ -919,6 +942,7 @@ internal class AEPPresentableTest {
         presentationDelegate,
         appLifecycleProvider,
         presentationStateManager,
+        activityCompatOwnerUtils,
         mainScope,
         presentationObserver
     ) {

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/common/AEPPresentableTest.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/common/AEPPresentableTest.kt
@@ -16,6 +16,7 @@ import android.content.Context
 import android.view.ViewGroup
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.platform.ComposeView
+import com.adobe.marketing.mobile.internal.util.ActivityCompatOwnerUtils
 import com.adobe.marketing.mobile.services.ui.Alert
 import com.adobe.marketing.mobile.services.ui.AlreadyDismissed
 import com.adobe.marketing.mobile.services.ui.AlreadyHidden


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
ComposeView requires a lifecycle owner  when attaching to a view and not finding one will result in a crash.
`android.app.Activity`, which is the base class in the framework package, does not provide a lifecycle owner by default.
`android.app.Activty` has not been updated for a long time and Android created `AppCompatActivity`/`FragmentActivity` in the support package to allow updates to be compatible with old android devices. Android [recommends](https://developer.android.com/topic/libraries/support-library#framework-apis) using inheriting from `AppCompatActivity` or similar which provides a lifecycle owner by default (irrespective of whether compose is being used or not).

There may be cases where apps still use this legacy Activity in their apps and launching our Ui Service components on top of them will not work unless the ComposeView sees that there is some lifecycle owner.
To fix this, attach a proxy lifecycle owner and related owners to the view of the activity just before attaching the ComposeView and detach it when the activity is destroyed. This will allow displaying out UI components like InAppMessages, Floating buttons on these legacy implementations. Since there is originally no observer attachable to the Activity, there are no components dependent on the events from this owner except for the compose view.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Fix crash during composable attachment to android.app.Activity

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Manual tests by launching an `android.app.Activity` with test app and also using Assurance 2.x which uses the same.. Unit tests need complicated logic due to the way underlying implementation of the `View.find*Owner`.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
