### PR TITLE
[Android 3.0.0] Adopt the network service changes in Signal

### DIFF
--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/NetworkServiceTests.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/NetworkServiceTests.java
@@ -84,7 +84,7 @@ public class NetworkServiceTests {
         }
     }
 
-    @Test(timeout = 1000L)
+    @Test(timeout = 10000L)
     public void testConnectAsync_InternetIsAvailable() throws InterruptedException {
         try (MockedStatic<NetworkUtils> ignored = Mockito.mockStatic(NetworkUtils.class);
                 MockedStatic<Log> mockedLog = Mockito.mockStatic(Log.class)) {

--- a/code/signal/src/main/java/com/adobe/marketing/mobile/signal/internal/SignalExtension.kt
+++ b/code/signal/src/main/java/com/adobe/marketing/mobile/signal/internal/SignalExtension.kt
@@ -27,6 +27,7 @@ import com.adobe.marketing.mobile.services.PersistentHitQueue
 import com.adobe.marketing.mobile.services.ServiceProvider
 import com.adobe.marketing.mobile.util.DataReader
 import com.adobe.marketing.mobile.util.SQLiteUtils
+import com.adobe.marketing.mobile.util.UrlUtils
 
 class SignalExtension : Extension {
     private val hitQueue: HitQueuing
@@ -139,6 +140,16 @@ class SignalExtension : Extension {
             )
             return
         }
+
+        if (!UrlUtils.isValidUrl(url)) {
+            Log.warning(
+                SignalConstants.LOG_TAG,
+                CLASS_NAME,
+                "Rule consequence Event for Signal will not be processed, url ($url) is malformed."
+            )
+            return
+        }
+
         if (event.isCollectPii() && !url.startsWith("https")) {
             Log.warning(
                 SignalConstants.LOG_TAG,
@@ -147,6 +158,7 @@ class SignalExtension : Extension {
             )
             return
         }
+
         val body = event.templateBody() ?: ""
         val contentType = event.contentType()
         val timeout = event.timeout()

--- a/code/signal/src/main/java/com/adobe/marketing/mobile/signal/internal/SignalHitProcessor.kt
+++ b/code/signal/src/main/java/com/adobe/marketing/mobile/signal/internal/SignalHitProcessor.kt
@@ -20,8 +20,6 @@ import com.adobe.marketing.mobile.services.Log
 import com.adobe.marketing.mobile.services.NetworkRequest
 import com.adobe.marketing.mobile.services.Networking
 import com.adobe.marketing.mobile.services.ServiceProvider
-import java.net.MalformedURLException
-import java.net.URL
 
 internal class SignalHitProcessor : HitProcessing {
     private val networkService: Networking
@@ -50,20 +48,6 @@ internal class SignalHitProcessor : HitProcessing {
                 SignalConstants.LOG_TAG,
                 CLASS_NAME,
                 "Drop this data entity as it's not able to convert it to a valid Signal request: ${entity.data}"
-            )
-            processingResult.complete(true)
-            return
-        }
-
-        // The connectAsync() API will invoke the callback with a null connection if the URL string is malformed.
-        // Validate the url string before making the request.
-        try {
-            URL(request.url)
-        } catch (e: MalformedURLException) {
-            Log.warning(
-                SignalConstants.LOG_TAG,
-                CLASS_NAME,
-                "Drop this data entity as it includes the malformed url string: ${request.url}"
             )
             processingResult.complete(true)
             return

--- a/code/signal/src/main/java/com/adobe/marketing/mobile/signal/internal/SignalHitProcessor.kt
+++ b/code/signal/src/main/java/com/adobe/marketing/mobile/signal/internal/SignalHitProcessor.kt
@@ -55,7 +55,8 @@ internal class SignalHitProcessor : HitProcessing {
             return
         }
 
-        // The malformed URL string cause throwing the MalformedURLException inside the Network service
+        // The connectAsync() API will invoke the callback with a null connection if the URL string is malformed.
+        // Validate the url string before making the request.
         try {
             URL(request.url)
         } catch (e: MalformedURLException) {

--- a/code/signal/src/main/java/com/adobe/marketing/mobile/signal/internal/SignalHitProcessor.kt
+++ b/code/signal/src/main/java/com/adobe/marketing/mobile/signal/internal/SignalHitProcessor.kt
@@ -20,6 +20,8 @@ import com.adobe.marketing.mobile.services.Log
 import com.adobe.marketing.mobile.services.NetworkRequest
 import com.adobe.marketing.mobile.services.Networking
 import com.adobe.marketing.mobile.services.ServiceProvider
+import java.net.MalformedURLException
+import java.net.URL
 
 internal class SignalHitProcessor : HitProcessing {
     private val networkService: Networking
@@ -52,6 +54,20 @@ internal class SignalHitProcessor : HitProcessing {
             processingResult.complete(true)
             return
         }
+
+        // The malformed URL string cause throwing the MalformedURLException inside the Network service
+        try {
+            URL(request.url)
+        } catch (e: MalformedURLException) {
+            Log.warning(
+                SignalConstants.LOG_TAG,
+                CLASS_NAME,
+                "Drop this data entity as it includes the malformed url string: ${request.url}"
+            )
+            processingResult.complete(true)
+            return
+        }
+
         networkService.connectAsync(request) { connection ->
             if (connection == null) {
                 Log.debug(

--- a/code/signal/src/main/java/com/adobe/marketing/mobile/signal/internal/SignalHitProcessor.kt
+++ b/code/signal/src/main/java/com/adobe/marketing/mobile/signal/internal/SignalHitProcessor.kt
@@ -54,7 +54,12 @@ internal class SignalHitProcessor : HitProcessing {
         }
         networkService.connectAsync(request) { connection ->
             if (connection == null) {
-                processingResult.complete(true)
+                Log.debug(
+                    SignalConstants.LOG_TAG,
+                    CLASS_NAME,
+                    "Network request returned null connection. Will retry request later."
+                )
+                processingResult.complete(false)
                 return@connectAsync
             }
             when (val responseCode = connection.responseCode) {

--- a/code/signal/src/test/java/com/adobe/marketing/mobile/signal/internal/SignalFunctionalTests.kt
+++ b/code/signal/src/test/java/com/adobe/marketing/mobile/signal/internal/SignalFunctionalTests.kt
@@ -218,7 +218,7 @@ class SignalFunctionalTests {
     }
 
     @Test
-    fun `handleRulesEngineResponse() - collect pii without valid url`() {
+    fun `handleRulesEngineResponse() - collect pii with empty url`() {
         val event = Event.Builder("event", "type", "source").setEventData(
             mapOf(
                 "triggeredconsequence" to mapOf(
@@ -226,6 +226,41 @@ class SignalFunctionalTests {
                     "detail" to mapOf(
                         "timeout" to 0,
                         "templateurl" to null
+                    )
+                )
+            )
+        ).build()
+        `when`(
+            mockedExtensionApi.getSharedState(
+                any(),
+                any(),
+                anyOrNull(),
+                any()
+            )
+        ).thenReturn(
+            SharedStateResult(
+                SharedStateStatus.SET,
+                mapOf(
+                    "global.privacy" to "optedin"
+                )
+            )
+        )
+        val spiedSignalExtension = spy(signalExtension)
+        spiedSignalExtension.handleRulesEngineResponse(event)
+        verify(spiedSignalExtension, times(1)).handlePostback(anyOrNull())
+        verify(spiedSignalExtension, never()).handleOpenURL(anyOrNull())
+        verify(mockedHitQueue, never()).queue(any())
+    }
+
+    @Test
+    fun `handleRulesEngineResponse() - collect pii with malformed url`() {
+        val event = Event.Builder("event", "type", "source").setEventData(
+            mapOf(
+                "triggeredconsequence" to mapOf(
+                    "type" to "pii",
+                    "detail" to mapOf(
+                        "timeout" to 0,
+                        "templateurl" to "https://www.adobe.com:_80/"
                     )
                 )
             )

--- a/code/signal/src/test/java/com/adobe/marketing/mobile/signal/internal/SignalFunctionalTests.kt
+++ b/code/signal/src/test/java/com/adobe/marketing/mobile/signal/internal/SignalFunctionalTests.kt
@@ -392,4 +392,38 @@ class SignalFunctionalTests {
         verify(spiedSignalExtension, times(1)).handlePostback(anyOrNull())
         verify(spiedSignalExtension, never()).handleOpenURL(anyOrNull())
     }
+
+    @Test
+    fun `handleRulesEngineResponse() - post back with malformed url`() {
+        val event = Event.Builder("event", "type", "source").setEventData(
+            mapOf(
+                "triggeredconsequence" to mapOf(
+                    "type" to "pb",
+                    "detail" to mapOf(
+                        "templateurl" to "https://www.adobe.com:_80/"
+                    )
+                )
+            )
+        ).build()
+        `when`(
+            mockedExtensionApi.getSharedState(
+                any(),
+                any(),
+                anyOrNull(),
+                any()
+            )
+        ).thenReturn(
+            SharedStateResult(
+                SharedStateStatus.SET,
+                mapOf(
+                    "global.privacy" to "optedin"
+                )
+            )
+        )
+        val spiedSignalExtension = spy(signalExtension)
+        spiedSignalExtension.handleRulesEngineResponse(event)
+        verify(spiedSignalExtension, times(1)).handlePostback(anyOrNull())
+        verify(spiedSignalExtension, never()).handleOpenURL(anyOrNull())
+        verify(mockedHitQueue, never()).queue(any())
+    }
 }

--- a/code/signal/src/test/java/com/adobe/marketing/mobile/signal/internal/SignalHitProcessorTests.kt
+++ b/code/signal/src/test/java/com/adobe/marketing/mobile/signal/internal/SignalHitProcessorTests.kt
@@ -15,22 +15,17 @@ import com.adobe.marketing.mobile.services.DataEntity
 import com.adobe.marketing.mobile.services.HttpConnecting
 import com.adobe.marketing.mobile.services.HttpMethod
 import com.adobe.marketing.mobile.services.NetworkRequest
-import com.adobe.marketing.mobile.services.Networking
-import com.adobe.marketing.mobile.services.ServiceProvider
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito
-import org.mockito.Mockito.times
 import org.mockito.Mockito.`when`
 import org.mockito.junit.MockitoJUnitRunner
-import org.mockito.kotlin.timeout
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 @RunWith(MockitoJUnitRunner.Silent::class)
 class SignalHitProcessorTests {
@@ -40,13 +35,10 @@ class SignalHitProcessorTests {
 
     private lateinit var signalHitProcessor: SignalHitProcessor
 
-    private lateinit var spiedNetworkService: Networking
-
     @Before
     fun setup() {
         Mockito.reset(httpResponseConnection)
-        spiedNetworkService = Mockito.spy(ServiceProvider.getInstance().networkService)
-        signalHitProcessor = SignalHitProcessor(spiedNetworkService)
+        signalHitProcessor = SignalHitProcessor()
     }
 
     @Test(timeout = 100)
@@ -240,31 +232,6 @@ class SignalHitProcessorTests {
         }
 
         countDownLatch.await()
-    }
-
-    @Test
-    fun `processHit() - should not send requests when the url string is malformed`() {
-        val entity = DataEntity(
-            """
-            {
-              "contentType": "",
-              "body": "{\"key\":\"value\"}",
-              "url": "https://www.postback.com:_80/",
-              "timeout": 2
-            }
-            """.trimIndent()
-        )
-        signalHitProcessor = SignalHitProcessor { _, callback ->
-            callback.call(null)
-        }
-        val countDownLatch = CountDownLatch(1)
-        signalHitProcessor.processHit(entity) { processingResult ->
-            // the malformed url should be dropped
-            assertTrue(processingResult)
-            countDownLatch.countDown()
-        }
-        countDownLatch.await()
-        Mockito.verifyNoInteractions(spiedNetworkService)
     }
 
     @Test

--- a/code/signal/src/test/java/com/adobe/marketing/mobile/signal/internal/SignalHitProcessorTests.kt
+++ b/code/signal/src/test/java/com/adobe/marketing/mobile/signal/internal/SignalHitProcessorTests.kt
@@ -15,29 +15,38 @@ import com.adobe.marketing.mobile.services.DataEntity
 import com.adobe.marketing.mobile.services.HttpConnecting
 import com.adobe.marketing.mobile.services.HttpMethod
 import com.adobe.marketing.mobile.services.NetworkRequest
+import com.adobe.marketing.mobile.services.Networking
+import com.adobe.marketing.mobile.services.ServiceProvider
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito
+import org.mockito.Mockito.times
 import org.mockito.Mockito.`when`
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.timeout
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @RunWith(MockitoJUnitRunner.Silent::class)
 class SignalHitProcessorTests {
 
     @Mock
     private lateinit var httpResponseConnection: HttpConnecting
+
     private lateinit var signalHitProcessor: SignalHitProcessor
+
+    private lateinit var spiedNetworkService: Networking
 
     @Before
     fun setup() {
         Mockito.reset(httpResponseConnection)
-        signalHitProcessor = SignalHitProcessor()
+        spiedNetworkService = Mockito.spy(ServiceProvider.getInstance().networkService)
+        signalHitProcessor = SignalHitProcessor(spiedNetworkService)
     }
 
     @Test(timeout = 100)
@@ -231,6 +240,31 @@ class SignalHitProcessorTests {
         }
 
         countDownLatch.await()
+    }
+
+    @Test
+    fun `processHit() - should not send requests when the url string is malformed`() {
+        val entity = DataEntity(
+            """
+            {
+              "contentType": "",
+              "body": "{\"key\":\"value\"}",
+              "url": "https://www.postback.com:_80/",
+              "timeout": 2
+            }
+            """.trimIndent()
+        )
+        signalHitProcessor = SignalHitProcessor { _, callback ->
+            callback.call(null)
+        }
+        val countDownLatch = CountDownLatch(1)
+        signalHitProcessor.processHit(entity) { processingResult ->
+            // the malformed url should be dropped
+            assertTrue(processingResult)
+            countDownLatch.countDown()
+        }
+        countDownLatch.await()
+        Mockito.verifyNoInteractions(spiedNetworkService)
     }
 
     @Test

--- a/code/signal/src/test/java/com/adobe/marketing/mobile/signal/internal/SignalHitProcessorTests.kt
+++ b/code/signal/src/test/java/com/adobe/marketing/mobile/signal/internal/SignalHitProcessorTests.kt
@@ -25,6 +25,7 @@ import org.mockito.Mockito.`when`
 import org.mockito.junit.MockitoJUnitRunner
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlin.test.assertFalse
 
 @RunWith(MockitoJUnitRunner.Silent::class)
 class SignalHitProcessorTests {
@@ -223,7 +224,11 @@ class SignalHitProcessorTests {
             callback.call(null)
         }
         val countDownLatch = CountDownLatch(1)
-        signalHitProcessor.processHit(entity) { countDownLatch.countDown() }
+        signalHitProcessor.processHit(entity) { hitIsProcessed ->
+            // If the network callback was invoked with a null connection, then return false to indicate that the hit is not processed.
+            assertFalse(hitIsProcessed)
+            countDownLatch.countDown()
+        }
 
         countDownLatch.await()
     }

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/core/testapp/SignalView.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/core/testapp/SignalView.kt
@@ -19,9 +19,16 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import com.adobe.marketing.mobile.Event
+import com.adobe.marketing.mobile.EventSource
+import com.adobe.marketing.mobile.EventType
+import com.adobe.marketing.mobile.MobileCore
 import com.adobe.marketing.mobile.Signal
+import com.adobe.marketing.mobile.core.testapp.ui.theme.AEPSDKCoreAndroidTheme
 
 @Composable
 fun SignalView(navController: NavHostController) {
@@ -36,8 +43,37 @@ fun SignalView(navController: NavHostController) {
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            Button(onClick = {
+                MobileCore.dispatchEvent(
+                    Event.Builder("consequence event", EventType.RULES_ENGINE, EventSource.RESPONSE_CONTENT).setEventData(
+                    mapOf(
+                        "triggeredconsequence" to mapOf(
+                            "type" to "pii",
+                            "detail" to mapOf(
+                                "timeout" to 0,
+                                "templateurl" to "https://www.adobe.com"
+                            )
+                        )
+                    )
+                ).build())
+
+            }) {
+                Text(text = "post back")
+            }
+            // openURL is covered by automation test, we can enable it later if needed for customer issue verification
+            Button(onClick = {},enabled = false) {
+                Text(text = "open URL")
+            }
             Text(text = "Signal extension version - ${Signal.extensionVersion()}")
         }
 
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DefaultPreviewForSignalView() {
+    AEPSDKCoreAndroidTheme {
+        SignalView(rememberNavController())
     }
 }

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/core/testapp/SignalView.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/core/testapp/SignalView.kt
@@ -15,12 +15,18 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Button
+import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.adobe.marketing.mobile.Event
@@ -32,6 +38,8 @@ import com.adobe.marketing.mobile.core.testapp.ui.theme.AEPSDKCoreAndroidTheme
 
 @Composable
 fun SignalView(navController: NavHostController) {
+    var url by remember { mutableStateOf("https://www.adobe.com") }
+
     Column(Modifier.padding(8.dp)) {
         Button(onClick = {
             navController.navigate(NavRoutes.HomeView.route)
@@ -43,6 +51,12 @@ fun SignalView(navController: NavHostController) {
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            Text(text = "Example of the malformed URL: https://www.adobe.com:_80/", fontSize = 10.sp)
+            OutlinedTextField(
+                value = url,
+                onValueChange = { url = it },
+                label = { Text("URL") }
+            )
             Button(onClick = {
                 MobileCore.dispatchEvent(
                     Event.Builder("consequence event", EventType.RULES_ENGINE, EventSource.RESPONSE_CONTENT).setEventData(
@@ -51,7 +65,7 @@ fun SignalView(navController: NavHostController) {
                             "type" to "pii",
                             "detail" to mapOf(
                                 "timeout" to 0,
-                                "templateurl" to "https://www.adobe.com"
+                                "templateurl" to url
                             )
                         )
                     )


### PR DESCRIPTION
- The Signal extension is updated to adopt the network service changes added in Android Core 3.0.0. (https://github.com/adobe/aepsdk-core-android/pull/612) 
- The test app has been updated for manual testing behaviors of the Signal extension when the device's network is on and off.

The test cases mentioned below have been tested on both the Android device and emulator.
1. When the device's network is online, the Signal extension can send `post back` requests correctly. 
2. When the device's network is offline, `post back` requests were queued, and there was no network connection established (monitored through Android Stidio's network inspector view) 
3. The queued requests were sent out correctly after the device's network was back online. 
4. New requests can be sent out immediately if the device's network is still online.

