### PR TITLE
Fix InAppMessage inset behavior

### DIFF
--- a/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/message/InAppMessageSettings.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/message/InAppMessageSettings.kt
@@ -119,13 +119,13 @@ class InAppMessageSettings private constructor(
          * of the screen as a percentage of the screen height.
          * @param verticalInset the vertical inset of the message
          */
-        fun verticalInset(verticalInset: Int) = apply { this.verticalInset = clipToPercent(verticalInset) }
+        fun verticalInset(verticalInset: Int) = apply { this.verticalInset = clipToPercent(verticalInset, true) }
 
         /**
          * Sets the horizontal inset of the message. This is the padding from the left and right
          * of the screen as a percentage of the screen width.
          */
-        fun horizontalInset(horizontalInset: Int) = apply { this.horizontalInset = clipToPercent(horizontalInset) }
+        fun horizontalInset(horizontalInset: Int) = apply { this.horizontalInset = clipToPercent(horizontalInset, true) }
 
         /**
          * Sets the vertical alignment of the message on the screen.
@@ -224,12 +224,15 @@ class InAppMessageSettings private constructor(
 
         private companion object {
             /**
-             * Clips a value to a percentage. This is used to ensure that values are between 0 and 100.
+             * Clips a value to a percentage. This is used to ensure that values are between -100 and 100
+             * when negative values are allowed and between 0 and 100 when negative values are not allowed.
              * @param toClip the value to clip
+             * @param allowNegative whether negative values are allowed
              * @return the clipped value
              */
-            fun clipToPercent(toClip: Int) = when {
-                toClip <= 0 -> 0
+            fun clipToPercent(toClip: Int, allowNegative: Boolean = false) = when {
+                !allowNegative && toClip <= 0 -> 0
+                toClip <= -100 -> -100
                 toClip >= 100 -> 100
                 else -> toClip
             }

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/mapping/MessageOffsetMapper.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/mapping/MessageOffsetMapper.kt
@@ -1,0 +1,81 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.services.ui.message.mapping
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.adobe.marketing.mobile.services.ui.message.InAppMessageSettings
+
+/**
+ * A mapper to calculate the horizontal and vertical offset for the InAppMessage based
+ * on the alignment and offset percent.
+ */
+internal object MessageOffsetMapper {
+
+    /**
+     * Returns the horizontal offset for the InAppMessage based on the alignment and offset percent
+     * relative to the screen width.
+     *
+     * LEFT alignment with +ve offset will move the message to the right.
+     * LEFT alignment with -ve offset will move the message to the left.
+     * RIGHT alignment with +ve offset will move the message to the left.
+     * RIGHT alignment with -ve offset will move the message to the right.
+     *
+     * @param horizontalAlignment the horizontal alignment of the message
+     * @param offsetPercent the offset percent of the message
+     * @param screenWidthDp the screen width in dp
+     * @return the horizontal offset in dp
+     */
+    internal fun getHorizontalOffset(
+        horizontalAlignment: InAppMessageSettings.MessageAlignment,
+        offsetPercent: Int,
+        screenWidthDp: Dp
+    ): Dp {
+        val offset = ((offsetPercent * screenWidthDp.value) / 100).dp
+
+        return when (horizontalAlignment) {
+            InAppMessageSettings.MessageAlignment.LEFT -> offset
+            InAppMessageSettings.MessageAlignment.RIGHT -> -offset
+            InAppMessageSettings.MessageAlignment.CENTER -> 0.dp
+            else -> 0.dp
+        }
+    }
+
+    /**
+     * Returns the vertical offset for the InAppMessage based on the alignment and offset percent
+     * relative to the screen height.
+     *
+     * TOP alignment with +ve offset will move the message down.
+     * TOP alignment with -ve offset will move the message up.
+     * BOTTOM alignment with +ve offset will move the message up.
+     * BOTTOM alignment with -ve offset will move the message down.
+     *
+     * @param verticalAlignment the vertical alignment of the message
+     * @param offsetPercent the offset percent of the message
+     * @param screenHeightDp the screen height in dp
+     * @return the vertical offset in dp
+     */
+    internal fun getVerticalOffset(
+        verticalAlignment: InAppMessageSettings.MessageAlignment,
+        offsetPercent: Int,
+        screenHeightDp: Dp
+    ): Dp {
+        val offset = ((offsetPercent * screenHeightDp.value) / 100).dp
+
+        return when (verticalAlignment) {
+            InAppMessageSettings.MessageAlignment.TOP -> offset
+            InAppMessageSettings.MessageAlignment.BOTTOM -> -offset
+            InAppMessageSettings.MessageAlignment.CENTER -> 0.dp
+            else -> 0.dp
+        }
+    }
+}

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageFrame.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageFrame.kt
@@ -17,7 +17,7 @@ import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.runtime.Composable
@@ -35,6 +35,7 @@ import com.adobe.marketing.mobile.services.ui.message.InAppMessageSettings
 import com.adobe.marketing.mobile.services.ui.message.mapping.MessageAlignmentMapper
 import com.adobe.marketing.mobile.services.ui.message.mapping.MessageAnimationMapper
 import com.adobe.marketing.mobile.services.ui.message.mapping.MessageArrangementMapper
+import com.adobe.marketing.mobile.services.ui.message.mapping.MessageOffsetMapper
 
 /**
  * Represents the frame of the InAppMessage that contains the content of the message.
@@ -53,10 +54,22 @@ internal fun MessageFrame(
     onDisposed: () -> Unit
 ) {
     val currentConfiguration = LocalConfiguration.current
-    val horizontalPadding =
-        remember { ((inAppMessageSettings.horizontalInset * currentConfiguration.screenWidthDp) / 100).dp }
-    val verticalPadding =
-        remember { ((inAppMessageSettings.verticalInset * currentConfiguration.screenHeightDp) / 100).dp }
+    val horizontalOffset =
+        remember {
+            MessageOffsetMapper.getHorizontalOffset(
+                inAppMessageSettings.horizontalAlignment,
+                inAppMessageSettings.horizontalInset,
+                currentConfiguration.screenWidthDp.dp
+            )
+        }
+    val verticalOffset =
+        remember {
+            MessageOffsetMapper.getVerticalOffset(
+                inAppMessageSettings.verticalAlignment,
+                inAppMessageSettings.verticalInset,
+                currentConfiguration.screenHeightDp.dp
+            )
+        }
 
     AnimatedVisibility(
         visibleState = visibility,
@@ -66,10 +79,9 @@ internal fun MessageFrame(
         exit = gestureTracker.getExitTransition()
     ) {
         Row(
-
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = horizontalPadding, vertical = verticalPadding)
+                .offset(x = horizontalOffset, y = verticalOffset)
                 .background(Color.Transparent)
                 .testTag(MessageTestTags.MESSAGE_FRAME),
             horizontalArrangement = MessageArrangementMapper.getHorizontalArrangement(

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/message/InAppMessageSettingsTest.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/message/InAppMessageSettingsTest.kt
@@ -85,6 +85,104 @@ class InAppMessageSettingsTest {
     }
 
     @Test
+    fun `Test InAppMessageSettings with negative insets needing clipping`() {
+        val iamSettings = InAppMessageSettings.Builder()
+            .height(50)
+            .width(50)
+            .horizontalInset(-20)
+            .verticalInset(-10)
+            .build()
+        assertEquals("", iamSettings.content)
+        assertEquals(50, iamSettings.width)
+        assertEquals(50, iamSettings.height)
+        assertEquals(-10, iamSettings.verticalInset)
+        assertEquals(-20, iamSettings.horizontalInset)
+        assertEquals(InAppMessageSettings.MessageAlignment.CENTER, iamSettings.verticalAlignment)
+        assertEquals(InAppMessageSettings.MessageAlignment.CENTER, iamSettings.horizontalAlignment)
+        assertEquals(InAppMessageSettings.MessageAnimation.NONE, iamSettings.displayAnimation)
+        assertEquals(InAppMessageSettings.MessageAnimation.NONE, iamSettings.dismissAnimation)
+        assertEquals("#000000", iamSettings.backdropColor)
+        assertEquals(0.0f, iamSettings.backdropOpacity)
+        assertEquals(0.0f, iamSettings.cornerRadius)
+        assertFalse(iamSettings.shouldTakeOverUi)
+        assertTrue(iamSettings.assetMap.isEmpty())
+        assertTrue(iamSettings.gestureMap.isEmpty())
+    }
+
+    @Test
+    fun `Test InAppMessageSettings with negative height, width needing clipping`() {
+        val iamSettings = InAppMessageSettings.Builder()
+            .height(-50)
+            .width(-50)
+            .build()
+        assertEquals("", iamSettings.content)
+        assertEquals(0, iamSettings.width)
+        assertEquals(0, iamSettings.height)
+        assertEquals(0, iamSettings.verticalInset)
+        assertEquals(0, iamSettings.horizontalInset)
+        assertEquals(InAppMessageSettings.MessageAlignment.CENTER, iamSettings.verticalAlignment)
+        assertEquals(InAppMessageSettings.MessageAlignment.CENTER, iamSettings.horizontalAlignment)
+        assertEquals(InAppMessageSettings.MessageAnimation.NONE, iamSettings.displayAnimation)
+        assertEquals(InAppMessageSettings.MessageAnimation.NONE, iamSettings.dismissAnimation)
+        assertEquals("#000000", iamSettings.backdropColor)
+        assertEquals(0.0f, iamSettings.backdropOpacity)
+        assertEquals(0.0f, iamSettings.cornerRadius)
+        assertFalse(iamSettings.shouldTakeOverUi)
+        assertTrue(iamSettings.assetMap.isEmpty())
+        assertTrue(iamSettings.gestureMap.isEmpty())
+    }
+
+    @Test
+    fun `Test InAppMessageSettings with exceeding +ve insets and dimensions needing clipping`() {
+        val iamSettings = InAppMessageSettings.Builder()
+            .height(173)
+            .width(233)
+            .horizontalInset(220)
+            .verticalInset(220)
+            .build()
+        assertEquals("", iamSettings.content)
+        assertEquals(100, iamSettings.width)
+        assertEquals(100, iamSettings.height)
+        assertEquals(100, iamSettings.verticalInset)
+        assertEquals(100, iamSettings.horizontalInset)
+        assertEquals(InAppMessageSettings.MessageAlignment.CENTER, iamSettings.verticalAlignment)
+        assertEquals(InAppMessageSettings.MessageAlignment.CENTER, iamSettings.horizontalAlignment)
+        assertEquals(InAppMessageSettings.MessageAnimation.NONE, iamSettings.displayAnimation)
+        assertEquals(InAppMessageSettings.MessageAnimation.NONE, iamSettings.dismissAnimation)
+        assertEquals("#000000", iamSettings.backdropColor)
+        assertEquals(0.0f, iamSettings.backdropOpacity)
+        assertEquals(0.0f, iamSettings.cornerRadius)
+        assertFalse(iamSettings.shouldTakeOverUi)
+        assertTrue(iamSettings.assetMap.isEmpty())
+        assertTrue(iamSettings.gestureMap.isEmpty())
+    }
+
+    @Test
+    fun `Test InAppMessageSettings with exceeding -ve insets and dimensions needing clipping`() {
+        val iamSettings = InAppMessageSettings.Builder()
+            .height(-173)
+            .width(-233)
+            .horizontalInset(-220)
+            .verticalInset(-220)
+            .build()
+        assertEquals("", iamSettings.content)
+        assertEquals(0, iamSettings.width)
+        assertEquals(0, iamSettings.height)
+        assertEquals(-100, iamSettings.verticalInset)
+        assertEquals(-100, iamSettings.horizontalInset)
+        assertEquals(InAppMessageSettings.MessageAlignment.CENTER, iamSettings.verticalAlignment)
+        assertEquals(InAppMessageSettings.MessageAlignment.CENTER, iamSettings.horizontalAlignment)
+        assertEquals(InAppMessageSettings.MessageAnimation.NONE, iamSettings.displayAnimation)
+        assertEquals(InAppMessageSettings.MessageAnimation.NONE, iamSettings.dismissAnimation)
+        assertEquals("#000000", iamSettings.backdropColor)
+        assertEquals(0.0f, iamSettings.backdropOpacity)
+        assertEquals(0.0f, iamSettings.cornerRadius)
+        assertFalse(iamSettings.shouldTakeOverUi)
+        assertTrue(iamSettings.assetMap.isEmpty())
+        assertTrue(iamSettings.gestureMap.isEmpty())
+    }
+
+    @Test
     fun `Test InAppMessageSettings with custom params`() {
         val iamSettings = InAppMessageSettings.Builder()
             .content("<html><head><body>Hi</body></head></html>")

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/message/mapping/MessageOffsetMapperTest.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/message/mapping/MessageOffsetMapperTest.kt
@@ -1,0 +1,188 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.services.ui.message.mapping
+
+import androidx.compose.ui.unit.dp
+import com.adobe.marketing.mobile.services.ui.message.InAppMessageSettings
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MessageOffsetMapperTest {
+
+    @Test
+    fun `Test #getHorizontalOffset with LEFT alignment and +ve offset`() {
+        // setup
+        val horizontalAlignment = InAppMessageSettings.MessageAlignment.LEFT
+        val offsetPercent = 10
+        val screenWidthDp = 100.dp
+
+        // test
+        val result = MessageOffsetMapper.getHorizontalOffset(horizontalAlignment, offsetPercent, screenWidthDp)
+
+        // verify
+        assertEquals(10.dp, result)
+    }
+
+    @Test
+    fun `Test #getHorizontalOffset with LEFT alignment and -ve offset`() {
+        // setup
+        val horizontalAlignment = InAppMessageSettings.MessageAlignment.LEFT
+        val offsetPercent = -10
+        val screenWidthDp = 100.dp
+
+        // test
+        val result = MessageOffsetMapper.getHorizontalOffset(horizontalAlignment, offsetPercent, screenWidthDp)
+
+        // verify
+        assertEquals(-10.dp, result)
+    }
+
+    @Test
+    fun `Test #getHorizontalOffset with RIGHT alignment and +ve offset`() {
+        // setup
+        val horizontalAlignment = InAppMessageSettings.MessageAlignment.RIGHT
+        val offsetPercent = 10
+        val screenWidthDp = 100.dp
+
+        // test
+        val result = MessageOffsetMapper.getHorizontalOffset(horizontalAlignment, offsetPercent, screenWidthDp)
+
+        // verify
+        assertEquals(-10.dp, result)
+    }
+
+    @Test
+    fun `Test #getHorizontalOffset with RIGHT alignment and -ve offset`() {
+        // setup
+        val horizontalAlignment = InAppMessageSettings.MessageAlignment.RIGHT
+        val offsetPercent = -10
+        val screenWidthDp = 100.dp
+
+        // test
+        val result = MessageOffsetMapper.getHorizontalOffset(horizontalAlignment, offsetPercent, screenWidthDp)
+
+        // verify
+        assertEquals(10.dp, result)
+    }
+
+    @Test
+    fun `Test #getHorizontalOffset with CENTER alignment`() {
+        // setup
+        val horizontalAlignment = InAppMessageSettings.MessageAlignment.CENTER
+        val offsetPercent = 10
+        val screenWidthDp = 100.dp
+
+        // test
+        val result = MessageOffsetMapper.getHorizontalOffset(horizontalAlignment, offsetPercent, screenWidthDp)
+
+        // verify
+        assertEquals(0.dp, result)
+    }
+
+    @Test
+    fun `Test #getVerticalOffset with TOP alignment and +ve offset`() {
+        // setup
+        val verticalAlignment = InAppMessageSettings.MessageAlignment.TOP
+        val offsetPercent = 10
+        val screenHeightDp = 100.dp
+
+        // test
+        val result = MessageOffsetMapper.getVerticalOffset(verticalAlignment, offsetPercent, screenHeightDp)
+
+        // verify
+        assertEquals(10.dp, result)
+    }
+
+    @Test
+    fun `Test #getVerticalOffset with TOP alignment and -ve offset`() {
+        // setup
+        val verticalAlignment = InAppMessageSettings.MessageAlignment.TOP
+        val offsetPercent = -10
+        val screenHeightDp = 100.dp
+
+        // test
+        val result = MessageOffsetMapper.getVerticalOffset(verticalAlignment, offsetPercent, screenHeightDp)
+
+        // verify
+        assertEquals(-10.dp, result)
+    }
+
+    @Test
+    fun `Test #getVerticalOffset with BOTTOM alignment and +ve offset`() {
+        // setup
+        val verticalAlignment = InAppMessageSettings.MessageAlignment.BOTTOM
+        val offsetPercent = 10
+        val screenHeightDp = 100.dp
+
+        // test
+        val result = MessageOffsetMapper.getVerticalOffset(verticalAlignment, offsetPercent, screenHeightDp)
+
+        // verify
+        assertEquals(-10.dp, result)
+    }
+
+    @Test
+    fun `Test #getVerticalOffset with BOTTOM alignment and -ve offset`() {
+        // setup
+        val verticalAlignment = InAppMessageSettings.MessageAlignment.BOTTOM
+        val offsetPercent = -10
+        val screenHeightDp = 100.dp
+
+        // test
+        val result = MessageOffsetMapper.getVerticalOffset(verticalAlignment, offsetPercent, screenHeightDp)
+
+        // verify
+        assertEquals(10.dp, result)
+    }
+
+    @Test
+    fun `Test #getVerticalOffset with CENTER alignment`() {
+        // setup
+        val verticalAlignment = InAppMessageSettings.MessageAlignment.CENTER
+        val offsetPercent = 10
+        val screenHeightDp = 100.dp
+
+        // test
+        val result = MessageOffsetMapper.getVerticalOffset(verticalAlignment, offsetPercent, screenHeightDp)
+
+        // verify
+        assertEquals(0.dp, result)
+    }
+
+    @Test
+    fun `Test #getVerticalOffset with invalid vertical alignment`() {
+        // setup
+        val verticalAlignment = InAppMessageSettings.MessageAlignment.RIGHT
+        val offsetPercent = 10
+        val screenHeightDp = 100.dp
+
+        // test
+        val result = MessageOffsetMapper.getVerticalOffset(verticalAlignment, offsetPercent, screenHeightDp)
+
+        // verify
+        assertEquals(0.dp, result)
+    }
+
+    @Test
+    fun `Test #getHorizontalOffset with invalid horizontal alignment`() {
+        // setup
+        val horizontalAlignment = InAppMessageSettings.MessageAlignment.TOP
+        val offsetPercent = 10
+        val screenWidthDp = 100.dp
+
+        // test
+        val result = MessageOffsetMapper.getHorizontalOffset(horizontalAlignment, offsetPercent, screenWidthDp)
+
+        // verify
+        assertEquals(0.dp, result)
+    }
+}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently, InAppMessages use the horizontal and vertical insets from in-app message settings as padding values. However, the intended behavior is that the insets act as offsets relative to the alignment and screen dimensions.
Fix the behavior based on the spec and production behavior

<!--- Describe your changes in detail -->

## Related Issue
MOB-20535
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Currently, InAppMessages use the horizontal and vertical insets from in-app message settings as padding values. However, the intended behavior is that the insets act as offsets relative to the alignment and screen dimensions.
Fix the behavior based on the spec and production behavior

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
