### PR TITLE
[Android 3.0.0] Adopt the network service changes in Identity

### DIFF
--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -912,6 +912,7 @@ public final class IdentityExtension extends Extension {
             final String urlString =
                     buildURLString(
                             currentCustomerIds, dpids, latestValidConfig, didAdidConsentChange);
+            // URLBuilder will return null, if the final URL is invalid. Drop the hit in that case.
             if (urlString != null) {
                 IdentityHit hit = new IdentityHit(urlString, event);
                 hitQueue.queue(hit.toDataEntity());

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -628,6 +628,11 @@ public final class IdentityExtension extends Extension {
                 networkRequest,
                 connection -> {
                     if (connection == null) {
+                        Log.trace(
+                                IdentityConstants.LOG_TAG,
+                                LOG_SOURCE,
+                                "sendOptOutHit - Failed to send the opt-out hit because the"
+                                        + " connection  is null(device is offline).");
                         return;
                     }
 
@@ -907,8 +912,16 @@ public final class IdentityExtension extends Extension {
             final String urlString =
                     buildURLString(
                             currentCustomerIds, dpids, latestValidConfig, didAdidConsentChange);
-            IdentityHit hit = new IdentityHit(urlString, event);
-            hitQueue.queue(hit.toDataEntity());
+            if (urlString != null) {
+                IdentityHit hit = new IdentityHit(urlString, event);
+                hitQueue.queue(hit.toDataEntity());
+            } else {
+                Log.warning(
+                        IdentityConstants.LOG_TAG,
+                        LOG_SOURCE,
+                        "handleSyncIdentifiers : Ignoring ID sync because the URL is invalid.");
+            }
+
         } else {
             // nothing to sync
             Log.debug(

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityHitsProcessing.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityHitsProcessing.java
@@ -84,17 +84,13 @@ class IdentityHitsProcessing implements HitProcessing {
                         networkRequest,
                         connection -> {
                             if (connection == null) {
+                                // connection is null when the device is offline
                                 Log.debug(
                                         IdentityConstants.LOG_TAG,
                                         LOG_SOURCE,
-                                        "IdentityHitsDatabase.process : An unknown error occurred"
-                                                + " during the Identity network call, connection is"
-                                                + " null. Will not retry.");
-
-                                // make sure the parent updates shared state and notifies one-time
-                                // listeners accordingly
-                                identityExtension.networkResponseLoaded(null, hit.getEvent());
-                                processingResult.complete(true);
+                                        "IdentityHitsDatabase.process : network connection is"
+                                                + " null. Will retry later.");
+                                processingResult.complete(false);
                                 return;
                             }
                             if (connection.getResponseCode() == HttpURLConnection.HTTP_OK) {

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityHitsProcessingTests.kt
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityHitsProcessingTests.kt
@@ -34,6 +34,7 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
 import java.io.InputStream
 import java.util.concurrent.CountDownLatch
 
@@ -131,19 +132,16 @@ class IdentityHitsProcessingTests {
         jsonObject.put("EVENT", EventCoder.encode(event))
 
         ServiceProvider.getInstance().networkService = Networking { _, callback ->
-
             callback.call(null)
         }
-        val countDownLatch = CountDownLatch(2)
-        doAnswer { invocation ->
-            assertNull(invocation.arguments[0])
-            countDownLatch.countDown()
-        }.`when`(mockedIdentityExtension).networkResponseLoaded(anyOrNull(), any())
+        val countDownLatch = CountDownLatch(1)
         identityHitsProcessing.processHit(DataEntity(jsonObject.toString())) {
-            assertTrue(it)
+            assertFalse(it)
             countDownLatch.countDown()
         }
         countDownLatch.await()
+
+        verifyNoMoreInteractions(mockedIdentityExtension)
     }
 
     @Test(timeout = 10000)


### PR DESCRIPTION
The Identity extension is updated to adopt the network service changes added in Android Core 3.0.0. (https://github.com/adobe/aepsdk-core-android/pull/612) 

The test cases mentioned below have been tested on both the Android device (API level 34) and the emulator (API level 21/34).
1. When the device’s network is **online**, call `setPushIdentifier` API multiple times and check the requests are sent out correctly. (monitored through Android Studio’s network inspector view)
2. When the device’s network is **offline**, call `setPushIdentifier` API multiple times (requests should be queued), and there is no network connection established (monitored through Android Studio’s network inspector view)
3. The queued requests are sent out correctly after the device’s network is back **online**.
4. New requests can be sent out immediately if the device’s network is still **online**.

Simulated device/emulator online and offline situations by using:
- Turn on/off the airplane mode
- Turn on/off Wifi+Cellular