### PR TITLE
Use InAppMessage dimensions relative to host activity

### DIFF
--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageContent.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageContent.kt
@@ -16,17 +16,13 @@ import android.webkit.WebView
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.adobe.marketing.mobile.services.Log
@@ -38,23 +34,18 @@ import java.nio.charset.StandardCharsets
 
 /**
  * Represents the content of the InAppMessage. Holds a WebView that loads the HTML content of the message
+ * @param modifier [Modifier] to apply to the content (AndroidView holding the WebView)
  * @param inAppMessageSettings [InAppMessageSettings] settings for the InAppMessage
  * @param onCreated callback to be invoked when the WenView that this composable holds is created
  * @param gestureTracker [GestureTracker] to track the swipe/drag gestures on the webview
  */
 @Composable
 internal fun MessageContent(
+    modifier: Modifier,
     inAppMessageSettings: InAppMessageSettings,
     onCreated: (WebView) -> Unit,
     gestureTracker: GestureTracker
 ) {
-    // Size variables
-    val currentConfiguration = LocalConfiguration.current
-    val heightDp: Dp =
-        remember { ((currentConfiguration.screenHeightDp * inAppMessageSettings.height) / 100).dp }
-    val widthDp: Dp =
-        remember { ((currentConfiguration.screenWidthDp * inAppMessageSettings.width) / 100).dp }
-
     // Swipe/Drag variables
     val offsetX = remember { mutableStateOf(0f) }
     val offsetY = remember { mutableStateOf(0f) }
@@ -89,9 +80,7 @@ internal fun MessageContent(
                 )
             }
         },
-        modifier = Modifier
-            .height(heightDp)
-            .width(widthDp)
+        modifier = modifier
             .clip(RoundedCornerShape(inAppMessageSettings.cornerRadius.dp))
             .draggable(
                 state = rememberDraggableState { delta ->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
**Problem** : Currently, the size of the InAppMessage is based on the screen height and width. This displays the IAM ass desired for all single activity cases. However, this is not always the case when the activity is not occupying the entire screen.
Such cases will see a full screen message within the activity irrespective of the dimensions of the actual content size of
the activity. So 70% height would be 70% screen height and exceed the activity content view height where as it should have been 70% of the height within the activity.

**Solution**: Use the Use InAppMessage dimensions relative to host activity and not the entire screen.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
**Problem** : Currently, the size of the InAppMessage is based on the screen height and width. This displays the IAM ass desired for all single activity cases. However, this is not always the case when the activity is not occupying the entire screen.
Such cases will see a full screen message within the activity irrespective of the dimensions of the actual content size of
the activity. So 70% height would be 70% screen height and exceed the activity content view height where as it should have been 70% of the height within the activity.

**Solution**: Use the Use InAppMessage dimensions relative to host activity and not the entire screen.

<!--- Why is this change required? What problem does it solve? -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
