### PR TITLE
Publish Lifecycle, Signal, Identity with `core:3.0.0.beta.1-SNAPSHOT` dependancies

### DIFF
--- a/code/identity/build.gradle.kts
+++ b/code/identity/build.gradle.kts
@@ -18,7 +18,9 @@ aepLibrary {
         mavenRepoName = identityMavenRepoName
         mavenRepoDescription = identityMavenRepoDescription
         gitRepoName = "aepsdk-core-android"
-        addCoreDependency(coreExtensionVersion)
+
+        // Stop using snapshot version after release
+        addCoreDependency("$coreExtensionVersion-SNAPSHPOT")
     }
 }
 

--- a/code/lifecycle/build.gradle.kts
+++ b/code/lifecycle/build.gradle.kts
@@ -18,7 +18,9 @@ aepLibrary {
         mavenRepoName = lifecycleMavenRepoName
         mavenRepoDescription = lifecycleMavenRepoDescription
         gitRepoName = "aepsdk-core-android"
-        addCoreDependency(coreExtensionVersion)
+
+        // Stop using snapshot version after release
+        addCoreDependency("$coreExtensionVersion-SNAPSHPOT")
     }
 }
 

--- a/code/signal/build.gradle.kts
+++ b/code/signal/build.gradle.kts
@@ -19,7 +19,9 @@ aepLibrary {
         mavenRepoName = signalMavenRepoName
         mavenRepoDescription = signalMavenRepoDescription
         gitRepoName = "aepsdk-core-android"
-        addCoreDependency(coreExtensionVersion)
+
+        // Stop using snapshot version after release
+        addCoreDependency("$coreExtensionVersion-SNAPSHPOT")
     }
 }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Publish Lifecycle, Signal, Identity use the `coreExtensionVersion` to publish dependencies in POM. 
`addCoreDependency()`  from the aep-library plugin being [used inside the ](https://github.com/adobe/aepsdk-userprofile-android/blob/dev-v3.0.0/code/userprofile/build.gradle.kts#L14) `build.gradle.kts` for extensions do not have a way to know that the current build variant being built. So the SNAPSHOT  suffix is not being added to dependancies
Use "$coreExtensionVersion-SNAPSHPOT" instead.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Publish Lifecycle, Signal, Identity use the `coreExtensionVersion` to publish dependencies in POM. 

`addCoreDependency()`  from the aep-library plugin being [used inside the ](https://github.com/adobe/aepsdk-userprofile-android/blob/dev-v3.0.0/code/userprofile/build.gradle.kts#L14) `build.gradle.kts` for extensions do not have a way to know that the current build variant being built. So the SNAPSHOT  suffix is not being added to dependancies
Use "$coreExtensionVersion-SNAPSHPOT" instead.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
