### PR TITLE
Fix InAppMessage Scrolling

### DIFF
--- a/code/core/src/androidTest/java/com/adobe/marketing/mobile/services/ui/message/views/MessageScreenTests.kt
+++ b/code/core/src/androidTest/java/com/adobe/marketing/mobile/services/ui/message/views/MessageScreenTests.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onRoot
-import androidx.compose.ui.test.performGesture
+import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeWithVelocity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpRect
@@ -236,7 +236,7 @@ class MessageScreenTests {
         composeTestRule.waitForIdle()
         validateMessageAppeared(true)
         // Swipe gestures
-        composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).performGesture {
+        composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).performTouchInput {
             // create a swipe right gesture
             swipeWithVelocity(
                 start = Offset(100f, 10f),
@@ -274,7 +274,7 @@ class MessageScreenTests {
         validateMessageAppeared(false)
 
         // Swipe gestures
-        composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).performGesture {
+        composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).performTouchInput {
             // create a swipe right gesture
             swipeWithVelocity(
                 start = Offset(100f, 10f),
@@ -312,7 +312,7 @@ class MessageScreenTests {
         validateMessageAppeared(true)
 
         // Swipe gestures
-        composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).performGesture {
+        composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).assertIsDisplayed().performTouchInput {
             // create a swipe down gesture
             swipeWithVelocity(
                 start = Offset(0f, 10f),
@@ -320,9 +320,10 @@ class MessageScreenTests {
                 endVelocity = 1000f
             )
         }
+
         composeTestRule.waitForIdle()
 
-        composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_BACKDROP).performGesture {
+        composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_BACKDROP).assertIsDisplayed().performTouchInput {
             click(
                 Offset(100f, 10f)
             )

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageContent.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageContent.kt
@@ -41,8 +41,7 @@ import java.nio.charset.StandardCharsets
 @Composable
 internal fun MessageContent(
     inAppMessageSettings: InAppMessageSettings,
-    onCreated: (WebView) -> Unit,
-    gestureTracker: GestureTracker
+    onCreated: (WebView) -> Unit
 ) {
     // Size variables
     val currentConfiguration = LocalConfiguration.current

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageContent.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageContent.kt
@@ -13,14 +13,10 @@ package com.adobe.marketing.mobile.services.ui.message.views
 
 import android.view.ViewGroup
 import android.webkit.WebView
-import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.gestures.draggable
-import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -55,11 +51,6 @@ internal fun MessageContent(
     val widthDp: Dp =
         remember { ((currentConfiguration.screenWidthDp * inAppMessageSettings.width) / 100).dp }
 
-    // Swipe/Drag variables
-    val offsetX = remember { mutableStateOf(0f) }
-    val offsetY = remember { mutableStateOf(0f) }
-    val dragVelocity = remember { mutableStateOf(0f) }
-
     AndroidView(
         factory = {
             WebView(it).apply {
@@ -93,30 +84,6 @@ internal fun MessageContent(
             .height(heightDp)
             .width(widthDp)
             .clip(RoundedCornerShape(inAppMessageSettings.cornerRadius.dp))
-            .draggable(
-                state = rememberDraggableState { delta ->
-                    offsetX.value += delta
-                },
-                orientation = Orientation.Horizontal,
-                onDragStopped = { velocity ->
-                    gestureTracker.onDragFinished(offsetX.value, offsetY.value, velocity)
-                    dragVelocity.value = 0f
-                    offsetY.value = 0f
-                    offsetX.value = 0f
-                }
-            )
-            .draggable(
-                state = rememberDraggableState { delta ->
-                    offsetY.value += delta
-                },
-                orientation = Orientation.Vertical,
-                onDragStopped = { velocity ->
-                    gestureTracker.onDragFinished(offsetX.value, offsetY.value, velocity)
-                    dragVelocity.value = 0f
-                    offsetY.value = 0f
-                    offsetX.value = 0f
-                }
-            ).testTag(MessageTestTags.MESSAGE_CONTENT)
-
+            .testTag(MessageTestTags.MESSAGE_CONTENT)
     )
 }

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageFrame.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageFrame.kt
@@ -136,7 +136,7 @@ internal fun MessageFrame(
             // the WebView message is clipped to the rounded corners for API versions 22 and below. This does not
             // affect the appearance of the message on API versions 23 and above.
             Card(modifier = Modifier.clip(RoundedCornerShape(inAppMessageSettings.cornerRadius.dp)).alpha(0.99f)) {
-                MessageContent(inAppMessageSettings, onCreated, gestureTracker)
+                MessageContent(inAppMessageSettings, onCreated)
             }
 
             // This is a one-time effect that will be called when this composable is completely removed from the composition

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageFrame.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageFrame.kt
@@ -92,40 +92,6 @@ internal fun MessageFrame(
                 .fillMaxSize()
                 .offset(x = horizontalOffset, y = verticalOffset)
                 .background(Color.Transparent)
-                .draggable(
-                    enabled = allowGestures,
-                    state = rememberDraggableState { delta ->
-                        offsetX.value += delta
-                    },
-                    orientation = Orientation.Horizontal,
-                    onDragStopped = { velocity ->
-                        gestureTracker.onDragFinished(
-                            offsetX.value,
-                            offsetY.value,
-                            velocity
-                        )
-                        dragVelocity.value = 0f
-                        offsetY.value = 0f
-                        offsetX.value = 0f
-                    }
-                )
-                .draggable(
-                    enabled = allowGestures,
-                    state = rememberDraggableState { delta ->
-                        offsetY.value += delta
-                    },
-                    orientation = Orientation.Vertical,
-                    onDragStopped = { velocity ->
-                        gestureTracker.onDragFinished(
-                            offsetX.value,
-                            offsetY.value,
-                            velocity
-                        )
-                        dragVelocity.value = 0f
-                        offsetY.value = 0f
-                        offsetX.value = 0f
-                    }
-                )
                 .testTag(MessageTestTags.MESSAGE_FRAME),
             horizontalArrangement = MessageArrangementMapper.getHorizontalArrangement(
                 inAppMessageSettings.horizontalAlignment
@@ -135,7 +101,45 @@ internal fun MessageFrame(
             // The content of the InAppMessage. This needs to be placed inside a Card with .99 alpha to ensure that
             // the WebView message is clipped to the rounded corners for API versions 22 and below. This does not
             // affect the appearance of the message on API versions 23 and above.
-            Card(modifier = Modifier.clip(RoundedCornerShape(inAppMessageSettings.cornerRadius.dp)).alpha(0.99f)) {
+            Card(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(inAppMessageSettings.cornerRadius.dp))
+                    .alpha(0.99f)
+                    .draggable(
+                        enabled = allowGestures,
+                        state = rememberDraggableState { delta ->
+                            offsetX.value += delta
+                        },
+                        orientation = Orientation.Horizontal,
+                        onDragStopped = { velocity ->
+                            gestureTracker.onDragFinished(
+                                offsetX.value,
+                                offsetY.value,
+                                velocity
+                            )
+                            dragVelocity.value = 0f
+                            offsetY.value = 0f
+                            offsetX.value = 0f
+                        }
+                    )
+                    .draggable(
+                        enabled = allowGestures,
+                        state = rememberDraggableState { delta ->
+                            offsetY.value += delta
+                        },
+                        orientation = Orientation.Vertical,
+                        onDragStopped = { velocity ->
+                            gestureTracker.onDragFinished(
+                                offsetX.value,
+                                offsetY.value,
+                                velocity
+                            )
+                            dragVelocity.value = 0f
+                            offsetY.value = 0f
+                            offsetX.value = 0f
+                        }
+                    )
+            ) {
                 MessageContent(inAppMessageSettings, onCreated)
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

**Problem**: Currently, InAppMessages with content overflowing the bounds are not scrollable even when gestures are disabled. This is because the `draggable` effect on the AndroidView that hosts the WebView is conflicting with the WebViews scroll (`isHorizontalScrollEnabled`, `isVerticalScrollEnabled`).

**Solution**: Apply gesture detection on the frame of the WebView i.e the Card inside the `MessageFrame` and ensure that it is enabled only if gestures are not available.

Also fixed deprecated usage of `performGesture` with `performTouchInput`

<!--- Describe your changes in detail -->

## Related Issue
#638 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Manual test with test app.
- Jetpack test suite does not support scroll verification, the swipe verification instrumented tests pass.
    -  No gestures defined + swipe/scroll on in-app message => scrolls webveiw
    - Gestured defined + swipe + swipe/scroll on in-app message => No change

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
