### PR TITLE
Lifecycle v2 enhancement (app upgrade)

### DIFF
--- a/code/lifecycle/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtil.java
+++ b/code/lifecycle/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtil.java
@@ -96,7 +96,7 @@ final class LifecycleUtil {
      * @param deviceInfoService DeviceInfoService instance
      * @return application version
      */
-    static String getAppVersion(final DeviceInforming deviceInfoService) {
+    static String getV2AppVersion(final DeviceInforming deviceInfoService) {
         if (deviceInfoService == null) {
             return null;
         }

--- a/code/lifecycle/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtil.java
+++ b/code/lifecycle/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleUtil.java
@@ -11,6 +11,7 @@
 
 package com.adobe.marketing.mobile.lifecycle;
 
+import com.adobe.marketing.mobile.services.DeviceInforming;
 import com.adobe.marketing.mobile.util.StringUtils;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -86,5 +87,28 @@ final class LifecycleUtil {
         }
 
         return locale.toLanguageTag();
+    }
+
+    /**
+     * Returns the application version in the format of "appVersion (versionCode)". Example: 2.3
+     * (10)
+     *
+     * @param deviceInfoService DeviceInfoService instance
+     * @return application version
+     */
+    static String getAppVersion(final DeviceInforming deviceInfoService) {
+        if (deviceInfoService == null) {
+            return null;
+        }
+        final String applicationVersion = deviceInfoService.getApplicationVersion();
+        final String applicationVersionCode = deviceInfoService.getApplicationVersionCode();
+        return String.format(
+                "%s%s",
+                !StringUtils.isNullOrEmpty(applicationVersion)
+                        ? String.format("%s", applicationVersion)
+                        : "",
+                !StringUtils.isNullOrEmpty(applicationVersionCode)
+                        ? String.format(" (%s)", applicationVersionCode)
+                        : "");
     }
 }

--- a/code/lifecycle/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2Extension.java
+++ b/code/lifecycle/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2Extension.java
@@ -210,8 +210,16 @@ class LifecycleV2Extension {
         if (dataStore != null && deviceInfoService != null) {
             dataStore.setString(
                     LifecycleV2Constants.DataStoreKeys.LAST_APP_VERSION,
-                    deviceInfoService.getApplicationVersion());
+                    generateAppFullVersion(
+                            deviceInfoService.getApplicationVersion(),
+                            deviceInfoService.getApplicationVersionCode()));
         }
+    }
+
+    private String generateAppFullVersion(String appVersion, String appVersionCode) {
+        String validAppVersion = StringUtils.isNullOrEmpty(appVersion) ? "": appVersion;
+        String validAppVersionCode = StringUtils.isNullOrEmpty(appVersionCode) ? "": appVersionCode;
+        return String.format("%s(%s)", validAppVersion, validAppVersionCode);
     }
 
     /**

--- a/code/lifecycle/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2Extension.java
+++ b/code/lifecycle/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2Extension.java
@@ -217,8 +217,9 @@ class LifecycleV2Extension {
     }
 
     private String generateAppFullVersion(String appVersion, String appVersionCode) {
-        String validAppVersion = StringUtils.isNullOrEmpty(appVersion) ? "": appVersion;
-        String validAppVersionCode = StringUtils.isNullOrEmpty(appVersionCode) ? "": appVersionCode;
+        String validAppVersion = StringUtils.isNullOrEmpty(appVersion) ? "" : appVersion;
+        String validAppVersionCode =
+                StringUtils.isNullOrEmpty(appVersionCode) ? "" : appVersionCode;
         return String.format("%s(%s)", validAppVersion, validAppVersionCode);
     }
 

--- a/code/lifecycle/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2Extension.java
+++ b/code/lifecycle/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2Extension.java
@@ -201,7 +201,7 @@ class LifecycleV2Extension {
 
         return (deviceInfoService != null
                 && !StringUtils.isNullOrEmpty(previousAppVersion)
-                && !previousAppVersion.equalsIgnoreCase(deviceInfoService.getApplicationVersion()));
+                && !previousAppVersion.equalsIgnoreCase(getAppFullVersion()));
     }
 
     /** Persist the application version into datastore */
@@ -209,14 +209,13 @@ class LifecycleV2Extension {
         // Persist app version for xdm workflow
         if (dataStore != null && deviceInfoService != null) {
             dataStore.setString(
-                    LifecycleV2Constants.DataStoreKeys.LAST_APP_VERSION,
-                    generateAppFullVersion(
-                            deviceInfoService.getApplicationVersion(),
-                            deviceInfoService.getApplicationVersionCode()));
+                    LifecycleV2Constants.DataStoreKeys.LAST_APP_VERSION, getAppFullVersion());
         }
     }
 
-    private String generateAppFullVersion(String appVersion, String appVersionCode) {
+    private String getAppFullVersion() {
+        String appVersion = deviceInfoService.getApplicationVersion();
+        String appVersionCode = deviceInfoService.getApplicationVersionCode();
         String validAppVersion = StringUtils.isNullOrEmpty(appVersion) ? "" : appVersion;
         String validAppVersionCode =
                 StringUtils.isNullOrEmpty(appVersionCode) ? "" : appVersionCode;

--- a/code/lifecycle/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2Extension.java
+++ b/code/lifecycle/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2Extension.java
@@ -201,7 +201,8 @@ class LifecycleV2Extension {
 
         return (deviceInfoService != null
                 && !StringUtils.isNullOrEmpty(previousAppVersion)
-                && !previousAppVersion.equalsIgnoreCase(getAppVersion()));
+                && !previousAppVersion.equalsIgnoreCase(
+                        LifecycleUtil.getAppVersion(deviceInfoService)));
     }
 
     /** Persist the application version into datastore */
@@ -209,17 +210,9 @@ class LifecycleV2Extension {
         // Persist app version for xdm workflow
         if (dataStore != null && deviceInfoService != null) {
             dataStore.setString(
-                    LifecycleV2Constants.DataStoreKeys.LAST_APP_VERSION, getAppVersion());
+                    LifecycleV2Constants.DataStoreKeys.LAST_APP_VERSION,
+                    LifecycleUtil.getAppVersion(deviceInfoService));
         }
-    }
-
-    private String getAppVersion() {
-        String appVersion = deviceInfoService.getApplicationVersion();
-        String appVersionCode = deviceInfoService.getApplicationVersionCode();
-        String validAppVersion = StringUtils.isNullOrEmpty(appVersion) ? "" : appVersion;
-        String validAppVersionCode =
-                StringUtils.isNullOrEmpty(appVersionCode) ? "" : appVersionCode;
-        return String.format("%s(%s)", validAppVersion, validAppVersionCode);
     }
 
     /**

--- a/code/lifecycle/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2Extension.java
+++ b/code/lifecycle/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2Extension.java
@@ -202,7 +202,7 @@ class LifecycleV2Extension {
         return (deviceInfoService != null
                 && !StringUtils.isNullOrEmpty(previousAppVersion)
                 && !previousAppVersion.equalsIgnoreCase(
-                        LifecycleUtil.getAppVersion(deviceInfoService)));
+                        LifecycleUtil.getV2AppVersion(deviceInfoService)));
     }
 
     /** Persist the application version into datastore */
@@ -211,7 +211,7 @@ class LifecycleV2Extension {
         if (dataStore != null && deviceInfoService != null) {
             dataStore.setString(
                     LifecycleV2Constants.DataStoreKeys.LAST_APP_VERSION,
-                    LifecycleUtil.getAppVersion(deviceInfoService));
+                    LifecycleUtil.getV2AppVersion(deviceInfoService));
         }
     }
 

--- a/code/lifecycle/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2Extension.java
+++ b/code/lifecycle/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2Extension.java
@@ -201,7 +201,7 @@ class LifecycleV2Extension {
 
         return (deviceInfoService != null
                 && !StringUtils.isNullOrEmpty(previousAppVersion)
-                && !previousAppVersion.equalsIgnoreCase(getAppFullVersion()));
+                && !previousAppVersion.equalsIgnoreCase(getAppVersion()));
     }
 
     /** Persist the application version into datastore */
@@ -209,11 +209,11 @@ class LifecycleV2Extension {
         // Persist app version for xdm workflow
         if (dataStore != null && deviceInfoService != null) {
             dataStore.setString(
-                    LifecycleV2Constants.DataStoreKeys.LAST_APP_VERSION, getAppFullVersion());
+                    LifecycleV2Constants.DataStoreKeys.LAST_APP_VERSION, getAppVersion());
         }
     }
 
-    private String getAppFullVersion() {
+    private String getAppVersion() {
         String appVersion = deviceInfoService.getApplicationVersion();
         String appVersionCode = deviceInfoService.getApplicationVersionCode();
         String validAppVersion = StringUtils.isNullOrEmpty(appVersion) ? "" : appVersion;

--- a/code/lifecycle/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2MetricsBuilder.java
+++ b/code/lifecycle/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2MetricsBuilder.java
@@ -13,7 +13,6 @@ package com.adobe.marketing.mobile.lifecycle;
 
 import com.adobe.marketing.mobile.services.DeviceInforming;
 import com.adobe.marketing.mobile.services.Log;
-import com.adobe.marketing.mobile.util.StringUtils;
 import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -134,7 +133,7 @@ class LifecycleV2MetricsBuilder {
 
         xdmApplicationInfoLaunch.setName(deviceInfoService.getApplicationName());
         xdmApplicationInfoLaunch.setId(deviceInfoService.getApplicationPackageName());
-        xdmApplicationInfoLaunch.setVersion(getAppVersion());
+        xdmApplicationInfoLaunch.setVersion(LifecycleUtil.getAppVersion(deviceInfoService));
         xdmApplicationInfoLaunch.setLanguage(
                 LifecycleUtil.formatLocaleXDM(deviceInfoService.getActiveLocale()));
 
@@ -237,28 +236,6 @@ class LifecycleV2MetricsBuilder {
         xdmDeviceInfo.setManufacturer(deviceInfoService.getDeviceManufacturer());
 
         return xdmDeviceInfo;
-    }
-
-    /**
-     * Returns the application version in the format appVersion (versionCode). Example: 2.3 (10)
-     *
-     * @return the app version as a {@link String} formatted in the specified format.
-     */
-    private String getAppVersion() {
-        if (deviceInfoService == null) {
-            return null;
-        }
-
-        final String applicationVersion = deviceInfoService.getApplicationVersion();
-        final String applicationVersionCode = deviceInfoService.getApplicationVersionCode();
-        return String.format(
-                "%s%s",
-                !StringUtils.isNullOrEmpty(applicationVersion)
-                        ? String.format("%s", applicationVersion)
-                        : "",
-                !StringUtils.isNullOrEmpty(applicationVersionCode)
-                        ? String.format(" (%s)", applicationVersionCode)
-                        : "");
     }
 
     /**

--- a/code/lifecycle/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2MetricsBuilder.java
+++ b/code/lifecycle/src/main/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2MetricsBuilder.java
@@ -133,7 +133,7 @@ class LifecycleV2MetricsBuilder {
 
         xdmApplicationInfoLaunch.setName(deviceInfoService.getApplicationName());
         xdmApplicationInfoLaunch.setId(deviceInfoService.getApplicationPackageName());
-        xdmApplicationInfoLaunch.setVersion(LifecycleUtil.getAppVersion(deviceInfoService));
+        xdmApplicationInfoLaunch.setVersion(LifecycleUtil.getV2AppVersion(deviceInfoService));
         xdmApplicationInfoLaunch.setLanguage(
                 LifecycleUtil.formatLocaleXDM(deviceInfoService.getActiveLocale()));
 

--- a/code/lifecycle/src/test/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2ExtensionTest.java
+++ b/code/lifecycle/src/test/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2ExtensionTest.java
@@ -569,7 +569,7 @@ public class LifecycleV2ExtensionTest {
                     .thenReturn("1.1");
         } else {
             when(lifecycleDataStore.getString(eq(DATASTORE_KEY_LAST_APP_VERSION), anyString()))
-                    .thenReturn("1.1(12345)");
+                    .thenReturn("1.1 (12345)");
         }
     }
 }

--- a/code/lifecycle/src/test/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2ExtensionTest.java
+++ b/code/lifecycle/src/test/java/com/adobe/marketing/mobile/lifecycle/LifecycleV2ExtensionTest.java
@@ -561,8 +561,6 @@ public class LifecycleV2ExtensionTest {
 
         when(lifecycleDataStore.getLong(eq(DATASTORE_KEY_INSTALL_DATE), anyLong()))
                 .thenReturn(timestampOneDayEarlierMilliseconds);
-        when(lifecycleDataStore.getString(eq(DATASTORE_KEY_LAST_APP_VERSION), anyString()))
-                .thenReturn("1.0");
 
         if (isUpgrade) {
             when(lifecycleDataStore.getString(eq(DATASTORE_KEY_LAST_APP_VERSION), anyString()))


### PR DESCRIPTION
The lifecycle v2 extension detects app upgrades by comparing the stored `app version name` string with the current one. To improve detection accuracy, the system now updates to use the full version string in the format of `<version number> (<version code>)`, which matches how the app version is displayed in XDM objects.
To ensure consistency across platforms, we can release this change simultaneously for both the iOS and Android SDKs. We can merge this PR at a later time, once we have decided on the release date.
