### PR TITLE
Notify PresentationDelegate on all webview uri's

### DIFF
--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/uri/UriService.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/uri/UriService.kt
@@ -47,7 +47,7 @@ internal class UriService : UriOpening {
             currentActivity.startActivity(intent)
             true
         } catch (e: Exception) {
-            Log.debug(ServiceConstants.LOG_TAG, LOG_TAG, "Failed to open URI: $uri")
+            Log.debug(ServiceConstants.LOG_TAG, LOG_TAG, "Failed to open URI: $uri. ${e.message}")
             false
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently, presentation delegate notifies only the url's opened by the UriService - which is a regression from 2.x (where all successfully opened URI's were notified)
As a solution change the logic to make UiService handle both uri's and url's if the event listener is unable to handle them. Further, notify PresentationDelegate of all uri's opened as part of the interaction.

- Update `handleInAppUri` to `handleInAppUri`
- Remove url validation because we now handle all URI's (handled by UriService)
- Add tests

<!--- Describe your changes in detail -->

## Related Issue
(Internal) MOB-20924
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Currently, presentation delegate notifies only the url's opened by the UriService which is a regression from 2.x.

Change the logic to make UiService handle both uri's and url's if the event listener is unable to handle them. Further, notify PresentationDelegate of all uri's opened as part of the interaction.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
