### PR TITLE
port fixes from ACC 2.1.6: support mutliple lines of text and fix widescreen image cropping in carousel templates

### DIFF
--- a/code/core/src/main/res/layout/push_template_auto_carousel.xml
+++ b/code/core/src/main/res/layout/push_template_auto_carousel.xml
@@ -3,6 +3,8 @@
     android:id="@+id/carousel_container_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:clipToPadding="false"
+    android:clipChildren="false"
     android:orientation="vertical">
 
     <ImageView
@@ -15,7 +17,7 @@
         android:id="@+id/notification_title"
         style="@style/Title"
         android:layout_width="match_parent"
-        android:layout_height="20dp"
+        android:layout_height="wrap_content"
         android:layout_gravity="start"
         android:textAlignment="viewStart"
         android:layout_toLeftOf="@+id/large_icon"/>
@@ -24,7 +26,7 @@
         android:id="@+id/notification_body_expanded"
         style="@style/Body"
         android:layout_width="match_parent"
-        android:layout_height="30dp"
+        android:layout_height="wrap_content"
         android:layout_gravity="start"
         android:textAlignment="viewStart"
         android:layout_below="@id/notification_title"
@@ -33,11 +35,10 @@
     <ViewFlipper
         android:id="@+id/auto_carousel_view_flipper"
         android:layout_width="match_parent"
-        android:layout_height="300dp"
+        android:layout_height="wrap_content"
         android:autoStart="true"
         android:flipInterval="5000"
-        android:layout_gravity="center"
-        android:scaleType="centerCrop"
+        android:scaleType="fitCenter"
         android:adjustViewBounds="true"
         android:layout_below="@id/notification_body_expanded"
         android:inAnimation="@android:anim/slide_in_left"

--- a/code/core/src/main/res/layout/push_template_auto_carousel.xml
+++ b/code/core/src/main/res/layout/push_template_auto_carousel.xml
@@ -9,8 +9,8 @@
 
     <ImageView
         android:id="@+id/large_icon"
-        android:layout_height="35dp"
-        android:layout_width="35dp"
+        android:layout_height="@dimen/large_icon_height"
+        android:layout_width="@dimen/large_icon_width"
         android:layout_alignParentRight="true" />
 
     <TextView

--- a/code/core/src/main/res/layout/push_template_carousel_item.xml
+++ b/code/core/src/main/res/layout/push_template_carousel_item.xml
@@ -3,22 +3,24 @@
     android:id="@+id/carousel_container_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:clipToPadding="false"
+    android:clipChildren="false"
     android:orientation="vertical">
 
-    <ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+    <ImageView
         android:id="@+id/carousel_item_image_view"
         android:layout_centerHorizontal="true"
         android:layout_width="250dp"
-        android:scaleType="centerCrop"
+        android:scaleType="fitCenter"
         android:adjustViewBounds="true"
         android:layout_gravity="center"
         android:layout_height="200dp" />
 
     <TextView
         android:id="@+id/carousel_item_caption"
-        style="@style/TextAppearance.Compat.Notification.Title"
+        style="@style/Caption"
         android:layout_width="wrap_content"
-        android:layout_height="20dp"
+        android:layout_height="wrap_content"
         android:layout_below="@id/carousel_item_image_view"
         android:layout_centerHorizontal="true"
         android:layout_gravity="center" />

--- a/code/core/src/main/res/layout/push_template_carousel_item.xml
+++ b/code/core/src/main/res/layout/push_template_carousel_item.xml
@@ -10,11 +10,11 @@
     <ImageView
         android:id="@+id/carousel_item_image_view"
         android:layout_centerHorizontal="true"
-        android:layout_width="250dp"
+        android:layout_width="@dimen/carousel_item_layout_width"
         android:scaleType="fitCenter"
         android:adjustViewBounds="true"
         android:layout_gravity="center"
-        android:layout_height="200dp" />
+        android:layout_height="@dimen/carousel_item_layout_height" />
 
     <TextView
         android:id="@+id/carousel_item_caption"

--- a/code/core/src/main/res/layout/push_template_collapsed.xml
+++ b/code/core/src/main/res/layout/push_template_collapsed.xml
@@ -3,6 +3,8 @@
     android:id="@+id/basic_small_layout"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:clipToPadding="false"
+    android:clipChildren="false"
     android:orientation="vertical">
 
     <ImageView
@@ -15,7 +17,7 @@
         android:id="@+id/notification_title"
         style="@style/Title"
         android:layout_width="match_parent"
-        android:layout_height="25dp"
+        android:layout_height="wrap_content"
         android:layout_gravity="start"
         android:textAlignment="viewStart"
         android:layout_toLeftOf="@+id/large_icon"/>
@@ -24,7 +26,7 @@
         android:id="@+id/notification_body"
         style="@style/Body"
         android:layout_width="match_parent"
-        android:layout_height="25dp"
+        android:layout_height="wrap_content"
         android:layout_below="@id/notification_title"
         android:layout_gravity="start"
         android:textAlignment="viewStart"

--- a/code/core/src/main/res/layout/push_template_collapsed.xml
+++ b/code/core/src/main/res/layout/push_template_collapsed.xml
@@ -9,8 +9,8 @@
 
     <ImageView
         android:id="@+id/large_icon"
-        android:layout_height="35dp"
-        android:layout_width="35dp"
+        android:layout_height="@dimen/large_icon_height"
+        android:layout_width="@dimen/large_icon_width"
         android:layout_alignParentRight="true" />
 
     <TextView

--- a/code/core/src/main/res/layout/push_template_expanded.xml
+++ b/code/core/src/main/res/layout/push_template_expanded.xml
@@ -3,6 +3,8 @@
     android:id="@+id/basic_expanded_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:clipToPadding="false"
+    android:clipChildren="false"
     android:orientation="vertical">
 
     <ImageView
@@ -15,7 +17,7 @@
         android:id="@+id/notification_title"
         style="@style/Title"
         android:layout_width="match_parent"
-        android:layout_height="20dp"
+        android:layout_height="wrap_content"
         android:layout_gravity="start"
         android:textAlignment="viewStart"
         android:layout_toLeftOf="@+id/large_icon"/>
@@ -24,7 +26,7 @@
         android:id="@+id/notification_body_expanded"
         style="@style/Body"
         android:layout_width="match_parent"
-        android:layout_height="30dp"
+        android:layout_height="wrap_content"
         android:layout_below="@id/notification_title"
         android:layout_gravity="start"
         android:textAlignment="viewStart"

--- a/code/core/src/main/res/layout/push_template_expanded.xml
+++ b/code/core/src/main/res/layout/push_template_expanded.xml
@@ -9,8 +9,8 @@
 
     <ImageView
         android:id="@+id/large_icon"
-        android:layout_height="35dp"
-        android:layout_width="35dp"
+        android:layout_height="@dimen/large_icon_height"
+        android:layout_width="@dimen/large_icon_width"
         android:layout_alignParentRight="true" />
 
     <TextView
@@ -35,7 +35,7 @@
     <ImageView
         android:id="@+id/expanded_template_image"
         android:layout_width="match_parent"
-        android:layout_height="200dp"
+        android:layout_height="@dimen/basic_expanded_image_height"
         android:layout_gravity="center"
         android:adjustViewBounds="true"
         android:layout_below="@id/notification_body_expanded"/>

--- a/code/core/src/main/res/layout/push_template_filmstrip_carousel.xml
+++ b/code/core/src/main/res/layout/push_template_filmstrip_carousel.xml
@@ -3,6 +3,8 @@
     android:id="@+id/carousel_container_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:clipToPadding="false"
+    android:clipChildren="false"
     android:orientation="vertical">
 
     <ImageView
@@ -15,7 +17,7 @@
         android:id="@+id/notification_title"
         style="@style/Title"
         android:layout_width="match_parent"
-        android:layout_height="20dp"
+        android:layout_height="wrap_content"
         android:layout_gravity="start"
         android:textAlignment="viewStart"
         android:layout_toLeftOf="@+id/large_icon"/>
@@ -24,7 +26,7 @@
         android:id="@+id/notification_body_expanded"
         style="@style/Body"
         android:layout_width="match_parent"
-        android:layout_height="30dp"
+        android:layout_height="wrap_content"
         android:layout_below="@id/notification_title"
         android:layout_gravity="start"
         android:textAlignment="viewStart"
@@ -32,20 +34,19 @@
 
     <ImageView
         android:id="@+id/manual_carousel_filmstrip_center"
-        android:scaleType="centerCrop"
+        android:scaleType="fitCenter"
         android:adjustViewBounds="true"
         android:layout_width="200dp"
         android:layout_height="200dp"
-        android:layout_gravity="center"
-        android:layout_centerInParent="true"
+        android:layout_centerHorizontal="true"
         android:layout_below="@id/notification_body_expanded">
     </ImageView>
 
     <TextView
         android:id="@+id/manual_carousel_filmstrip_caption"
-        style="@style/TextAppearance.Compat.Notification.Title"
+        style="@style/Caption"
         android:layout_width="wrap_content"
-        android:layout_height="20dp"
+        android:layout_height="wrap_content"
         android:layout_below="@id/manual_carousel_filmstrip_center"
         android:layout_centerHorizontal="true"
         android:layout_gravity="center" />
@@ -54,6 +55,8 @@
         android:id="@+id/manual_carousel_filmstrip_left"
         android:scaleType="centerCrop"
         android:adjustViewBounds="true"
+        android:layout_gravity="center"
+        android:layout_centerHorizontal="true"
         android:layout_width="100dp"
         android:layout_height="175dp"
         android:layout_marginRight="2dp"
@@ -66,6 +69,8 @@
         android:id="@+id/manual_carousel_filmstrip_right"
         android:scaleType="centerCrop"
         android:adjustViewBounds="true"
+        android:layout_gravity="center"
+        android:layout_centerHorizontal="true"
         android:layout_width="100dp"
         android:layout_height="175dp"
         android:layout_marginLeft="2dp"
@@ -76,17 +81,17 @@
 
     <ImageButton
         android:id="@+id/leftImageButton"
-        android:layout_width="30dp"
-        android:layout_height="40dp"
-        android:layout_marginTop="130dp"
+        android:layout_width="15dp"
+        android:layout_height="20dp"
+        android:layout_centerVertical="true"
+        android:layout_alignParentLeft="true"
         android:background="@drawable/skipleft" />
 
     <ImageButton
         android:id="@+id/rightImageButton"
-        android:layout_width="30dp"
-        android:layout_height="40dp"
-        android:layout_marginTop="130dp"
+        android:layout_width="15dp"
+        android:layout_height="20dp"
+        android:layout_centerVertical="true"
         android:layout_alignEnd="@id/manual_carousel_filmstrip_right"
-        android:layout_alignParentEnd="true"
         android:background="@drawable/skipright" />
 </RelativeLayout>

--- a/code/core/src/main/res/layout/push_template_filmstrip_carousel.xml
+++ b/code/core/src/main/res/layout/push_template_filmstrip_carousel.xml
@@ -9,8 +9,8 @@
 
     <ImageView
         android:id="@+id/large_icon"
-        android:layout_height="35dp"
-        android:layout_width="35dp"
+        android:layout_height="@dimen/large_icon_height"
+        android:layout_width="@dimen/large_icon_width"
         android:layout_alignParentRight="true" />
 
     <TextView
@@ -36,8 +36,8 @@
         android:id="@+id/manual_carousel_filmstrip_center"
         android:scaleType="fitCenter"
         android:adjustViewBounds="true"
-        android:layout_width="200dp"
-        android:layout_height="200dp"
+        android:layout_width="@dimen/filmstrip_carousel_center_image_width"
+        android:layout_height="@dimen/filmstrip_carousel_center_image_height"
         android:layout_centerHorizontal="true"
         android:layout_below="@id/notification_body_expanded">
     </ImageView>
@@ -57,10 +57,10 @@
         android:adjustViewBounds="true"
         android:layout_gravity="center"
         android:layout_centerHorizontal="true"
-        android:layout_width="100dp"
-        android:layout_height="175dp"
-        android:layout_marginRight="2dp"
-        android:layout_marginTop="15dp"
+        android:layout_width="@dimen/filmstrip_carousel_side_image_width"
+        android:layout_height="@dimen/filmstrip_carousel_side_image_height"
+        android:layout_marginRight="@dimen/filmstrip_carousel_side_image_margin_edge"
+        android:layout_marginTop="@dimen/filmstrip_carousel_side_image_margin_top"
         android:layout_toLeftOf="@id/manual_carousel_filmstrip_center"
         android:layout_below="@id/notification_body_expanded">
     </ImageView>
@@ -71,26 +71,26 @@
         android:adjustViewBounds="true"
         android:layout_gravity="center"
         android:layout_centerHorizontal="true"
-        android:layout_width="100dp"
-        android:layout_height="175dp"
-        android:layout_marginLeft="2dp"
-        android:layout_marginTop="15dp"
+        android:layout_width="@dimen/filmstrip_carousel_side_image_width"
+        android:layout_height="@dimen/filmstrip_carousel_side_image_height"
+        android:layout_marginLeft="@dimen/filmstrip_carousel_side_image_margin_edge"
+        android:layout_marginTop="@dimen/filmstrip_carousel_side_image_margin_top"
         android:layout_toRightOf="@id/manual_carousel_filmstrip_center"
         android:layout_below="@id/notification_body_expanded">
     </ImageView>
 
     <ImageButton
         android:id="@+id/leftImageButton"
-        android:layout_width="15dp"
-        android:layout_height="20dp"
+        android:layout_width="@dimen/carousel_skip_button_width"
+        android:layout_height="@dimen/carousel_skip_button_height"
         android:layout_centerVertical="true"
         android:layout_alignParentLeft="true"
         android:background="@drawable/skipleft" />
 
     <ImageButton
         android:id="@+id/rightImageButton"
-        android:layout_width="15dp"
-        android:layout_height="20dp"
+        android:layout_width="@dimen/carousel_skip_button_width"
+        android:layout_height="@dimen/carousel_skip_button_height"
         android:layout_centerVertical="true"
         android:layout_alignEnd="@id/manual_carousel_filmstrip_right"
         android:background="@drawable/skipright" />

--- a/code/core/src/main/res/layout/push_template_manual_carousel.xml
+++ b/code/core/src/main/res/layout/push_template_manual_carousel.xml
@@ -3,6 +3,8 @@
     android:id="@+id/carousel_container_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:clipToPadding="false"
+    android:clipChildren="false"
     android:orientation="vertical">
 
     <ImageView
@@ -15,7 +17,7 @@
         android:id="@+id/notification_title"
         style="@style/Title"
         android:layout_width="match_parent"
-        android:layout_height="20dp"
+        android:layout_height="wrap_content"
         android:layout_gravity="start"
         android:textAlignment="viewStart"
         android:layout_toLeftOf="@+id/large_icon"/>
@@ -24,7 +26,7 @@
         android:id="@+id/notification_body_expanded"
         style="@style/Body"
         android:layout_width="match_parent"
-        android:layout_height="30dp"
+        android:layout_height="wrap_content"
         android:layout_gravity="start"
         android:textAlignment="viewStart"
         android:layout_below="@id/notification_title"
@@ -33,27 +35,25 @@
     <ViewFlipper
         android:id="@+id/manual_carousel_view_flipper"
         android:layout_width="match_parent"
-        android:layout_height="300dp"
-        android:layout_gravity="center"
-        android:scaleType="centerCrop"
-        android:layout_centerInParent="true"
-        android:adjustViewBounds="true"
-        android:layout_below="@id/notification_body_expanded">
+        android:layout_height="wrap_content"
+        android:scaleType="fitCenter"
+        android:layout_below="@id/notification_body_expanded"
+        android:adjustViewBounds="true">
     </ViewFlipper>
 
     <ImageButton
         android:id="@+id/leftImageButton"
-        android:layout_width="30dp"
-        android:layout_height="40dp"
-        android:layout_marginTop="120dp"
+        android:layout_width="15dp"
+        android:layout_height="20dp"
+        android:layout_centerVertical="true"
+        android:layout_alignParentStart="true"
         android:background="@drawable/skipleft" />
 
     <ImageButton
         android:id="@+id/rightImageButton"
-        android:layout_width="30dp"
-        android:layout_height="40dp"
-        android:layout_marginTop="120dp"
+        android:layout_width="15dp"
+        android:layout_height="20dp"
+        android:layout_centerVertical="true"
         android:layout_alignEnd="@id/manual_carousel_view_flipper"
-        android:layout_alignParentEnd="true"
         android:background="@drawable/skipright" />
 </RelativeLayout>

--- a/code/core/src/main/res/layout/push_template_manual_carousel.xml
+++ b/code/core/src/main/res/layout/push_template_manual_carousel.xml
@@ -9,8 +9,8 @@
 
     <ImageView
         android:id="@+id/large_icon"
-        android:layout_height="35dp"
-        android:layout_width="35dp"
+        android:layout_height="@dimen/large_icon_height"
+        android:layout_width="@dimen/large_icon_width"
         android:layout_alignParentRight="true" />
 
     <TextView
@@ -37,22 +37,21 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:scaleType="fitCenter"
-        android:layout_below="@id/notification_body_expanded"
-        android:adjustViewBounds="true">
-    </ViewFlipper>
+        android:adjustViewBounds="true"
+        android:layout_below="@id/notification_body_expanded" />
 
     <ImageButton
         android:id="@+id/leftImageButton"
-        android:layout_width="15dp"
-        android:layout_height="20dp"
+        android:layout_width="@dimen/carousel_skip_button_width"
+        android:layout_height="@dimen/carousel_skip_button_height"
         android:layout_centerVertical="true"
         android:layout_alignParentStart="true"
         android:background="@drawable/skipleft" />
 
     <ImageButton
         android:id="@+id/rightImageButton"
-        android:layout_width="15dp"
-        android:layout_height="20dp"
+        android:layout_width="@dimen/carousel_skip_button_width"
+        android:layout_height="@dimen/carousel_skip_button_height"
         android:layout_centerVertical="true"
         android:layout_alignEnd="@id/manual_carousel_view_flipper"
         android:background="@drawable/skipright" />

--- a/code/core/src/main/res/values/dimens.xml
+++ b/code/core/src/main/res/values/dimens.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="large_icon_height">35dp</dimen>
+    <dimen name="large_icon_width">35dp</dimen>
+    <dimen name="basic_expanded_image_height">200dp</dimen>
+    <dimen name="carousel_item_layout_height">200dp</dimen>
+    <dimen name="carousel_item_layout_width">250dp</dimen>
+    <dimen name="carousel_skip_button_height">20dp</dimen>
+    <dimen name="carousel_skip_button_width">15dp</dimen>
+    <dimen name="filmstrip_carousel_center_image_height">200dp</dimen>
+    <dimen name="filmstrip_carousel_center_image_width">200dp</dimen>
+    <dimen name="filmstrip_carousel_side_image_height">175dp</dimen>
+    <dimen name="filmstrip_carousel_side_image_width">100dp</dimen>
+    <dimen name="filmstrip_carousel_side_image_margin_edge">2dp</dimen>
+    <dimen name="filmstrip_carousel_side_image_margin_top">15dp</dimen>
+</resources>

--- a/code/core/src/main/res/values/styles.xml
+++ b/code/core/src/main/res/values/styles.xml
@@ -8,15 +8,21 @@
         <item name="android:windowIsFloating">true</item>
         <item name="android:backgroundDimEnabled">false</item>
     </style>
-    <style name="Title" parent="android:Widget.TextView">
-        <item name="android:textColor">@android:color/black</item>
+    <style name="Title" parent="android:TextAppearance.Material.Title">
+        <item name="android:textColor">?android:textColorPrimary</item>
         <item name="android:textStyle">bold</item>
         <item name="android:textSize">12sp</item>
         <item name="android:maxLines">1</item>
         <item name="android:ellipsize">end</item>
     </style>
-    <style name="Body" parent="android:Widget.TextView">
-        <item name="android:textColor">@android:color/black</item>
+    <style name="Body" parent="android:TextAppearance.Material.Body1">
+        <item name="android:textColor">?android:textColorPrimary</item>
+        <item name="android:textSize">12sp</item>
+        <item name="android:maxLines">3</item>
+        <item name="android:ellipsize">end</item>
+    </style>
+    <style name="Caption" parent="android:TextAppearance.Material.Caption">
+        <item name="android:textColor">?android:textColorPrimary</item>
         <item name="android:textSize">12sp</item>
         <item name="android:maxLines">1</item>
         <item name="android:ellipsize">end</item>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- in addition, reduce skip left and skip right size by 50%
- details and screenshots can be seen in https://github.com/adobe/aepsdk-campaignclassic-android/pull/74
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
