### PR TITLE
Always recompute screen size related calculations

### DIFF
--- a/code/core/build.gradle.kts
+++ b/code/core/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(BuildConstants.Dependencies.ANDROIDX_LIFECYCLE_KTX)
 
     androidTestImplementation(BuildConstants.Dependencies.MOCKITO_CORE)
+    androidTestImplementation("androidx.test.uiautomator:uiautomator:2.3.0")
     //TODO: Consider moving this to the aep-library plugin later
     androidTestImplementation("com.linkedin.dexmaker:dexmaker-mockito-inline:2.28.3")
 }

--- a/code/core/src/androidTest/AndroidManifest.xml
+++ b/code/core/src/androidTest/AndroidManifest.xml
@@ -5,6 +5,10 @@
   <application>
     <meta-data android:name="DeviceInfoServiceTests.testGetPropertyFromManifest.do.not.delete" android:value="this_is_a_value"/>
     <activity android:name="com.adobe.marketing.mobile.internal.DataMarshallerTests$TestActivity" />
+    <activity
+        android:name="com.adobe.marketing.mobile.services.ui.RestrictedConfigActivity"
+        android:configChanges="orientation"
+        />
   </application>
   <uses-permission android:name="android.permission.INTERNET" />
 

--- a/code/core/src/androidTest/AndroidManifest.xml
+++ b/code/core/src/androidTest/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <activity android:name="com.adobe.marketing.mobile.internal.DataMarshallerTests$TestActivity" />
     <activity
         android:name="com.adobe.marketing.mobile.services.ui.RestrictedConfigActivity"
-        android:configChanges="orientation"
+        android:configChanges="orientation|screenSize"
         />
   </application>
   <uses-permission android:name="android.permission.INTERNET" />

--- a/code/core/src/androidTest/java/com/adobe/marketing/mobile/services/ui/RestrictedConfigActivity.kt
+++ b/code/core/src/androidTest/java/com/adobe/marketing/mobile/services/ui/RestrictedConfigActivity.kt
@@ -1,0 +1,16 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.services.ui
+
+import androidx.activity.ComponentActivity
+
+class RestrictedConfigActivity : ComponentActivity()

--- a/code/core/src/androidTest/java/com/adobe/marketing/mobile/services/ui/message/views/MessageScreenOrientationTests.kt
+++ b/code/core/src/androidTest/java/com/adobe/marketing/mobile/services/ui/message/views/MessageScreenOrientationTests.kt
@@ -1,0 +1,240 @@
+package com.adobe.marketing.mobile.services.ui.message.views
+
+import android.view.View
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import com.adobe.marketing.mobile.services.ui.RestrictedConfigActivity
+import com.adobe.marketing.mobile.services.ui.common.PresentationStateManager
+import com.adobe.marketing.mobile.services.ui.message.InAppMessageSettings
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * AEPPresentable handles the orientation changes of a presentable by detaching and reattaching
+ * the presentable from the activity by listening to Application.ActivityLifecycleCallbacks.
+ * However, the test cannot be isolated to listen to ApplicationLifecycle changes at the screen level.
+ * So, the tests in this class are done on the MessageScreen which is attached to an activity that
+ * restricts orientation/screen size changes. So the rotation will not destroy the activity but it
+ * is expected that the MessageScreen will be recomposed to fit the new screen dimensions.
+ * While this is not the ideal test, it is the best we can do to test the
+ * orientation changes of the message screen along with [MessageScreenTests.testMessageScreenIsRestoredOnConfigurationChange]
+ * which tests the configuration changes of the message screen.
+ */
+@RunWith(AndroidJUnit4::class)
+class MessageScreenOrientationTests {
+    @get: Rule
+    val composeTestRule = createAndroidComposeRule<RestrictedConfigActivity>()
+
+    private var onCreatedCalled = false
+    private var onDisposedCalled = false
+    private var onBackPressed = false
+    private val detectedGestures = mutableListOf<InAppMessageSettings.MessageGesture>()
+    private val presentationStateManager = PresentationStateManager()
+
+    private val HTML_TEXT_SAMPLE = "<html>\n" +
+            "<head>\n" +
+            "<title>A Sample HTML Page</title>\n" +
+            "</head>\n" +
+            "<body>\n" +
+            "\n" +
+            "<h1>This is a sample HTML page</h1>\n" +
+            "\n" +
+            "</body>\n" +
+            "</html>"
+
+
+    // ----------------------------------------------------------------------------------------------
+    // Test cases for orientation changes
+    // ----------------------------------------------------------------------------------------------
+    @Test
+    fun testMessageScreenIsRestoredOnOrientationChange() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val uiDevice = UiDevice.getInstance(instrumentation)
+
+        val heightPercentage = 95
+        val widthPercentage = 60
+        val settings = InAppMessageSettings.Builder()
+            .height(heightPercentage)
+            .width(widthPercentage)
+            .content(HTML_TEXT_SAMPLE)
+            .build()
+
+        val screenHeightDp = mutableStateOf(0.dp)
+        val screenWidthDp = mutableStateOf(0.dp)
+        val activityHeightDp = mutableStateOf(0.dp)
+        val activityWidthDp = mutableStateOf(0.dp)
+        composeTestRule.setContent { // setting our composable as content for test
+            // Get the screen dimensions
+            val currentConfiguration = LocalConfiguration.current
+            screenHeightDp.value = currentConfiguration.screenHeightDp.dp
+            screenWidthDp.value = currentConfiguration.screenWidthDp.dp
+
+            val activityRoot =
+                composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
+            activityHeightDp.value = with(LocalDensity.current) { activityRoot.height.toDp() }
+            activityWidthDp.value = with(LocalDensity.current) { activityRoot.width.toDp() }
+
+
+            MessageScreen(
+                presentationStateManager = presentationStateManager,
+                inAppMessageSettings = settings,
+                onCreated = { onCreatedCalled = true },
+                onDisposed = { onDisposedCalled = true },
+                onGestureDetected = { gesture -> detectedGestures.add(gesture) },
+                onBackPressed = { onBackPressed = true }
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).assertDoesNotExist()
+
+        // Change the state of the presentation state manager to shown to display the message
+        presentationStateManager.onShown()
+        composeTestRule.waitForIdle()
+        MessageScreenTestHelper.validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = false
+        )
+
+        // Verify that the message content is resized to fit the screen
+        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
+            .getUnclippedBoundsInRoot()
+        val (expectedInitialHeight, expectedInitialWidth) = calculateDimensions(
+            screenHeightDp.value,
+            screenWidthDp.value,
+            activityHeightDp.value,
+            heightPercentage,
+            widthPercentage)
+
+        MessageScreenTestHelper.validateViewSize(
+            contentBounds,
+            expectedInitialHeight,
+            expectedInitialWidth
+        )
+
+        assertTrue(onCreatedCalled)
+        assertFalse(onDisposedCalled)
+        assertFalse(onBackPressed)
+        assertTrue(detectedGestures.isEmpty())
+        resetState()
+
+        // Rotate the device to landscape
+        uiDevice.setOrientationLandscape()
+
+        // Wait for the device to stabilize
+        uiDevice.waitForIdle()
+        composeTestRule.waitForIdle()
+
+        // Verify that the message content is resized to fit the new orientation
+        MessageScreenTestHelper.validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = false
+        )
+        val landscapeContentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
+            .getUnclippedBoundsInRoot()
+        val (expectedLandscapeHeight, expectedLandscapeWidth) = calculateDimensions(
+            screenHeightDp.value,
+            screenWidthDp.value,
+            activityHeightDp.value,
+            heightPercentage,
+            widthPercentage)
+
+        MessageScreenTestHelper.validateViewSize(
+            landscapeContentBounds,
+            expectedLandscapeHeight,
+            expectedLandscapeWidth
+        )
+
+        // onCreated should not be called again due to orientation change restrictions
+        assertFalse(onCreatedCalled)
+        assertFalse(onDisposedCalled)
+        assertFalse(onBackPressed)
+        assertTrue(detectedGestures.isEmpty())
+        resetState()
+
+        // Rotate the device back to its original orientation
+        uiDevice.setOrientationNatural()
+
+        // Wait for the device to stabilize
+        uiDevice.waitForIdle()
+        composeTestRule.waitForIdle()
+        MessageScreenTestHelper.validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = false
+        )
+
+        // Verify that the message content is restored to its original size
+        val (expectedNaturalHeight, expectedNaturalWidth) = calculateDimensions(
+            screenHeightDp.value,
+            screenWidthDp.value,
+            activityHeightDp.value,
+            heightPercentage,
+            widthPercentage)
+
+        val naturalContentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
+            .getUnclippedBoundsInRoot()
+
+        MessageScreenTestHelper.validateViewSize(
+            naturalContentBounds,
+            expectedNaturalHeight,
+            expectedNaturalWidth
+        )
+    }
+
+    /**
+     * Calculates the expected height and width of the message content based on the screen dimensions
+     * If the height exceeds what is allowed by the activity (due to actionbar), it takes
+     * up the full height of the activity
+     * @param screenHeightDp the screen height in dp
+     * @param screenWidthDp the screen width in dp
+     * @param activityHeightDp the height of the activity in dp
+     * @param heightPercentage the percentage of the screen height the message content should take
+     * @param widthPercentage the percentage of the screen width the message content should take
+     * @return a pair of the expected height and width of the message content
+     */
+    private fun calculateDimensions(
+        screenHeightDp: Dp,
+        screenWidthDp: Dp,
+        activityHeightDp: Dp,
+        heightPercentage: Int,
+        widthPercentage: Int
+    ): Pair<Dp, Dp> {
+        val expectedHeight = if ((screenHeightDp * (heightPercentage / 100f)) > activityHeightDp) {
+            activityHeightDp
+        } else {
+            screenHeightDp * (heightPercentage / 100f)
+        }
+        val expectedWidth = screenWidthDp * (widthPercentage / 100f)
+
+        return Pair(expectedHeight, expectedWidth)
+    }
+
+    private fun resetState() {
+        onCreatedCalled = false
+        onDisposedCalled = false
+        onBackPressed = false
+        detectedGestures.clear()
+    }
+
+    @After
+    fun tearDown() {
+        resetState()
+    }
+
+}

--- a/code/core/src/androidTest/java/com/adobe/marketing/mobile/services/ui/message/views/MessageScreenOrientationTests.kt
+++ b/code/core/src/androidTest/java/com/adobe/marketing/mobile/services/ui/message/views/MessageScreenOrientationTests.kt
@@ -1,3 +1,14 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
 package com.adobe.marketing.mobile.services.ui.message.views
 
 import android.view.View
@@ -45,16 +56,15 @@ class MessageScreenOrientationTests {
     private val presentationStateManager = PresentationStateManager()
 
     private val HTML_TEXT_SAMPLE = "<html>\n" +
-            "<head>\n" +
-            "<title>A Sample HTML Page</title>\n" +
-            "</head>\n" +
-            "<body>\n" +
-            "\n" +
-            "<h1>This is a sample HTML page</h1>\n" +
-            "\n" +
-            "</body>\n" +
-            "</html>"
-
+        "<head>\n" +
+        "<title>A Sample HTML Page</title>\n" +
+        "</head>\n" +
+        "<body>\n" +
+        "\n" +
+        "<h1>This is a sample HTML page</h1>\n" +
+        "\n" +
+        "</body>\n" +
+        "</html>"
 
     // ----------------------------------------------------------------------------------------------
     // Test cases for orientation changes
@@ -87,7 +97,6 @@ class MessageScreenOrientationTests {
             activityHeightDp.value = with(LocalDensity.current) { activityRoot.height.toDp() }
             activityWidthDp.value = with(LocalDensity.current) { activityRoot.width.toDp() }
 
-
             MessageScreen(
                 presentationStateManager = presentationStateManager,
                 inAppMessageSettings = settings,
@@ -118,7 +127,8 @@ class MessageScreenOrientationTests {
             screenWidthDp.value,
             activityHeightDp.value,
             heightPercentage,
-            widthPercentage)
+            widthPercentage
+        )
 
         MessageScreenTestHelper.validateViewSize(
             contentBounds,
@@ -152,7 +162,8 @@ class MessageScreenOrientationTests {
             screenWidthDp.value,
             activityHeightDp.value,
             heightPercentage,
-            widthPercentage)
+            widthPercentage
+        )
 
         MessageScreenTestHelper.validateViewSize(
             landscapeContentBounds,
@@ -185,7 +196,8 @@ class MessageScreenOrientationTests {
             screenWidthDp.value,
             activityHeightDp.value,
             heightPercentage,
-            widthPercentage)
+            widthPercentage
+        )
 
         val naturalContentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
             .getUnclippedBoundsInRoot()
@@ -236,5 +248,4 @@ class MessageScreenOrientationTests {
     fun tearDown() {
         resetState()
     }
-
 }

--- a/code/core/src/androidTest/java/com/adobe/marketing/mobile/services/ui/message/views/MessageScreenTestHelper.kt
+++ b/code/core/src/androidTest/java/com/adobe/marketing/mobile/services/ui/message/views/MessageScreenTestHelper.kt
@@ -1,0 +1,70 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.services.ui.message.views
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEqualTo
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.height
+import androidx.compose.ui.unit.width
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+
+internal object MessageScreenTestHelper {
+
+    /**
+     * Validates the size of the view bounds with the given height and width
+     */
+    internal fun validateViewSize(viewBounds: DpRect, height: Dp, width: Dp) {
+        viewBounds.height.assertIsEqualTo(height, "failed", Dp(2f))
+        viewBounds.width.assertIsEqualTo(width, "failed", Dp(2f))
+    }
+
+    /**
+     * Validates the bounds of the view with the given top, bottom, left and right values
+     */
+    internal fun validateBounds(viewBounds: DpRect, top: Dp, bottom: Dp, left: Dp, right: Dp) {
+        viewBounds.top.assertIsEqualTo(top, "failed", Dp(2f))
+        viewBounds.bottom.assertIsEqualTo(bottom, "failed", Dp(2f))
+        viewBounds.left.assertIsEqualTo(left, "failed", Dp(2f))
+        viewBounds.right.assertIsEqualTo(right, "failed", Dp(2f))
+    }
+
+    /**
+     * Validates the message content with the given backdrop and clipped values
+     * @param composeTestRule the compose test rule
+     * @param withBackdrop whether the backdrop is present
+     * @param clipped whether the message is expected to be clipped
+     */
+    internal fun <T : ComponentActivity> validateMessageAppeared(
+        composeTestRule: AndroidComposeTestRule<ActivityScenarioRule<T>, T>,
+        withBackdrop: Boolean,
+        clipped: Boolean
+    ) {
+        composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).assertExists().also {
+            if (!clipped) it.assertIsDisplayed()
+        }
+        composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).assertExists().also {
+            if (!clipped) it.assertIsDisplayed()
+        }
+        if (withBackdrop) {
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_BACKDROP).assertExists().also {
+                if (!clipped) it.assertIsDisplayed()
+            }
+        } else {
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_BACKDROP).assertDoesNotExist()
+        }
+    }
+}

--- a/code/core/src/androidTest/java/com/adobe/marketing/mobile/services/ui/message/views/MessageScreenTests.kt
+++ b/code/core/src/androidTest/java/com/adobe/marketing/mobile/services/ui/message/views/MessageScreenTests.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsEqualTo
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.getBoundsInRoot
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
@@ -27,15 +26,14 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeWithVelocity
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.height
-import androidx.compose.ui.unit.width
 import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.adobe.marketing.mobile.services.ui.common.PresentationStateManager
 import com.adobe.marketing.mobile.services.ui.message.InAppMessageSettings
+import com.adobe.marketing.mobile.services.ui.message.views.MessageScreenTestHelper.validateBounds
+import com.adobe.marketing.mobile.services.ui.message.views.MessageScreenTestHelper.validateMessageAppeared
+import com.adobe.marketing.mobile.services.ui.message.views.MessageScreenTestHelper.validateViewSize
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -108,7 +106,11 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(false)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = false
+        )
 
         assertTrue(onCreatedCalled)
         assertFalse(onDisposedCalled)
@@ -135,7 +137,11 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(false)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = false
+        )
 
         // Change the state of the presentation state manager to hidden to remove the message
         presentationStateManager.onHidden()
@@ -173,7 +179,11 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(true)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = true,
+            clipped = false
+        )
 
         assertTrue(onCreatedCalled)
         assertFalse(onDisposedCalled)
@@ -200,7 +210,11 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(true)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = true,
+            clipped = false
+        )
 
         // Press back
         Espresso.pressBack()
@@ -234,7 +248,11 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(true)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = true,
+            clipped = false
+        )
         // Swipe gestures
         composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).performTouchInput {
             // create a swipe right gesture
@@ -271,7 +289,11 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(false)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = false
+        )
 
         // Swipe gestures
         composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).performTouchInput {
@@ -309,25 +331,31 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(true)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = true,
+            clipped = false
+        )
 
         // Swipe gestures
-        composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).assertIsDisplayed().performTouchInput {
-            // create a swipe down gesture
-            swipeWithVelocity(
-                start = Offset(0f, 10f),
-                end = Offset(0f, 600f),
-                endVelocity = 1000f
-            )
-        }
+        composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).assertIsDisplayed()
+            .performTouchInput {
+                // create a swipe down gesture
+                swipeWithVelocity(
+                    start = Offset(0f, 10f),
+                    end = Offset(0f, 600f),
+                    endVelocity = 1000f
+                )
+            }
 
         composeTestRule.waitForIdle()
 
-        composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_BACKDROP).assertIsDisplayed().performTouchInput {
-            click(
-                Offset(100f, 10f)
-            )
-        }
+        composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_BACKDROP).assertIsDisplayed()
+            .performTouchInput {
+                click(
+                    Offset(100f, 10f)
+                )
+            }
         composeTestRule.waitForIdle()
 
         assertTrue(onCreatedCalled)
@@ -338,10 +366,10 @@ class MessageScreenTests {
     }
 
     // ----------------------------------------------------------------------------------------------
-    // Test cases for orientation changes
+    // Test cases for configuration changes
     // ----------------------------------------------------------------------------------------------
     @Test
-    fun testMessageScreenIsRestoredOnOrientationChange() {
+    fun testMessageScreenIsRestoredOnConfigurationChange() {
         val restorationTester = StateRestorationTester(composeTestRule)
         restorationTester.setContent { // setting our composable as content for test
             MessageScreen(
@@ -360,7 +388,11 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(false)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = false
+        )
 
         assertTrue(onCreatedCalled)
         assertFalse(onDisposedCalled)
@@ -371,7 +403,11 @@ class MessageScreenTests {
         restorationTester.emulateSavedInstanceStateRestore()
 
         composeTestRule.waitForIdle()
-        validateMessageAppeared(false)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = false
+        )
     }
 
     // ----------------------------------------------------------------------------------------------
@@ -394,7 +430,8 @@ class MessageScreenTests {
             screenHeightDp = currentConfiguration.screenHeightDp.dp
             screenWidthDp = currentConfiguration.screenWidthDp.dp
 
-            val activityRoot = composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
+            val activityRoot =
+                composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
             activityHeightDp = with(LocalDensity.current) { activityRoot.height.toDp() }
             activityWidthDp = with(LocalDensity.current) { activityRoot.width.toDp() }
 
@@ -414,14 +451,20 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(false)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = false
+        )
 
         // Message Frame all the available height and width allowed by the parent (in this case ComponentActivity)
-        val frameBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
+        val frameBounds =
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
         validateViewSize(frameBounds, activityHeightDp, screenWidthDp)
 
         // Message Content(WebView) is 100% of height and width, as allowed by the activity
-        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).getUnclippedBoundsInRoot()
+        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
+            .getUnclippedBoundsInRoot()
         validateViewSize(contentBounds, activityHeightDp, screenWidthDp)
     }
 
@@ -444,7 +487,8 @@ class MessageScreenTests {
             screenHeightDp = currentConfiguration.screenHeightDp.dp
             screenWidthDp = currentConfiguration.screenWidthDp.dp
 
-            val activityRoot = composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
+            val activityRoot =
+                composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
             activityHeightDp = with(LocalDensity.current) { activityRoot.height.toDp() }
             activityWidthDp = with(LocalDensity.current) { activityRoot.width.toDp() }
             MessageScreen(
@@ -463,7 +507,11 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(false)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = false
+        )
 
         // Message Frame all the available height and width allowed by the parent (in this case ComponentActivity)
         val frameBounds =
@@ -475,9 +523,17 @@ class MessageScreenTests {
         val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
             .getUnclippedBoundsInRoot()
         if ((screenHeightDp * (heightPercentage / 100f)) > activityHeightDp) {
-            validateViewSize(contentBounds, activityHeightDp, screenWidthDp * (widthPercentage / 100f))
+            validateViewSize(
+                contentBounds,
+                activityHeightDp,
+                screenWidthDp * (widthPercentage / 100f)
+            )
         } else {
-            validateViewSize(contentBounds, screenHeightDp * (heightPercentage / 100f), screenWidthDp * (widthPercentage / 100f))
+            validateViewSize(
+                contentBounds,
+                screenHeightDp * (heightPercentage / 100f),
+                screenWidthDp * (widthPercentage / 100f)
+            )
         }
     }
 
@@ -504,7 +560,8 @@ class MessageScreenTests {
             screenHeightDp = currentConfiguration.screenHeightDp.dp
             screenWidthDp = currentConfiguration.screenWidthDp.dp
 
-            val activityRoot = composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
+            val activityRoot =
+                composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
             activityHeightDp = with(LocalDensity.current) { activityRoot.height.toDp() }
             activityWidthDp = with(LocalDensity.current) { activityRoot.width.toDp() }
             MessageScreen(
@@ -523,16 +580,28 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(false)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = false
+        )
 
         val rootBounds = composeTestRule.onRoot().getBoundsInRoot()
-        val frameBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getBoundsInRoot()
-        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).getBoundsInRoot()
+        val frameBounds =
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getBoundsInRoot()
+        val contentBounds =
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).getBoundsInRoot()
         val contentHeightDp = screenHeightDp * heightPercent.toFloat() / 100f
         val horizontalContentPaddingDp = (screenWidthDp * (100 - widthPercent).toFloat() / 100f) / 2
 
         // Frame is same size as its parent so bounds should match the root bounds
-        validateBounds(frameBounds, rootBounds.top, rootBounds.bottom, rootBounds.left, rootBounds.right)
+        validateBounds(
+            frameBounds,
+            rootBounds.top,
+            rootBounds.bottom,
+            rootBounds.left,
+            rootBounds.right
+        )
 
         // Content is top aligned vertically and centered horizontally and takes 80% of screen width
         validateBounds(
@@ -564,7 +633,8 @@ class MessageScreenTests {
             screenHeightDp = currentConfiguration.screenHeightDp.dp
             screenWidthDp = currentConfiguration.screenWidthDp.dp
 
-            val activityRoot = composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
+            val activityRoot =
+                composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
             activityHeightDp = with(LocalDensity.current) { activityRoot.height.toDp() }
             activityWidthDp = with(LocalDensity.current) { activityRoot.width.toDp() }
             MessageScreen(
@@ -583,16 +653,28 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(false)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = false
+        )
 
         val rootBounds = composeTestRule.onRoot().getBoundsInRoot()
-        val frameBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getBoundsInRoot()
-        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).getBoundsInRoot()
+        val frameBounds =
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getBoundsInRoot()
+        val contentBounds =
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).getBoundsInRoot()
         val contentHeightDp = screenHeightDp * heightPercent.toFloat() / 100f
         val horizontalContentPaddingDp = (screenWidthDp * (100 - widthPercent).toFloat() / 100f) / 2
 
         // Frame is same size as its parent so bounds should match the root bounds
-        validateBounds(frameBounds, rootBounds.top, rootBounds.bottom, rootBounds.left, rootBounds.right)
+        validateBounds(
+            frameBounds,
+            rootBounds.top,
+            rootBounds.bottom,
+            rootBounds.left,
+            rootBounds.right
+        )
 
         // Content is bottom aligned vertically and centered horizontally and takes 80% of screen width
         validateBounds(
@@ -624,7 +706,8 @@ class MessageScreenTests {
             screenHeightDp = currentConfiguration.screenHeightDp.dp
             screenWidthDp = currentConfiguration.screenWidthDp.dp
 
-            val activityRoot = composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
+            val activityRoot =
+                composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
             activityHeightDp = with(LocalDensity.current) { activityRoot.height.toDp() }
             activityWidthDp = with(LocalDensity.current) { activityRoot.width.toDp() }
             MessageScreen(
@@ -643,16 +726,28 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(false)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = false
+        )
 
         val rootBounds = composeTestRule.onRoot().getBoundsInRoot()
-        val frameBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getBoundsInRoot()
-        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).getBoundsInRoot()
+        val frameBounds =
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getBoundsInRoot()
+        val contentBounds =
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).getBoundsInRoot()
         val contentHeightDp = screenHeightDp * heightPercent.toFloat() / 100f
         val contentWidth = screenWidthDp * widthPercent.toFloat() / 100f
 
         // Frame is same size as its parent so bounds should match the root bounds
-        validateBounds(frameBounds, rootBounds.top, rootBounds.bottom, rootBounds.left, rootBounds.right)
+        validateBounds(
+            frameBounds,
+            rootBounds.top,
+            rootBounds.bottom,
+            rootBounds.left,
+            rootBounds.right
+        )
 
         // Content is center aligned vertically and left aligned horizontally and takes heightPercent% of screen height
         validateBounds(
@@ -684,7 +779,8 @@ class MessageScreenTests {
             screenHeightDp = currentConfiguration.screenHeightDp.dp
             screenWidthDp = currentConfiguration.screenWidthDp.dp
 
-            val activityRoot = composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
+            val activityRoot =
+                composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
             activityHeightDp = with(LocalDensity.current) { activityRoot.height.toDp() }
             activityWidthDp = with(LocalDensity.current) { activityRoot.width.toDp() }
             MessageScreen(
@@ -703,16 +799,28 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(false)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = false
+        )
 
         val rootBounds = composeTestRule.onRoot().getBoundsInRoot()
-        val frameBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getBoundsInRoot()
-        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).getBoundsInRoot()
+        val frameBounds =
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getBoundsInRoot()
+        val contentBounds =
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).getBoundsInRoot()
         val contentHeightDp = screenHeightDp * heightPercent.toFloat() / 100f
         val contentWidth = screenWidthDp * widthPercent.toFloat() / 100f
 
         // Frame is same size as its parent so bounds should match the root bounds
-        validateBounds(frameBounds, rootBounds.top, rootBounds.bottom, rootBounds.left, rootBounds.right)
+        validateBounds(
+            frameBounds,
+            rootBounds.top,
+            rootBounds.bottom,
+            rootBounds.left,
+            rootBounds.right
+        )
 
         // Content is center aligned vertically and right aligned horizontally and takes heightPercent% of screen height
         validateBounds(
@@ -745,7 +853,8 @@ class MessageScreenTests {
             screenHeightDp = currentConfiguration.screenHeightDp.dp
             screenWidthDp = currentConfiguration.screenWidthDp.dp
 
-            val activityRoot = composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
+            val activityRoot =
+                composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
             activityHeightDp = with(LocalDensity.current) { activityRoot.height.toDp() }
             activityWidthDp = with(LocalDensity.current) { activityRoot.width.toDp() }
             MessageScreen(
@@ -764,16 +873,28 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(false)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = false
+        )
 
         val rootBounds = composeTestRule.onRoot().getBoundsInRoot()
-        val frameBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getBoundsInRoot()
-        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).getBoundsInRoot()
+        val frameBounds =
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getBoundsInRoot()
+        val contentBounds =
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).getBoundsInRoot()
         val contentHeightDp = screenHeightDp * heightPercent.toFloat() / 100f
         val contentWidth = screenWidthDp * widthPercent.toFloat() / 100f
 
         // Frame is same size as its parent so bounds should match the root bounds
-        validateBounds(frameBounds, rootBounds.top, rootBounds.bottom, rootBounds.left, rootBounds.right)
+        validateBounds(
+            frameBounds,
+            rootBounds.top,
+            rootBounds.bottom,
+            rootBounds.left,
+            rootBounds.right
+        )
 
         // Content is center aligned vertically and right aligned horizontally and takes heightPercent% of screen height
         validateBounds(
@@ -810,7 +931,8 @@ class MessageScreenTests {
             screenHeightDp = currentConfiguration.screenHeightDp.dp
             screenWidthDp = currentConfiguration.screenWidthDp.dp
 
-            val activityRoot = composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
+            val activityRoot =
+                composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
             activityHeightDp = with(LocalDensity.current) { activityRoot.height.toDp() }
             activityWidthDp = with(LocalDensity.current) { activityRoot.width.toDp() }
             MessageScreen(
@@ -829,11 +951,17 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(false, clipped = true)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = true
+        )
 
         val rootBounds = composeTestRule.onRoot().getBoundsInRoot()
-        val frameBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
-        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).getUnclippedBoundsInRoot()
+        val frameBounds =
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
+        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
+            .getUnclippedBoundsInRoot()
         val contentHeightDp = screenHeightDp * heightPercent.toFloat() / 100f
         val horizontalContentPaddingDp = (screenWidthDp * (100 - widthPercent).toFloat() / 100f) / 2
         val offsetDp = screenHeightDp * offsetPercent.toFloat() / 100f
@@ -879,7 +1007,8 @@ class MessageScreenTests {
             screenHeightDp = currentConfiguration.screenHeightDp.dp
             screenWidthDp = currentConfiguration.screenWidthDp.dp
 
-            val activityRoot = composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
+            val activityRoot =
+                composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
             activityHeightDp = with(LocalDensity.current) { activityRoot.height.toDp() }
             activityWidthDp = with(LocalDensity.current) { activityRoot.width.toDp() }
             MessageScreen(
@@ -898,11 +1027,17 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(false, clipped = true)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = true
+        )
 
         val rootBounds = composeTestRule.onRoot().getBoundsInRoot()
-        val frameBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
-        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).getUnclippedBoundsInRoot()
+        val frameBounds =
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
+        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
+            .getUnclippedBoundsInRoot()
         val contentHeightDp = screenHeightDp * heightPercent.toFloat() / 100f
         val horizontalContentPaddingDp = (screenWidthDp * (100 - widthPercent).toFloat() / 100f) / 2
         val offsetDp = screenHeightDp * offsetPercent.toFloat() / 100f
@@ -948,7 +1083,8 @@ class MessageScreenTests {
             screenHeightDp = currentConfiguration.screenHeightDp.dp
             screenWidthDp = currentConfiguration.screenWidthDp.dp
 
-            val activityRoot = composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
+            val activityRoot =
+                composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
             activityHeightDp = with(LocalDensity.current) { activityRoot.height.toDp() }
             activityWidthDp = with(LocalDensity.current) { activityRoot.width.toDp() }
             MessageScreen(
@@ -967,11 +1103,17 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(false, clipped = true)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = true
+        )
 
         val rootBounds = composeTestRule.onRoot().getBoundsInRoot()
-        val frameBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
-        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).getUnclippedBoundsInRoot()
+        val frameBounds =
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
+        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
+            .getUnclippedBoundsInRoot()
         val contentHeightDp = screenHeightDp * heightPercent.toFloat() / 100f
         val horizontalContentPaddingDp = (screenWidthDp * (100 - widthPercent).toFloat() / 100f) / 2
         val offsetDp = screenHeightDp * offsetPercent.toFloat() / 100f
@@ -1017,7 +1159,8 @@ class MessageScreenTests {
             screenHeightDp = currentConfiguration.screenHeightDp.dp
             screenWidthDp = currentConfiguration.screenWidthDp.dp
 
-            val activityRoot = composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
+            val activityRoot =
+                composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
             activityHeightDp = with(LocalDensity.current) { activityRoot.height.toDp() }
             activityWidthDp = with(LocalDensity.current) { activityRoot.width.toDp() }
             MessageScreen(
@@ -1036,11 +1179,17 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(false, clipped = true)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = true
+        )
 
         val rootBounds = composeTestRule.onRoot().getBoundsInRoot()
-        val frameBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
-        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).getUnclippedBoundsInRoot()
+        val frameBounds =
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
+        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
+            .getUnclippedBoundsInRoot()
         val contentHeightDp = screenHeightDp * heightPercent.toFloat() / 100f
         val horizontalContentPaddingDp = (screenWidthDp * (100 - widthPercent).toFloat() / 100f) / 2
         val offsetDp = screenHeightDp * offsetPercent.toFloat() / 100f
@@ -1086,7 +1235,8 @@ class MessageScreenTests {
             screenHeightDp = currentConfiguration.screenHeightDp.dp
             screenWidthDp = currentConfiguration.screenWidthDp.dp
 
-            val activityRoot = composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
+            val activityRoot =
+                composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
             activityHeightDp = with(LocalDensity.current) { activityRoot.height.toDp() }
             activityWidthDp = with(LocalDensity.current) { activityRoot.width.toDp() }
             MessageScreen(
@@ -1105,11 +1255,17 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(false, clipped = true)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = true
+        )
 
         val rootBounds = composeTestRule.onRoot().getBoundsInRoot()
-        val frameBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
-        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).getUnclippedBoundsInRoot()
+        val frameBounds =
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
+        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
+            .getUnclippedBoundsInRoot()
         val contentHeightDp = screenHeightDp * heightPercent.toFloat() / 100f
         val contentWidthDp = screenWidthDp * widthPercent.toFloat() / 100f
         val verticalContentPaddingDp = (activityHeightDp - contentHeightDp) / 2
@@ -1156,7 +1312,8 @@ class MessageScreenTests {
             screenHeightDp = currentConfiguration.screenHeightDp.dp
             screenWidthDp = currentConfiguration.screenWidthDp.dp
 
-            val activityRoot = composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
+            val activityRoot =
+                composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
             activityHeightDp = with(LocalDensity.current) { activityRoot.height.toDp() }
             activityWidthDp = with(LocalDensity.current) { activityRoot.width.toDp() }
             MessageScreen(
@@ -1175,11 +1332,17 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(false, clipped = true)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = true
+        )
 
         val rootBounds = composeTestRule.onRoot().getBoundsInRoot()
-        val frameBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
-        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).getUnclippedBoundsInRoot()
+        val frameBounds =
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
+        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
+            .getUnclippedBoundsInRoot()
         val contentHeightDp = screenHeightDp * heightPercent.toFloat() / 100f
         val contentWidthDp = screenWidthDp * widthPercent.toFloat() / 100f
         val verticalContentPaddingDp = (activityHeightDp - contentHeightDp) / 2
@@ -1226,7 +1389,8 @@ class MessageScreenTests {
             screenHeightDp = currentConfiguration.screenHeightDp.dp
             screenWidthDp = currentConfiguration.screenWidthDp.dp
 
-            val activityRoot = composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
+            val activityRoot =
+                composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
             activityHeightDp = with(LocalDensity.current) { activityRoot.height.toDp() }
             activityWidthDp = with(LocalDensity.current) { activityRoot.width.toDp() }
             MessageScreen(
@@ -1245,11 +1409,17 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(false, clipped = true)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = true
+        )
 
         val rootBounds = composeTestRule.onRoot().getBoundsInRoot()
-        val frameBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
-        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).getUnclippedBoundsInRoot()
+        val frameBounds =
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
+        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
+            .getUnclippedBoundsInRoot()
         val contentHeightDp = screenHeightDp * heightPercent.toFloat() / 100f
         val contentWidthDp = screenWidthDp * widthPercent.toFloat() / 100f
         val verticalContentPaddingDp = (activityHeightDp - contentHeightDp) / 2
@@ -1296,7 +1466,8 @@ class MessageScreenTests {
             screenHeightDp = currentConfiguration.screenHeightDp.dp
             screenWidthDp = currentConfiguration.screenWidthDp.dp
 
-            val activityRoot = composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
+            val activityRoot =
+                composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
             activityHeightDp = with(LocalDensity.current) { activityRoot.height.toDp() }
             activityWidthDp = with(LocalDensity.current) { activityRoot.width.toDp() }
             MessageScreen(
@@ -1315,11 +1486,17 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(false, clipped = true)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = true
+        )
 
         val rootBounds = composeTestRule.onRoot().getBoundsInRoot()
-        val frameBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
-        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).getUnclippedBoundsInRoot()
+        val frameBounds =
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
+        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
+            .getUnclippedBoundsInRoot()
         val contentHeightDp = screenHeightDp * heightPercent.toFloat() / 100f
         val contentWidthDp = screenWidthDp * widthPercent.toFloat() / 100f
         val verticalContentPaddingDp = (activityHeightDp - contentHeightDp) / 2
@@ -1368,7 +1545,8 @@ class MessageScreenTests {
             screenHeightDp = currentConfiguration.screenHeightDp.dp
             screenWidthDp = currentConfiguration.screenWidthDp.dp
 
-            val activityRoot = composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
+            val activityRoot =
+                composeTestRule.activity.window.decorView.findViewById<View>(android.R.id.content)
             activityHeightDp = with(LocalDensity.current) { activityRoot.height.toDp() }
             activityWidthDp = with(LocalDensity.current) { activityRoot.width.toDp() }
             MessageScreen(
@@ -1387,11 +1565,17 @@ class MessageScreenTests {
         // Change the state of the presentation state manager to shown to display the message
         presentationStateManager.onShown()
         composeTestRule.waitForIdle()
-        validateMessageAppeared(false, clipped = true)
+        validateMessageAppeared(
+            composeTestRule = composeTestRule,
+            withBackdrop = false,
+            clipped = true
+        )
 
         val rootBounds = composeTestRule.onRoot().getBoundsInRoot()
-        val frameBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
-        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).getUnclippedBoundsInRoot()
+        val frameBounds =
+            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
+        val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
+            .getUnclippedBoundsInRoot()
         val contentHeightDp = screenHeightDp * heightPercent.toFloat() / 100f
         val contentWidthDp = screenWidthDp * widthPercent.toFloat() / 100f
         val heightOffset = screenHeightDp * offsetPercent.toFloat() / 100f
@@ -1426,22 +1610,6 @@ class MessageScreenTests {
         detectedGestures.clear()
     }
 
-    private fun validateMessageAppeared(withBackdrop: Boolean, clipped: Boolean = false) {
-        composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).assertExists().also {
-            if (!clipped) it.assertIsDisplayed()
-        }
-        composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT).assertExists().also {
-            if (!clipped) it.assertIsDisplayed()
-        }
-        if (withBackdrop) {
-            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_BACKDROP).assertExists().also {
-                if (!clipped) it.assertIsDisplayed()
-            }
-        } else {
-            composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_BACKDROP).assertDoesNotExist()
-        }
-    }
-
     private fun getSettings(withUiTakeOver: Boolean): InAppMessageSettings {
         return InAppMessageSettings.Builder()
             .backdropOpacity(0.5f)
@@ -1456,17 +1624,5 @@ class MessageScreenTests {
             .content(HTML_TEXT_SAMPLE)
             .gestureMap(acceptedGestures)
             .build()
-    }
-
-    private fun validateViewSize(viewBounds: DpRect, height: Dp, width: Dp) {
-        viewBounds.height.assertIsEqualTo(height, "failed", Dp(2f))
-        viewBounds.width.assertIsEqualTo(width, "failed", Dp(2f))
-    }
-
-    private fun validateBounds(viewBounds: DpRect, top: Dp, bottom: Dp, left: Dp, right: Dp) {
-        viewBounds.top.assertIsEqualTo(top, "failed", Dp(2f))
-        viewBounds.bottom.assertIsEqualTo(bottom, "failed", Dp(2f))
-        viewBounds.left.assertIsEqualTo(left, "failed", Dp(2f))
-        viewBounds.right.assertIsEqualTo(right, "failed", Dp(2f))
     }
 }

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/floatingbutton/views/FloatingButton.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/floatingbutton/views/FloatingButton.kt
@@ -58,8 +58,8 @@ internal fun FloatingButton(
     onDragFinished: (Offset) -> Unit
 ) {
     // Floating button draggable area dimensions
-    val heightDp = with(LocalConfiguration.current) { remember { mutableStateOf(screenHeightDp.dp) } }
-    val widthDp = with(LocalConfiguration.current) { remember { mutableStateOf(screenWidthDp.dp) } }
+    val heightDp = with(LocalConfiguration.current) { mutableStateOf(screenHeightDp.dp) }
+    val widthDp = with(LocalConfiguration.current) { mutableStateOf(screenWidthDp.dp) }
 
     // Floating button dimensions
     val fbHeightDp: Dp = remember { settings.height.dp }

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageContent.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageContent.kt
@@ -48,12 +48,14 @@ internal fun MessageContent(
     onCreated: (WebView) -> Unit,
     gestureTracker: GestureTracker
 ) {
-    // Size variables
+    // Size variables. Ideally, these values can be remembered because generally a configuration
+    // change will refresh the size. However, in-case the configuration changes (e.g. device rotation)
+    // are restricted by the Activity hosting this composable, these values will not be recomputed.
+    // So, we are not remembering these values to ensure that the size is recalculated on every
+    // composition.
     val currentConfiguration = LocalConfiguration.current
-    val heightDp: Dp =
-        remember { ((currentConfiguration.screenHeightDp * inAppMessageSettings.height) / 100).dp }
-    val widthDp: Dp =
-        remember { ((currentConfiguration.screenWidthDp * inAppMessageSettings.width) / 100).dp }
+    val heightDp: Dp = ((currentConfiguration.screenHeightDp * inAppMessageSettings.height) / 100).dp
+    val widthDp: Dp = ((currentConfiguration.screenWidthDp * inAppMessageSettings.width) / 100).dp
 
     // Swipe/Drag variables
     val offsetX = remember { mutableStateOf(0f) }

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageFrame.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageFrame.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
@@ -54,22 +53,22 @@ internal fun MessageFrame(
     onDisposed: () -> Unit
 ) {
     val currentConfiguration = LocalConfiguration.current
-    val horizontalOffset =
-        remember {
-            MessageOffsetMapper.getHorizontalOffset(
-                inAppMessageSettings.horizontalAlignment,
-                inAppMessageSettings.horizontalInset,
-                currentConfiguration.screenWidthDp.dp
-            )
-        }
-    val verticalOffset =
-        remember {
-            MessageOffsetMapper.getVerticalOffset(
-                inAppMessageSettings.verticalAlignment,
-                inAppMessageSettings.verticalInset,
-                currentConfiguration.screenHeightDp.dp
-            )
-        }
+
+    // Ideally, these values can be remembered because generally a configuration
+    // change will refresh the size. However, in-case the configuration changes (e.g. device rotation)
+    // are restricted by the Activity hosting this composable, these values will not be recomputed.
+    // So, we are not remembering these values to ensure that the size is recalculated on every
+    // composition.
+    val horizontalOffset = MessageOffsetMapper.getHorizontalOffset(
+        inAppMessageSettings.horizontalAlignment,
+        inAppMessageSettings.horizontalInset,
+        currentConfiguration.screenWidthDp.dp
+    )
+    val verticalOffset = MessageOffsetMapper.getVerticalOffset(
+        inAppMessageSettings.verticalAlignment,
+        inAppMessageSettings.verticalInset,
+        currentConfiguration.screenHeightDp.dp
+    )
 
     AnimatedVisibility(
         visibleState = visibility,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

**Problem**: Currently, screen size related calculations are done once and remembered on recompositions. This works well generally when adapting to the new size when orientation of the device is changed.
However, when the activity hosting the composable restricts configuration change (via `android:configChanges="orientation|..."` flags in the activity manifest), the remembered value is not recomputed preventing the presentables from adapting to the new screen size.

**Solution**: Do not remember the size related calculations. Always calculate them on composition.

- Rename current orientation test to reflect that they test configuration
-  Add UiAutomator as an android test dependency and simulate rotation using and test using config restricted activity.
<!--- Describe your changes in detail -->

## Related Issue
Internal (MOB-20923)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Manual tests
- Existing instrumentation tests
- New instrumentation tests for orientation changes
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
[MessageScreenOrientationTests.webm](https://github.com/adobe/aepsdk-core-android/assets/96199823/e27520ec-98b0-4557-89fb-ba4eeda56c81)
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.