### PR TITLE
Change push template image download to use NetworkService

### DIFF
--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/PushTemplateImageUtil.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/PushTemplateImageUtil.kt
@@ -76,7 +76,7 @@ internal object PushTemplateImageUtil {
                 Log.trace(
                     PushTemplateConstants.LOG_TAG,
                     SELF_TAG,
-                    "Found cached image for $urlList"
+                    "Found cached image for $url"
                 )
                 downloadedImageCount++
                 latch.countDown()
@@ -88,7 +88,7 @@ internal object PushTemplateImageUtil {
                     Log.trace(
                         PushTemplateConstants.LOG_TAG,
                         SELF_TAG,
-                        "Successfully download image from $urlList"
+                        "Successfully download image from $url"
                     )
                     downloadedImageCount++
 
@@ -108,7 +108,7 @@ internal object PushTemplateImageUtil {
                         Log.trace(
                             PushTemplateConstants.LOG_TAG,
                             SELF_TAG,
-                            "Exception occurred creating an input stream from a bitmap: ${exception.localizedMessage}."
+                            "Exception occurred creating an input stream from a bitmap for {$url}: ${exception.localizedMessage}."
                         )
                     }
                 }
@@ -167,6 +167,7 @@ internal object PushTemplateImageUtil {
             Log.trace(PushTemplateConstants.LOG_TAG, SELF_TAG, "Found cached image for $url")
             return BitmapFactory.decodeStream(cacheResult.data)
         }
+        Log.trace(PushTemplateConstants.LOG_TAG, SELF_TAG, "Image not found in cache for $url")
         return null
     }
 

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/PushTemplateImageUtil.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/PushTemplateImageUtil.kt
@@ -118,7 +118,27 @@ internal object PushTemplateImageUtil {
                 latch.countDown()
             }
         }
-        latch.await(DOWNLOAD_TIMEOUT_SECS.toLong(), TimeUnit.SECONDS)
+        try {
+            if (latch.await(DOWNLOAD_TIMEOUT_SECS.toLong(), TimeUnit.SECONDS)) {
+                Log.trace(
+                    PushTemplateConstants.LOG_TAG,
+                    SELF_TAG,
+                    "All image downloads have completed."
+                )
+            } else {
+                Log.warning(
+                    PushTemplateConstants.LOG_TAG,
+                    SELF_TAG,
+                    "Timed out waiting for image downloads to complete."
+                )
+            }
+        } catch (e: InterruptedException) {
+            Log.warning(
+                PushTemplateConstants.LOG_TAG,
+                SELF_TAG,
+                "Interrupted while waiting for image downloads to complete: ${e.localizedMessage}"
+            )
+        }
         return downloadedImageCount.get()
     }
 

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/PushTemplateImageUtil.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/PushTemplateImageUtil.kt
@@ -88,13 +88,6 @@ internal object PushTemplateImageUtil {
 
             download(url) { image ->
                 image?.let {
-                    Log.trace(
-                        PushTemplateConstants.LOG_TAG,
-                        SELF_TAG,
-                        "Successfully download image from $url"
-                    )
-                    downloadedImageCount.incrementAndGet()
-
                     // scale down the bitmap to 300dp x 200dp as we don't want to use a full
                     // size image due to memory constraints
                     val pushImage = scaleBitmap(image)
@@ -107,6 +100,7 @@ internal object PushTemplateImageUtil {
                                 url
                             )
                         }
+                        downloadedImageCount.incrementAndGet()
                     } catch (exception: IOException) {
                         Log.trace(
                             PushTemplateConstants.LOG_TAG,
@@ -182,7 +176,7 @@ internal object PushTemplateImageUtil {
      */
     internal fun getCachedImage(cacheService: CacheService, url: String?): Bitmap? {
         val assetCacheLocation = getAssetCacheLocation()
-        if (assetCacheLocation.isNullOrEmpty() || url.isNullOrEmpty()) {
+        if (url == null || !UrlUtils.isValidUrl(url) || assetCacheLocation.isNullOrEmpty()) {
             return null
         }
         val cacheResult = cacheService[assetCacheLocation, url]

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/PushTemplateImageUtils.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/PushTemplateImageUtils.kt
@@ -39,16 +39,16 @@ import java.util.concurrent.atomic.AtomicInteger
  * Utility functions to assist in downloading and caching images for push template notifications.
  */
 
-internal object PushTemplateImageUtil {
+internal object PushTemplateImageUtils {
     private const val SELF_TAG = "PushTemplateImageUtil"
     private const val FULL_BITMAP_QUALITY = 100
     private const val DOWNLOAD_TIMEOUT_SECS = 10
 
     /**
-     * Downloads an image using the provided url `String`. Prior to downloading, the image url
+     * Downloads and caches images provided in the [urlList]. Prior to downloading, the image url
      * is used to retrieve a [CacheResult] containing a previously cached image.
      * If a valid cache result is returned then no image is downloaded.
-     * If no cache result is returned, a call to [download] is made to download then cache the image.
+     * If no cache result is returned, a call to [downloadImage] is made to download then cache the image.
      *
      * This is a blocking method that returns only after the download for all images
      * have finished either by failing or successfully downloading, or the timeout has been reached.
@@ -57,7 +57,7 @@ internal object PushTemplateImageUtil {
      * @param urlList [String] containing an image asset url
      * @return [Int] number of images that were found in cache or successfully downloaded
      */
-    internal fun downloadImage(
+    internal fun cacheImages(
         cacheService: CacheService,
         urlList: List<String?>
     ): Int {
@@ -86,7 +86,7 @@ internal object PushTemplateImageUtil {
                 continue
             }
 
-            download(url) { image ->
+            downloadImage(url) { image ->
                 image?.let {
                     // scale down the bitmap to 300dp x 200dp as we don't want to use a full
                     // size image due to memory constraints
@@ -143,7 +143,7 @@ internal object PushTemplateImageUtil {
      * @param completionCallback callback to be invoked with the downloaded [Bitmap]
      * when image specified by the given url is downloaded
      */
-    internal fun download(
+    private fun downloadImage(
         url: String,
         completionCallback: (Bitmap?) -> Unit
     ) {

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/PushTemplateImageUtils.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/PushTemplateImageUtils.kt
@@ -33,6 +33,7 @@ import java.io.InputStream
 import java.net.HttpURLConnection
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -53,12 +54,10 @@ internal object PushTemplateImageUtils {
      * This is a blocking method that returns only after the download for all images
      * have finished either by failing or successfully downloading, or the timeout has been reached.
      *
-     * @param cacheService the AEPSDK [CacheService] to use for caching downloaded image assets
      * @param urlList [String] containing an image asset url
      * @return [Int] number of images that were found in cache or successfully downloaded
      */
     internal fun cacheImages(
-        cacheService: CacheService,
         urlList: List<String?>
     ): Int {
         val assetCacheLocation = getAssetCacheLocation()
@@ -66,7 +65,9 @@ internal object PushTemplateImageUtils {
             return 0
         }
 
-        var downloadedImageCount = AtomicInteger(0)
+        val cacheService = ServiceProvider.getInstance().cacheService
+        val downloadedImageCount = AtomicInteger(0)
+        val latchAborted = AtomicBoolean(false)
         val latch = CountDownLatch(urlList.size)
         for (url in urlList) {
             if (url == null || !UrlUtils.isValidUrl(url)) {
@@ -87,29 +88,31 @@ internal object PushTemplateImageUtils {
             }
 
             downloadImage(url) { image ->
-                image?.let {
-                    // scale down the bitmap to 300dp x 200dp as we don't want to use a full
-                    // size image due to memory constraints
-                    val pushImage = scaleBitmap(image)
-                    // write bitmap to cache
-                    try {
-                        bitmapToInputStream(pushImage).use { bitmapInputStream ->
-                            cacheBitmapInputStream(
-                                cacheService,
-                                bitmapInputStream,
-                                url
+                if (!latchAborted.get()) {
+                    image?.let {
+                        // scale down the bitmap to 300dp x 200dp as we don't want to use a full
+                        // size image due to memory constraints
+                        val pushImage = scaleBitmap(image)
+                        // write bitmap to cache
+                        try {
+                            bitmapToInputStream(pushImage).use { bitmapInputStream ->
+                                cacheBitmapInputStream(
+                                    cacheService,
+                                    bitmapInputStream,
+                                    url
+                                )
+                            }
+                            downloadedImageCount.incrementAndGet()
+                        } catch (exception: IOException) {
+                            Log.trace(
+                                PushTemplateConstants.LOG_TAG,
+                                SELF_TAG,
+                                "Exception occurred creating an input stream from a bitmap for {$url}: ${exception.localizedMessage}."
                             )
                         }
-                        downloadedImageCount.incrementAndGet()
-                    } catch (exception: IOException) {
-                        Log.trace(
-                            PushTemplateConstants.LOG_TAG,
-                            SELF_TAG,
-                            "Exception occurred creating an input stream from a bitmap for {$url}: ${exception.localizedMessage}."
-                        )
                     }
+                    latch.countDown()
                 }
-                latch.countDown()
             }
         }
         try {
@@ -125,6 +128,7 @@ internal object PushTemplateImageUtils {
                     SELF_TAG,
                     "Timed out waiting for image downloads to complete."
                 )
+                latchAborted.set(true)
             }
         } catch (e: InterruptedException) {
             Log.warning(
@@ -132,6 +136,7 @@ internal object PushTemplateImageUtils {
                 SELF_TAG,
                 "Interrupted while waiting for image downloads to complete: ${e.localizedMessage}"
             )
+            latchAborted.set(true)
         }
         return downloadedImageCount.get()
     }
@@ -170,22 +175,21 @@ internal object PushTemplateImageUtils {
     /**
      * Retrieves an image from the cache using the provided url `String`.
      *
-     * @param cacheService the AEPSDK [CacheService] to use for caching downloaded image assets
      * @param url [String] containing the image url to retrieve from cache
      * @return [Bitmap] containing the image retrieved from cache, or `null` if no image is found
      */
-    internal fun getCachedImage(cacheService: CacheService, url: String?): Bitmap? {
+    internal fun getCachedImage(url: String?): Bitmap? {
         val assetCacheLocation = getAssetCacheLocation()
         if (url == null || !UrlUtils.isValidUrl(url) || assetCacheLocation.isNullOrEmpty()) {
             return null
         }
-        val cacheResult = cacheService[assetCacheLocation, url]
-        if (cacheResult != null) {
-            Log.trace(PushTemplateConstants.LOG_TAG, SELF_TAG, "Found cached image for $url")
-            return BitmapFactory.decodeStream(cacheResult.data)
+        val cacheResult = ServiceProvider.getInstance().cacheService[assetCacheLocation, url]
+        if (cacheResult == null) {
+            Log.trace(PushTemplateConstants.LOG_TAG, SELF_TAG, "Image not found in cache for $url")
+            return null
         }
-        Log.trace(PushTemplateConstants.LOG_TAG, SELF_TAG, "Image not found in cache for $url")
-        return null
+        Log.trace(PushTemplateConstants.LOG_TAG, SELF_TAG, "Found cached image for $url")
+        return BitmapFactory.decodeStream(cacheResult.data)
     }
 
     private fun handleDownloadResponse(url: String?, connection: HttpConnecting?): Bitmap? {

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/builders/AEPPushNotificationBuilder.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/builders/AEPPushNotificationBuilder.kt
@@ -636,7 +636,7 @@ internal object AEPPushNotificationBuilder {
             return
         }
 
-        val bitmap = PushTemplateImageUtil.getImageFromCache(cacheService, imageUrl)
+        val bitmap = PushTemplateImageUtil.getCachedImage(cacheService, imageUrl)
         notificationBuilder.setLargeIcon(bitmap)
         val bigPictureStyle = NotificationCompat.BigPictureStyle()
         bigPictureStyle.bigPicture(bitmap)
@@ -756,7 +756,7 @@ internal object AEPPushNotificationBuilder {
             }
             remoteView.setImageViewBitmap(
                 R.id.large_icon,
-                PushTemplateImageUtil.getImageFromCache(cacheService, largeIcon)
+                PushTemplateImageUtil.getCachedImage(cacheService, largeIcon)
             )
         }
     }

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/builders/AutoCarouselNotificationBuilder.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/builders/AutoCarouselNotificationBuilder.kt
@@ -142,7 +142,7 @@ internal object AutoCarouselNotificationBuilder {
         val downloadedImageUris = mutableListOf<String>()
         for (item: CarouselPushTemplate.CarouselItem in items) {
             val imageUri: String = item.imageUri
-            val pushImage: Bitmap? = PushTemplateImageUtil.getImageFromCache(cacheService, imageUri)
+            val pushImage: Bitmap? = PushTemplateImageUtil.getCachedImage(cacheService, imageUri)
             if (pushImage == null) {
                 Log.trace(
                     PushTemplateConstants.LOG_TAG,

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/builders/AutoCarouselNotificationBuilder.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/builders/AutoCarouselNotificationBuilder.kt
@@ -20,9 +20,6 @@ import android.widget.RemoteViews
 import androidx.core.app.NotificationCompat
 import com.adobe.marketing.mobile.core.R
 import com.adobe.marketing.mobile.services.Log
-import com.adobe.marketing.mobile.services.ServiceProvider
-import com.adobe.marketing.mobile.services.caching.CacheService
-import com.adobe.marketing.mobile.services.ui.notification.NotificationConstructionFailedException
 import com.adobe.marketing.mobile.services.ui.notification.PushTemplateConstants
 import com.adobe.marketing.mobile.services.ui.notification.PushTemplateImageUtils
 import com.adobe.marketing.mobile.services.ui.notification.extensions.createNotificationChannelIfRequired
@@ -42,13 +39,6 @@ internal object AutoCarouselNotificationBuilder {
         trackerActivityClass: Class<out Activity>?,
         broadcastReceiverClass: Class<out BroadcastReceiver>?,
     ): NotificationCompat.Builder {
-        val cacheService = ServiceProvider.getInstance().cacheService
-            ?: throw NotificationConstructionFailedException(
-                (
-                    "Cache service is null, auto carousel push notification will not be" +
-                        " constructed."
-                    )
-            )
         Log.trace(
             PushTemplateConstants.LOG_TAG,
             SELF_TAG,
@@ -61,7 +51,6 @@ internal object AutoCarouselNotificationBuilder {
 
         // load images into the carousel
         val downloadedImageCount = PushTemplateImageUtils.cacheImages(
-            cacheService,
             pushTemplate.carouselItems.map { it.imageUri }
         )
 
@@ -69,7 +58,6 @@ internal object AutoCarouselNotificationBuilder {
         val downloadedImageUris = populateAutoCarouselImages(
             context,
             trackerActivityClass,
-            cacheService,
             expandedLayout,
             pushTemplate,
             pushTemplate.carouselItems,
@@ -124,7 +112,6 @@ internal object AutoCarouselNotificationBuilder {
      *
      * @param context the current [Context] of the application
      * @param trackerActivityClass the [Class] of the activity that will be used for tracking interactions with the carousel item
-     * @param cacheService the [CacheService] used to cache the downloaded images
      * @param expandedLayout the [RemoteViews] containing the expanded layout of the notification
      * @param pushTemplate the [CarouselPushTemplate] object containing the push template data
      * @param items the list of [CarouselPushTemplate.CarouselItem] objects to be displayed in the carousel
@@ -134,7 +121,6 @@ internal object AutoCarouselNotificationBuilder {
     private fun populateAutoCarouselImages(
         context: Context,
         trackerActivityClass: Class<out Activity>?,
-        cacheService: CacheService,
         expandedLayout: RemoteViews,
         pushTemplate: CarouselPushTemplate,
         items: MutableList<CarouselPushTemplate.CarouselItem>,
@@ -143,7 +129,7 @@ internal object AutoCarouselNotificationBuilder {
         val downloadedImageUris = mutableListOf<String>()
         for (item: CarouselPushTemplate.CarouselItem in items) {
             val imageUri: String = item.imageUri
-            val pushImage: Bitmap? = PushTemplateImageUtils.getCachedImage(cacheService, imageUri)
+            val pushImage: Bitmap? = PushTemplateImageUtils.getCachedImage(imageUri)
             if (pushImage == null) {
                 Log.trace(
                     PushTemplateConstants.LOG_TAG,

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/builders/AutoCarouselNotificationBuilder.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/builders/AutoCarouselNotificationBuilder.kt
@@ -24,7 +24,7 @@ import com.adobe.marketing.mobile.services.ServiceProvider
 import com.adobe.marketing.mobile.services.caching.CacheService
 import com.adobe.marketing.mobile.services.ui.notification.NotificationConstructionFailedException
 import com.adobe.marketing.mobile.services.ui.notification.PushTemplateConstants
-import com.adobe.marketing.mobile.services.ui.notification.PushTemplateImageUtil
+import com.adobe.marketing.mobile.services.ui.notification.PushTemplateImageUtils
 import com.adobe.marketing.mobile.services.ui.notification.extensions.createNotificationChannelIfRequired
 import com.adobe.marketing.mobile.services.ui.notification.extensions.setRemoteViewClickAction
 import com.adobe.marketing.mobile.services.ui.notification.templates.AutoCarouselPushTemplate
@@ -60,7 +60,7 @@ internal object AutoCarouselNotificationBuilder {
         val expandedLayout = RemoteViews(packageName, R.layout.push_template_auto_carousel)
 
         // load images into the carousel
-        val downloadedImageCount = PushTemplateImageUtil.downloadImage(
+        val downloadedImageCount = PushTemplateImageUtils.cacheImages(
             cacheService,
             pushTemplate.carouselItems.map { it.imageUri }
         )
@@ -143,7 +143,7 @@ internal object AutoCarouselNotificationBuilder {
         val downloadedImageUris = mutableListOf<String>()
         for (item: CarouselPushTemplate.CarouselItem in items) {
             val imageUri: String = item.imageUri
-            val pushImage: Bitmap? = PushTemplateImageUtil.getCachedImage(cacheService, imageUri)
+            val pushImage: Bitmap? = PushTemplateImageUtils.getCachedImage(cacheService, imageUri)
             if (pushImage == null) {
                 Log.trace(
                     PushTemplateConstants.LOG_TAG,

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/builders/BasicNotificationBuilder.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/builders/BasicNotificationBuilder.kt
@@ -22,7 +22,6 @@ import android.widget.RemoteViews
 import androidx.core.app.NotificationCompat
 import com.adobe.marketing.mobile.core.R
 import com.adobe.marketing.mobile.services.Log
-import com.adobe.marketing.mobile.services.ServiceProvider
 import com.adobe.marketing.mobile.services.ui.notification.NotificationConstructionFailedException
 import com.adobe.marketing.mobile.services.ui.notification.PushTemplateConstants
 import com.adobe.marketing.mobile.services.ui.notification.PushTemplateImageUtils
@@ -43,9 +42,6 @@ internal object BasicNotificationBuilder {
         trackerActivityClass: Class<out Activity>?,
         broadcastReceiverClass: Class<out BroadcastReceiver>?
     ): NotificationCompat.Builder {
-        val cacheService = ServiceProvider.getInstance().cacheService
-            ?: throw NotificationConstructionFailedException("Cache service is null, basic template notification will not be constructed.")
-
         Log.trace(
             PushTemplateConstants.LOG_TAG,
             SELF_TAG,
@@ -78,7 +74,7 @@ internal object BasicNotificationBuilder {
 
         // set the image on the notification
         val imageUri = pushTemplate.imageUrl
-        val downloadedImageCount = PushTemplateImageUtils.cacheImages(cacheService, listOf(imageUri))
+        val downloadedImageCount = PushTemplateImageUtils.cacheImages(listOf(imageUri))
 
         if (downloadedImageCount == 0) {
             Log.trace(
@@ -90,7 +86,7 @@ internal object BasicNotificationBuilder {
         } else {
             expandedLayout.setImageViewBitmap(
                 R.id.expanded_template_image,
-                PushTemplateImageUtils.getCachedImage(cacheService, imageUri)
+                PushTemplateImageUtils.getCachedImage(imageUri)
             )
         }
 

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/builders/BasicNotificationBuilder.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/builders/BasicNotificationBuilder.kt
@@ -25,7 +25,7 @@ import com.adobe.marketing.mobile.services.Log
 import com.adobe.marketing.mobile.services.ServiceProvider
 import com.adobe.marketing.mobile.services.ui.notification.NotificationConstructionFailedException
 import com.adobe.marketing.mobile.services.ui.notification.PushTemplateConstants
-import com.adobe.marketing.mobile.services.ui.notification.PushTemplateImageUtil
+import com.adobe.marketing.mobile.services.ui.notification.PushTemplateImageUtils
 import com.adobe.marketing.mobile.services.ui.notification.extensions.addActionButtons
 import com.adobe.marketing.mobile.services.ui.notification.extensions.createNotificationChannelIfRequired
 import com.adobe.marketing.mobile.services.ui.notification.templates.BasicPushTemplate
@@ -78,7 +78,7 @@ internal object BasicNotificationBuilder {
 
         // set the image on the notification
         val imageUri = pushTemplate.imageUrl
-        val downloadedImageCount = PushTemplateImageUtil.downloadImage(cacheService, listOf(imageUri))
+        val downloadedImageCount = PushTemplateImageUtils.cacheImages(cacheService, listOf(imageUri))
 
         if (downloadedImageCount == 0) {
             Log.trace(
@@ -90,7 +90,7 @@ internal object BasicNotificationBuilder {
         } else {
             expandedLayout.setImageViewBitmap(
                 R.id.expanded_template_image,
-                PushTemplateImageUtil.getCachedImage(cacheService, imageUri)
+                PushTemplateImageUtils.getCachedImage(cacheService, imageUri)
             )
         }
 

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/builders/BasicNotificationBuilder.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/builders/BasicNotificationBuilder.kt
@@ -101,7 +101,7 @@ internal object BasicNotificationBuilder {
         } else {
             expandedLayout.setImageViewBitmap(
                 R.id.expanded_template_image,
-                PushTemplateImageUtil.getImageFromCache(cacheService, imageUri)
+                PushTemplateImageUtil.getCachedImage(cacheService, imageUri)
             )
         }
 

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/builders/BasicNotificationBuilder.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/builders/BasicNotificationBuilder.kt
@@ -89,17 +89,20 @@ internal object BasicNotificationBuilder {
 
         // get push payload data
         val imageUri = pushTemplate.imageUrl
-        val pushImage = PushTemplateImageUtil.downloadImage(cacheService, imageUri)
+        val downloadedImageCount = PushTemplateImageUtil.downloadImage(cacheService, listOf(imageUri))
 
-        if (pushImage != null) {
-            expandedLayout.setImageViewBitmap(R.id.expanded_template_image, pushImage)
-        } else {
+        if (downloadedImageCount == 0) {
             Log.trace(
                 PushTemplateConstants.LOG_TAG,
                 SELF_TAG,
                 "No image found for basic push template."
             )
             expandedLayout.setViewVisibility(R.id.expanded_template_image, View.GONE)
+        } else {
+            expandedLayout.setImageViewBitmap(
+                R.id.expanded_template_image,
+                PushTemplateImageUtil.getImageFromCache(cacheService, imageUri)
+            )
         }
 
         smallLayout.setTextViewText(R.id.notification_title, pushTemplate.title)

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/builders/ManualCarouselNotificationBuilder.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/builders/ManualCarouselNotificationBuilder.kt
@@ -27,7 +27,7 @@ import com.adobe.marketing.mobile.services.ServiceProvider
 import com.adobe.marketing.mobile.services.caching.CacheService
 import com.adobe.marketing.mobile.services.ui.notification.NotificationConstructionFailedException
 import com.adobe.marketing.mobile.services.ui.notification.PushTemplateConstants
-import com.adobe.marketing.mobile.services.ui.notification.PushTemplateImageUtil
+import com.adobe.marketing.mobile.services.ui.notification.PushTemplateImageUtils
 import com.adobe.marketing.mobile.services.ui.notification.extensions.createNotificationChannelIfRequired
 import com.adobe.marketing.mobile.services.ui.notification.extensions.setRemoteViewClickAction
 import com.adobe.marketing.mobile.services.ui.notification.templates.CarouselPushTemplate
@@ -59,7 +59,7 @@ internal object ManualCarouselNotificationBuilder {
         )
 
         // download carousel images
-        val downloadedImagesCount = PushTemplateImageUtil.downloadImage(
+        val downloadedImagesCount = PushTemplateImageUtils.cacheImages(
             cacheService,
             pushTemplate.carouselItems.map { it.imageUri }
         )
@@ -171,7 +171,7 @@ internal object ManualCarouselNotificationBuilder {
         val validCarouselItems = mutableListOf<CarouselPushTemplate.CarouselItem>()
         for (item: CarouselPushTemplate.CarouselItem in items) {
             val imageUri: String = item.imageUri
-            val pushImage: Bitmap? = PushTemplateImageUtil.getCachedImage(cacheService, imageUri)
+            val pushImage: Bitmap? = PushTemplateImageUtils.getCachedImage(cacheService, imageUri)
             if (pushImage == null) {
                 Log.trace(
                     PushTemplateConstants.LOG_TAG,
@@ -335,7 +335,7 @@ internal object ManualCarouselNotificationBuilder {
     ) {
         for (item: CarouselPushTemplate.CarouselItem in items) {
             val imageUri = item.imageUri
-            val pushImage: Bitmap? = PushTemplateImageUtil.getCachedImage(cacheService, imageUri)
+            val pushImage: Bitmap? = PushTemplateImageUtils.getCachedImage(cacheService, imageUri)
             if (pushImage == null) {
                 Log.trace(
                     PushTemplateConstants.LOG_TAG,
@@ -404,7 +404,7 @@ internal object ManualCarouselNotificationBuilder {
         )
 
         // set the downloaded bitmaps in the filmstrip image views
-        val assetCacheLocation = PushTemplateImageUtil.getAssetCacheLocation()
+        val assetCacheLocation = PushTemplateImageUtils.getAssetCacheLocation()
         if (assetCacheLocation.isNullOrEmpty()) {
             Log.trace(
                 PushTemplateConstants.LOG_TAG,

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/builders/ManualCarouselNotificationBuilder.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/builders/ManualCarouselNotificationBuilder.kt
@@ -184,7 +184,7 @@ internal object ManualCarouselNotificationBuilder {
         val validCarouselItems = mutableListOf<CarouselPushTemplate.CarouselItem>()
         for (item: CarouselPushTemplate.CarouselItem in items) {
             val imageUri: String = item.imageUri
-            val pushImage: Bitmap? = PushTemplateImageUtil.getImageFromCache(cacheService, imageUri)
+            val pushImage: Bitmap? = PushTemplateImageUtil.getCachedImage(cacheService, imageUri)
             if (pushImage == null) {
                 Log.trace(
                     PushTemplateConstants.LOG_TAG,
@@ -356,7 +356,7 @@ internal object ManualCarouselNotificationBuilder {
     ) {
         for (item: CarouselPushTemplate.CarouselItem in items) {
             val imageUri = item.imageUri
-            val pushImage: Bitmap? = PushTemplateImageUtil.getImageFromCache(cacheService, imageUri)
+            val pushImage: Bitmap? = PushTemplateImageUtil.getCachedImage(cacheService, imageUri)
             if (pushImage == null) {
                 Log.trace(
                     PushTemplateConstants.LOG_TAG,

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/extensions/NotificationCompatBuilderExtensions.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/extensions/NotificationCompatBuilderExtensions.kt
@@ -20,7 +20,6 @@ import android.media.RingtoneManager
 import androidx.core.app.NotificationCompat
 import com.adobe.marketing.mobile.MobileCore
 import com.adobe.marketing.mobile.services.Log
-import com.adobe.marketing.mobile.services.ServiceProvider
 import com.adobe.marketing.mobile.services.ui.notification.PendingIntentUtils
 import com.adobe.marketing.mobile.services.ui.notification.PushTemplateConstants
 import com.adobe.marketing.mobile.services.ui.notification.PushTemplateImageUtils
@@ -189,9 +188,7 @@ internal fun NotificationCompat.Builder.setLargeIcon(
 ): NotificationCompat.Builder {
     // Quick bail out if there is no image url
     if (imageUrl.isNullOrEmpty()) return this
-    val cacheService = ServiceProvider.getInstance().cacheService
     val downloadedIconCount: Int = PushTemplateImageUtils.cacheImages(
-        cacheService,
         listOf(imageUrl)
     )
 
@@ -200,7 +197,7 @@ internal fun NotificationCompat.Builder.setLargeIcon(
         return this
     }
 
-    val bitmap = PushTemplateImageUtils.getCachedImage(cacheService, imageUrl)
+    val bitmap = PushTemplateImageUtils.getCachedImage(imageUrl)
     setLargeIcon(bitmap)
     val bigPictureStyle = NotificationCompat.BigPictureStyle()
     bigPictureStyle.bigPicture(bitmap)

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/extensions/NotificationCompatBuilderExtensions.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/extensions/NotificationCompatBuilderExtensions.kt
@@ -23,7 +23,7 @@ import com.adobe.marketing.mobile.services.Log
 import com.adobe.marketing.mobile.services.ServiceProvider
 import com.adobe.marketing.mobile.services.ui.notification.PendingIntentUtils
 import com.adobe.marketing.mobile.services.ui.notification.PushTemplateConstants
-import com.adobe.marketing.mobile.services.ui.notification.PushTemplateImageUtil
+import com.adobe.marketing.mobile.services.ui.notification.PushTemplateImageUtils
 import com.adobe.marketing.mobile.services.ui.notification.templates.AEPPushTemplate
 import com.adobe.marketing.mobile.services.ui.notification.templates.BasicPushTemplate
 import java.util.Random
@@ -190,7 +190,7 @@ internal fun NotificationCompat.Builder.setLargeIcon(
     // Quick bail out if there is no image url
     if (imageUrl.isNullOrEmpty()) return this
     val cacheService = ServiceProvider.getInstance().cacheService
-    val downloadedIconCount: Int = PushTemplateImageUtil.downloadImage(
+    val downloadedIconCount: Int = PushTemplateImageUtils.cacheImages(
         cacheService,
         listOf(imageUrl)
     )
@@ -200,7 +200,7 @@ internal fun NotificationCompat.Builder.setLargeIcon(
         return this
     }
 
-    val bitmap = PushTemplateImageUtil.getCachedImage(cacheService, imageUrl)
+    val bitmap = PushTemplateImageUtils.getCachedImage(cacheService, imageUrl)
     setLargeIcon(bitmap)
     val bigPictureStyle = NotificationCompat.BigPictureStyle()
     bigPictureStyle.bigPicture(bitmap)

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/extensions/RemoteViewsExtensions.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/extensions/RemoteViewsExtensions.kt
@@ -23,7 +23,7 @@ import com.adobe.marketing.mobile.services.Log
 import com.adobe.marketing.mobile.services.ServiceProvider
 import com.adobe.marketing.mobile.services.ui.notification.PendingIntentUtils
 import com.adobe.marketing.mobile.services.ui.notification.PushTemplateConstants
-import com.adobe.marketing.mobile.services.ui.notification.PushTemplateImageUtil
+import com.adobe.marketing.mobile.services.ui.notification.PushTemplateImageUtils
 import com.adobe.marketing.mobile.util.UrlUtils
 
 private const val SELF_TAG = "RemoteViewExtensions"
@@ -228,7 +228,7 @@ internal fun RemoteViews.setRemoteLargeIcon(largeIcon: String?) {
         return
     }
     val cacheService = ServiceProvider.getInstance().cacheService
-    val downloadedIconCount = PushTemplateImageUtil.downloadImage(cacheService, listOf(largeIcon))
+    val downloadedIconCount = PushTemplateImageUtils.cacheImages(cacheService, listOf(largeIcon))
     if (downloadedIconCount == 0) {
         Log.trace(
             PushTemplateConstants.LOG_TAG,
@@ -240,7 +240,7 @@ internal fun RemoteViews.setRemoteLargeIcon(largeIcon: String?) {
     }
     setImageViewBitmap(
         R.id.large_icon,
-        PushTemplateImageUtil.getCachedImage(cacheService, largeIcon)
+        PushTemplateImageUtils.getCachedImage(cacheService, largeIcon)
     )
 }
 

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/extensions/RemoteViewsExtensions.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/notification/extensions/RemoteViewsExtensions.kt
@@ -227,8 +227,7 @@ internal fun RemoteViews.setRemoteLargeIcon(largeIcon: String?) {
     if (!UrlUtils.isValidUrl(largeIcon)) {
         return
     }
-    val cacheService = ServiceProvider.getInstance().cacheService
-    val downloadedIconCount = PushTemplateImageUtils.cacheImages(cacheService, listOf(largeIcon))
+    val downloadedIconCount = PushTemplateImageUtils.cacheImages(listOf(largeIcon))
     if (downloadedIconCount == 0) {
         Log.trace(
             PushTemplateConstants.LOG_TAG,
@@ -240,7 +239,7 @@ internal fun RemoteViews.setRemoteLargeIcon(largeIcon: String?) {
     }
     setImageViewBitmap(
         R.id.large_icon,
-        PushTemplateImageUtils.getCachedImage(cacheService, largeIcon)
+        PushTemplateImageUtils.getCachedImage(largeIcon)
     )
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Changes `PushTemplateImageUtil` to use `NetworkService` for downloading images.
- Since multiple async requests for each image download are spawned at the same time, added a `CountDownLatch` to wait for all requests to complete.
- `download` method only return number of images downloaded to avoid holding bitmaps in memory. The images can be fetched from cache if/when needed using `getImageFromCache`

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
