### PR TITLE
Catch exceptions when retrieving data from Activity

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -1,4 +1,4 @@
-name: Publish Release
+name: Android 2.x Release
 on:
   workflow_dispatch:
     inputs:

--- a/code/core/src/main/java/com/adobe/marketing/mobile/DataMarshaller.java
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/DataMarshaller.java
@@ -138,10 +138,18 @@ class DataMarshaller {
                     newKey = LOCAL_NOTIFICATION_ID_KEY;
                 }
 
-                Object value = extraBundle.get(key);
-
-                if (value != null && value.toString().length() > 0) {
-                    this.launchData.put(newKey, value);
+                try {
+                    Object value = extraBundle.get(key);
+                    if (value != null && value.toString().length() > 0) {
+                        this.launchData.put(newKey, value);
+                    }
+                } catch (Exception e) {
+                    Log.warning(
+                            CoreConstants.LOG_TAG,
+                            TAG,
+                            "Failed to retrieve data (key = %s) from Activity, error is: %s",
+                            key,
+                            e.getLocalizedMessage());
                 }
             }
 

--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/CoreConstants.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/CoreConstants.kt
@@ -13,7 +13,7 @@ package com.adobe.marketing.mobile.internal
 
 internal object CoreConstants {
     const val LOG_TAG = "MobileCore"
-    const val VERSION = "2.6.2"
+    const val VERSION = "2.6.3"
 
     object EventDataKeys {
         /**

--- a/code/core/src/test/java/com/adobe/marketing/mobile/MobileCoreTests.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/MobileCoreTests.kt
@@ -35,7 +35,7 @@ import kotlin.test.assertTrue
 @RunWith(MockitoJUnitRunner.Silent::class)
 class MobileCoreTests {
 
-    private var EXTENSION_VERSION = "2.6.2"
+    private var EXTENSION_VERSION = "2.6.3"
 
     @Mock
     private lateinit var mockedEventHub: EventHub

--- a/code/core/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtensionTests.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/internal/configuration/ConfigurationExtensionTests.kt
@@ -60,7 +60,7 @@ import kotlin.test.assertTrue
 @RunWith(MockitoJUnitRunner.Silent::class)
 class ConfigurationExtensionTests {
 
-    private var EXTENSION_VERSION = "2.6.2"
+    private var EXTENSION_VERSION = "2.6.3"
 
     @Mock
     private lateinit var mockServiceProvider: ServiceProvider

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -6,7 +6,7 @@ android.useAndroidX=true
 #
 #Maven artifacts
 #Core extension
-coreExtensionVersion=2.6.2
+coreExtensionVersion=2.6.3
 coreExtensionName=core
 coreExtensionAARName=core-phone-release.aar
 coreMavenRepoName=AdobeMobileCoreSdk


### PR DESCRIPTION
https://developer.android.com/reference/android/os/BaseBundle#get(java.lang.String)
As reported by the customer, the above Android API used in [DataMarshaller.java](https://github.com/adobe/aepsdk-core-android/blob/main-v2/code/core/src/main/java/com/adobe/marketing/mobile/DataMarshaller.java#L128) throws ClassNotFound exceptions in certain cases. Catch those exceptions to avoid app crashes. 