### PR TITLE
Identity don't dispatch Analytics push event on privacy change

### DIFF
--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -80,7 +80,6 @@ public final class IdentityExtension extends Extension {
 
     private static final String LOG_SOURCE = "IdentityExtension";
     private HitQueuing hitQueue;
-    private static boolean pushEnabled = false;
     private static final Object pushEnabledMutex = new Object();
     @VisibleForTesting ConfigurationSharedStateIdentity latestValidConfig;
     private final NamedCollection namedCollection;
@@ -1673,7 +1672,7 @@ public final class IdentityExtension extends Extension {
     }
 
     /**
-     * Updates the {@link #pushEnabled} field and dispatches an event to generate a corresponding
+     * Updates the persisted {@code ADOBEMOBILE_PUSH_ENABLED} field and dispatches an event to generate a corresponding
      * Analytics request
      *
      * @param isEnabled whether the user is opted in to receive push notifications
@@ -1726,14 +1725,12 @@ public final class IdentityExtension extends Extension {
                 return false;
             }
 
-            pushEnabled = namedCollection.getBoolean(DataStoreKeys.PUSH_ENABLED, false);
+            return namedCollection.getBoolean(DataStoreKeys.PUSH_ENABLED, false);
         }
-
-        return pushEnabled;
     }
 
     /**
-     * Updates the {@link #pushEnabled} flag in DataStore with the provided value.
+     * Updates the persisted {@code ADOBEMOBILE_PUSH_ENABLED} flag in DataStore with the provided value.
      *
      * @param enabled new push status value to be updated
      */
@@ -1741,6 +1738,11 @@ public final class IdentityExtension extends Extension {
         synchronized (pushEnabledMutex) {
             if (namedCollection != null) {
                 namedCollection.setBoolean(DataStoreKeys.PUSH_ENABLED, enabled);
+                Log.trace(
+                        IdentityConstants.LOG_TAG,
+                        LOG_SOURCE,
+                        "setPushStatus : Push notifications status is now: "
+                                + (enabled ? "Enabled" : "Disabled"));
             } else {
                 Log.trace(
                         IdentityConstants.LOG_TAG,
@@ -1748,13 +1750,6 @@ public final class IdentityExtension extends Extension {
                         "setPushStatus : Unable to update push flag because the"
                                 + " LocalStorageService was not available.");
             }
-
-            pushEnabled = enabled;
-            Log.trace(
-                    IdentityConstants.LOG_TAG,
-                    LOG_SOURCE,
-                    "setPushStatus : Push notifications status is now: "
-                            + (pushEnabled ? "Enabled" : "Disabled"));
         }
     }
 

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -1674,8 +1674,8 @@ public final class IdentityExtension extends Extension {
     }
 
     /**
-     * Updates the persisted {@code ADOBEMOBILE_PUSH_ENABLED} field and dispatches an event to generate a corresponding
-     * Analytics request
+     * Updates the persisted {@code ADOBEMOBILE_PUSH_ENABLED} field and dispatches an event to
+     * generate a corresponding Analytics request
      *
      * @param isEnabled whether the user is opted in to receive push notifications
      */
@@ -1732,7 +1732,8 @@ public final class IdentityExtension extends Extension {
     }
 
     /**
-     * Updates the persisted {@code ADOBEMOBILE_PUSH_ENABLED} flag in DataStore with the provided value.
+     * Updates the persisted {@code ADOBEMOBILE_PUSH_ENABLED} flag in DataStore with the provided
+     * value.
      *
      * @param enabled new push status value to be updated
      */

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -499,18 +499,8 @@ public final class IdentityExtension extends Extension {
                     "handleIdentityRequestReset: Privacy is opt-out, ignoring event.");
             return;
         }
-        mid = null;
-        advertisingIdentifier = null;
-        blob = null;
-        locationHint = null;
-        customerIds = null;
-        pushIdentifier = null;
 
-        if (namedCollection != null) {
-            namedCollection.remove(DataStoreKeys.AID_SYNCED_KEY);
-            namedCollection.remove(DataStoreKeys.PUSH_ENABLED);
-        }
-
+        clearIdentifiers();
         savePersistently(); // clear datastore
 
         // When resetting identifiers, need to generate new Experience Cloud ID for the user
@@ -1857,17 +1847,7 @@ public final class IdentityExtension extends Extension {
                 privacyStatus.getValue());
 
         if (privacyStatus == MobilePrivacyStatus.OPT_OUT) {
-            mid = null;
-            advertisingIdentifier = null;
-            blob = null;
-            locationHint = null;
-            customerIds = null;
-
-            if (namedCollection != null) {
-                namedCollection.remove(DataStoreKeys.AID_SYNCED_KEY);
-            }
-
-            updatePushIdentifier(null);
+            clearIdentifiers();
             savePersistently(); // clear datastore
             getApi().createSharedState(packageEventData(), event);
         } else if (StringUtils.isNullOrEmpty(mid)) {
@@ -2449,6 +2429,21 @@ public final class IdentityExtension extends Extension {
                         Defaults.DEFAULT_MOBILE_PRIVACY.getValue());
 
         privacyStatus = MobilePrivacyStatus.fromString(privacyString);
+    }
+
+    /** Clears in-memory identifiers and persisted push ID flags. */
+    private void clearIdentifiers() {
+        mid = null;
+        advertisingIdentifier = null;
+        blob = null;
+        locationHint = null;
+        customerIds = null;
+        pushIdentifier = null;
+
+        if (namedCollection != null) {
+            namedCollection.remove(DataStoreKeys.AID_SYNCED_KEY);
+            namedCollection.remove(DataStoreKeys.PUSH_ENABLED);
+        }
     }
 
     @VisibleForTesting

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -2439,8 +2439,10 @@ public final class IdentityExtension extends Extension {
 
         if (namedCollection != null) {
             namedCollection.remove(DataStoreKeys.AID_SYNCED_KEY);
-            namedCollection.remove(DataStoreKeys.PUSH_ENABLED);
             namedCollection.remove(DataStoreKeys.ANALYTICS_PUSH_SYNC);
+            synchronized (pushEnabledMutex) {
+                namedCollection.remove(DataStoreKeys.PUSH_ENABLED);
+            }
         }
     }
 

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -2443,6 +2443,7 @@ public final class IdentityExtension extends Extension {
         if (namedCollection != null) {
             namedCollection.remove(DataStoreKeys.AID_SYNCED_KEY);
             namedCollection.remove(DataStoreKeys.PUSH_ENABLED);
+            namedCollection.remove(DataStoreKeys.ANALYTICS_PUSH_SYNC);
         }
     }
 

--- a/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
+++ b/code/identity/src/main/java/com/adobe/marketing/mobile/identity/IdentityExtension.java
@@ -1086,7 +1086,9 @@ public final class IdentityExtension extends Extension {
             return;
         }
 
-        if (pushId == null && !isPushEnabled()) {
+        final boolean pushEnabled = isPushEnabled();
+
+        if (pushId == null && !pushEnabled) {
             changePushStatusAndHitAnalytics(false);
             Log.debug(
                     IdentityConstants.LOG_TAG,
@@ -1094,7 +1096,7 @@ public final class IdentityExtension extends Extension {
                     "updatePushIdentifier : First time sending a.push.optin false");
         } else if (pushId == null) { // push is enabled
             changePushStatusAndHitAnalytics(false);
-        } else if (!isPushEnabled()) { // push ID is not null
+        } else if (!pushEnabled) { // push ID is not null
             changePushStatusAndHitAnalytics(true);
         }
     }

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityFunctionalTests.kt
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityFunctionalTests.kt
@@ -2142,7 +2142,6 @@ class IdentityFunctionalTests {
         assertTrue(persistedData["ADOBEMOBILE_ANALYTICS_PUSH_SYNC"] as? Boolean ?: false)
         assertFalse(persistedData["ADOBEMOBILE_PUSH_ENABLED"] as? Boolean ?: true)
     }
-    @Test(timeout = 10000)
     fun test_updatePrivacyStatusOptedOut_doesNotDispatch_analyticsForIdentityRequest() {
         val configuration = mapOf(
             "experienceCloud.org" to "orgid",
@@ -2173,7 +2172,6 @@ class IdentityFunctionalTests {
         assertNull(identityExtension.mid)
     }
 
-    @Test(timeout = 10000)
     fun test_resetIdentities_doesNotDispatch_analyticsForIdentityRequest() {
         val configuration = mapOf(
             "experienceCloud.org" to "orgid",

--- a/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityFunctionalTests.kt
+++ b/code/identity/src/test/java/com/adobe/marketing/mobile/identity/IdentityFunctionalTests.kt
@@ -12,7 +12,10 @@
 package com.adobe.marketing.mobile.identity
 
 import com.adobe.marketing.mobile.Event
+import com.adobe.marketing.mobile.EventSource
+import com.adobe.marketing.mobile.EventType
 import com.adobe.marketing.mobile.ExtensionApi
+import com.adobe.marketing.mobile.MobilePrivacyStatus
 import com.adobe.marketing.mobile.SharedStateResult
 import com.adobe.marketing.mobile.SharedStateStatus
 import com.adobe.marketing.mobile.VisitorID
@@ -52,6 +55,7 @@ import java.net.HttpURLConnection
 import java.util.Random
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlin.test.assertNotEquals
 
 private typealias NetworkMonitor = (url: String) -> Unit
 
@@ -2036,5 +2040,148 @@ class IdentityFunctionalTests {
         )
 
         countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    fun test_resetIdentities_doesNotDispatch_analyticsForIdentityRequest() {
+        val configuration = mapOf(
+            "experienceCloud.org" to "orgid",
+            "experienceCloud.server" to "test.com",
+            "global.privacy" to "optedin"
+        )
+        val identityExtension = initializeIdentityExtensionWithPreset(
+            FRESH_INSTALL_WITHOUT_CACHE,
+            configuration
+        )
+
+        val oldMid = identityExtension.mid
+
+        doAnswer { invocation ->
+            fail("Did not expect any dispatched events but found ${invocation.arguments.size}!")
+        }.`when`(mockedExtensionApi).dispatch(any())
+
+        identityExtension.handleIdentityRequestReset(
+            Event.Builder(
+                "event",
+                "com.adobe.eventType.generic.identity",
+                "com.adobe.eventSource.requestReset"
+            ).build()
+        )
+
+        assertNotEquals(oldMid, identityExtension.mid)
+    }
+
+    @Test(timeout = 10000)
+    fun test_setPushIdentifier_validToken_dispatchesAnalyticsForIdentityRequest() {
+        val configuration = mapOf(
+            "experienceCloud.org" to "orgid",
+            "experienceCloud.server" to "test.com",
+            "global.privacy" to "optedin"
+        )
+        val identityExtension = initializeIdentityExtensionWithPreset(
+            FRESH_INSTALL_WITHOUT_CACHE,
+            configuration
+        )
+
+        val countDownLatch = CountDownLatch(1)
+        doAnswer { invocation ->
+            val event: Event? = invocation.arguments[0] as Event?
+            assertEquals(EventType.ANALYTICS, event?.type)
+            assertEquals(EventSource.REQUEST_CONTENT, event?.source)
+            val eventData = event?.eventData
+            assertNotNull(eventData)
+            val jsonObject = JSONObject(eventData)
+            assertEquals("Push", jsonObject.getString("action"))
+            assertTrue(jsonObject.getBoolean("trackinternal"))
+            val jsonContextObject = jsonObject.getJSONObject("contextdata")
+            assertEquals("true", jsonContextObject.getString("a.push.optin"))
+            countDownLatch.countDown()
+        }.`when`(mockedExtensionApi).dispatch(any())
+
+        identityExtension.processIdentityRequest(
+            Event.Builder(
+                "event",
+                "com.adobe.eventType.generic.identity",
+                "com.adobe.eventSource.requestContent"
+            ).setEventData(
+                mapOf(
+                    "pushidentifier" to "D52DB39EEE21395B2B67B895FC478301CE6E936D82521E095902A5E0F57EE0B3"
+                )
+            ).build()
+        )
+
+        countDownLatch.await()
+    }
+
+    @Test(timeout = 10000)
+    fun test_setPushIdentifier_null_dispatchesAnalyticsForIdentityRequest() {
+        val configuration = mapOf(
+            "experienceCloud.org" to "orgid",
+            "experienceCloud.server" to "test.com",
+            "global.privacy" to "optedin"
+        )
+        val identityExtension = initializeIdentityExtensionWithPreset(
+            FRESH_INSTALL_WITHOUT_CACHE,
+            configuration
+        )
+
+        val countDownLatch = CountDownLatch(1)
+        doAnswer { invocation ->
+            val event: Event? = invocation.arguments[0] as Event?
+            assertEquals(EventType.ANALYTICS, event?.type)
+            assertEquals(EventSource.REQUEST_CONTENT, event?.source)
+            val eventData = event?.eventData
+            assertNotNull(eventData)
+            val jsonObject = JSONObject(eventData)
+            assertEquals("Push", jsonObject.getString("action"))
+            assertTrue(jsonObject.getBoolean("trackinternal"))
+            val jsonContextObject = jsonObject.getJSONObject("contextdata")
+            assertEquals("false", jsonContextObject.getString("a.push.optin"))
+            countDownLatch.countDown()
+        }.`when`(mockedExtensionApi).dispatch(any())
+
+        identityExtension.processIdentityRequest(
+            Event.Builder(
+                "event",
+                "com.adobe.eventType.generic.identity",
+                "com.adobe.eventSource.requestContent"
+            ).setEventData(
+                mapOf(
+                    "pushidentifier" to null
+                )
+            ).build()
+        )
+
+        countDownLatch.await()
+    }
+    @Test(timeout = 10000)
+    fun test_updatePrivacyStatusOptedOut_doesNotDispatch_analyticsForIdentityRequest() {
+        val configuration = mapOf(
+            "experienceCloud.org" to "orgid",
+            "experienceCloud.server" to "test.com",
+            "global.privacy" to "optedin"
+        )
+        val identityExtension = initializeIdentityExtensionWithPreset(
+            FRESH_INSTALL_WITHOUT_CACHE,
+            configuration
+        )
+
+        assertNotNull(identityExtension.mid)
+
+        doAnswer { invocation ->
+            fail("Did not expect any dispatched events but found ${invocation.arguments.size}!")
+        }.`when`(mockedExtensionApi).dispatch(any())
+
+        identityExtension.handleConfiguration(
+            Event.Builder(
+                "configuration response",
+                "com.adobe.eventType.configuration",
+                "com.adobe.eventSource.responseContent"
+            ).setEventData(
+                mapOf("global.privacy" to MobilePrivacyStatus.OPT_OUT.value)
+            ).build()
+        )
+
+        assertNull(identityExtension.mid)
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updates the Identity extension to not dispatch the `AnalyticsForIdentityRequest` event when privacy status is changed to optedout.

The Identity extension is expected to dispatch the `AnalyticsForIdentityRequest` event when the push identifier changes or when push tracking is denied the first time. This event tells Analytics to dispatch an ADBINTERNAL:Push event with `a.push.optin` value of either `True` or `False`. The issue is in some cases changing the privacy status to `optedout` would trigger a dispatch of the `AnalyticsForIdentityRequest` event even though `setPushIdentifier` was never called.

This fix changes how Identity handles processing of an privacy status change to `optedout` by clearing the push token and flags instead of calling `updatePushIdentifier` with nil, which would dispatch the event to Analytics.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
