### PR TITLE
Catch exceptions when retrieving data from Activity

### DIFF
--- a/code/core/src/androidTest/java/com/adobe/marketing/mobile/internal/DataMarshallerTests.kt
+++ b/code/core/src/androidTest/java/com/adobe/marketing/mobile/internal/DataMarshallerTests.kt
@@ -21,6 +21,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.Serializable
 
 @RunWith(AndroidJUnit4::class)
 class DataMarshallerTests {
@@ -176,6 +177,23 @@ class DataMarshallerTests {
 
     @Test
     fun marshalInvalidUrl_NoCrash() {
+        val throwsException = ObjectThrowsOnToString()
+        val intent =
+            Intent(ApplicationProvider.getApplicationContext(), TestActivity::class.java).apply {
+                putExtra("key", "value")
+                putExtra("exceptionKey", throwsException)
+            }
+
+        val activity = activityTestRule.launchActivity(intent)
+        val result = DataMarshaller.marshal(activity)
+        assertEquals(
+            mapOf("key" to "value"),
+            result
+        )
+    }
+
+    @Test
+    fun marshal_whenBundleThrowException_NoCrash() {
         val intent =
             Intent(ApplicationProvider.getApplicationContext(), TestActivity::class.java).apply {
                 data = Uri.parse("abc:abc")
@@ -188,7 +206,11 @@ class DataMarshallerTests {
             result
         )
     }
-
+    private class ObjectThrowsOnToString : Serializable {
+        override fun toString(): String {
+            throw IllegalStateException("This is a test exception")
+        }
+    }
     companion object {
         const val LEGACY_PUSH_MESSAGE_ID = "adb_m_id"
         const val PUSH_MESSAGE_ID_KEY = "pushmessageid"

--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/DataMarshaller.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/DataMarshaller.kt
@@ -70,9 +70,13 @@ internal object DataMarshaller {
                 NOTIFICATION_IDENTIFIER_KEY -> LOCAL_NOTIFICATION_ID_KEY
                 else -> key
             }
-            val value = extraBundle[key]
-            if (value?.toString()?.isNotEmpty() == true) {
-                marshalledData[newKey] = value
+            try {
+                val value = extraBundle[key]
+                if (value?.toString()?.isNotEmpty() == true) {
+                    marshalledData[newKey] = value
+                }
+            } catch (e: Exception) {
+                Log.error(CoreConstants.LOG_TAG, LOG_TAG, "Failed to retrieve data (key = $key) from Activity, error is: ${e.message}")
             }
         }
 


### PR DESCRIPTION
Port a bug fix (https://github.com/adobe/aepsdk-core-android/pull/658) from 2.x to 3.x 
