### PR TITLE
Set in-app web view container background to be transparent

### DIFF
--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageFrame.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageFrame.kt
@@ -102,6 +102,7 @@ internal fun MessageFrame(
             // the WebView message is clipped to the rounded corners for API versions 22 and below. This does not
             // affect the appearance of the message on API versions 23 and above.
             Card(
+                backgroundColor = Color.Transparent,
                 modifier = Modifier
                     .clip(RoundedCornerShape(inAppMessageSettings.cornerRadius.dp))
                     .alpha(0.99f)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
The InAppMessage WebView is hosted inside a `Card` container. By default the `Card` background color is grey. This is causing unintended results(grey bg being seen) for  in-app messages where dimensions are set to fill the entire screen but the content only occupies a portion of it.
As a solution, set the container Card's background color to Color.Transparent as with the WebView.

<!--- Describe your changes in detail -->

## Related Issue
Internal (MOB-21133)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
The InAppMessage WebView is hosted inside a `Card` container. By default the `Card` background color is grey. This is causing unintended results(grey bg being seen) for  in-app messages where dimensions are set to fill the entire screen but the content only occupies a portion of it.
As a solution, set the container Card's background color to Color.Transparent as with the WebView.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Test app with sample html.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
**Before**:
<img src="https://github.com/adobe/aepsdk-core-android/assets/96199823/0bbbbc20-1491-4c8b-8ead-e2d732552e01" width="150" height="300">


**After**
<img src="https://github.com/adobe/aepsdk-core-android/assets/96199823/1862d3e9-afde-4693-bb97-297fa2ecfbff" width="150" height="300">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
