### PR TITLE
Detach presentables before re-attaching to top Activity

### DIFF
--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/common/AEPPresentable.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/common/AEPPresentable.kt
@@ -60,6 +60,14 @@ internal abstract class AEPPresentable<T : Presentation<T>> :
     @VisibleForTesting internal val contentIdentifier: Int = Random().nextInt()
 
     /**
+     * Represents the activity to which the presentable is currently attached.
+     * This SHOULD always be updated whenever the presentable is attached or detached from an
+     * activity. For the sake of maintainability, modify this only in [attach] and [detach] and
+     * limit queries to this field in activity lifecycle methods.
+     */
+    private var attachmentHandle: WeakReference<Activity?> = WeakReference(null)
+
+    /**
      * @param presentation the [Presentation] to be used by this [Presentable]
      * @param presentationUtilityProvider the [PresentationUtilityProvider] to be used to fetch components needed by this [Presentable]
      * @param presentationDelegate the [PresentationDelegate] for notifying the application of [Presentation] lifecycle events
@@ -241,6 +249,22 @@ internal abstract class AEPPresentable<T : Presentation<T>> :
             if (getState() != Presentable.State.VISIBLE) {
                 return@launch
             }
+
+            // If the activity that has currently resumed is not the same as the one the presentable
+            // is attached to, then it means that another activity has launched on top of/beside
+            // current activity. Detach the presentable from the current activity before attaching
+            // it to the newly resumed activity.
+            val currentAttachmentHandle = attachmentHandle.get()
+            if (currentAttachmentHandle != null && currentAttachmentHandle != activity) {
+                Log.trace(
+                    ServiceConstants.LOG_TAG,
+                    LOG_SOURCE,
+                    "Detaching from $currentAttachmentHandle before attaching to $activity."
+                )
+
+                detach(currentAttachmentHandle)
+            }
+
             attach(activity)
         }
     }
@@ -327,6 +351,10 @@ internal abstract class AEPPresentable<T : Presentation<T>> :
         composeView.id = contentIdentifier
         val rootViewGroup = activityToAttach.findViewById<ViewGroup>(android.R.id.content)
         rootViewGroup.addView(composeView)
+
+        // Update the attachment handle to the currently attached activity.
+        attachmentHandle = WeakReference(activityToAttach)
+
         Log.trace(
             ServiceConstants.LOG_TAG,
             LOG_SOURCE,
@@ -373,6 +401,20 @@ internal abstract class AEPPresentable<T : Presentation<T>> :
         }
         existingComposeView.removeAllViews()
         rootViewGroup.removeView(existingComposeView)
+
+        // Clear the attachment handle if the current attachment handle is the same as the activity
+        // to detach. If not, the handle would have already been cleared when the presentable
+        // was attached due to another activity being resumed on top of the presentable.
+        val currentAttachmentHandle = attachmentHandle.get()
+        if (currentAttachmentHandle == activityToDetach) {
+            Log.trace(
+                ServiceConstants.LOG_TAG,
+                LOG_SOURCE,
+                "Clearing attachment handle ($activityToDetach)."
+            )
+            attachmentHandle.clear()
+        }
+
         activityCompatOwnerUtils.detachActivityCompatOwner(activityToDetach)
         Log.trace(ServiceConstants.LOG_TAG, LOG_SOURCE, "Detached ${contentIdentifier}from $activityToDetach.")
     }

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/common/AEPPresentableTest.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/common/AEPPresentableTest.kt
@@ -832,8 +832,6 @@ internal class AEPPresentableTest {
             }
         )
 
-        // simulate initial detached state
-        // `when`(mockPresentationStateManager.presentableState).thenReturn(mutableStateOf(Presentable.State.DETACHED))
         // simulate that the presentation delegate allows the presentation to be shown
         `when`(mockPresentationDelegate.canShow(aepPresentableWithGatedDisplay)).thenReturn(true)
         // simulate a valid activity being present
@@ -918,8 +916,6 @@ internal class AEPPresentableTest {
             }
         )
 
-        // simulate initial detached state
-        // `when`(mockPresentationStateManager.presentableState).thenReturn(mutableStateOf(Presentable.State.DETACHED))
         // simulate that the presentation delegate allows the presentation to be shown
         `when`(mockPresentationDelegate.canShow(aepPresentableWithGatedDisplay)).thenReturn(true)
         // simulate a valid activity being present

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/common/AEPPresentableTest.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/common/AEPPresentableTest.kt
@@ -41,11 +41,16 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 internal class AEPPresentableTest {
     @Mock
@@ -810,6 +815,92 @@ internal class AEPPresentableTest {
     }
 
     @Test
+    fun `Test that presentable is detached and resurfaced when an Activity launches over a visible presentable`() {
+        // setup
+        val presentationStateManager = PresentationStateManager()
+        val aepPresentableWithGatedDisplay = TestAEPPresentableGatedDisplay(
+            mockPresentation,
+            mockPresentationUtilityProvider,
+            mockPresentationDelegate,
+            mockAppLifecycleProvider,
+            presentationStateManager,
+            mockActivityCompatLifecycleUtils,
+            mockMainScope,
+            mockPresentationObserver,
+            conflictLogic = { visible ->
+                visible.any { it is Alert }
+            }
+        )
+
+        // simulate initial detached state
+        // `when`(mockPresentationStateManager.presentableState).thenReturn(mutableStateOf(Presentable.State.DETACHED))
+        // simulate that the presentation delegate allows the presentation to be shown
+        `when`(mockPresentationDelegate.canShow(aepPresentableWithGatedDisplay)).thenReturn(true)
+        // simulate a valid activity being present
+        `when`(mockPresentationUtilityProvider.getCurrentActivity()).thenReturn(mockActivity)
+        // simulate no existing ComposeView being present
+        `when`(mockActivity.findViewById<ComposeView?>(aepPresentableWithGatedDisplay.contentIdentifier)).thenReturn(
+            null
+        )
+        `when`(mockActivity.findViewById<ViewGroup>(eq(android.R.id.content))).thenReturn(
+            mockViewGroup
+        )
+
+        `when`(mockPresentationObserver.getVisiblePresentations()).thenReturn(
+            mutableListOf(mock(FloatingButton::class.java))
+        )
+
+        val mockAnotherActivity = mock(AnotherActivity::class.java)
+        val anotherViewGroup = mock(ViewGroup::class.java)
+        `when`(mockAnotherActivity.findViewById<ViewGroup>(eq(android.R.id.content))).thenReturn(
+            anotherViewGroup
+        )
+
+        runTest {
+            // Part-1: Simulate presentable shown for the first time
+            aepPresentableWithGatedDisplay.show()
+
+            // verify that the presentation delegate is called because display is gated
+            verify(mockPresentationDelegate).canShow(aepPresentableWithGatedDisplay)
+
+            // verify that the lifecycle provider is called to register the listener
+            verify(mockAppLifecycleProvider).registerListener(aepPresentableWithGatedDisplay)
+
+            // Verify that the compose view is added to the viewgroup
+            val composeViewCaptor: KArgumentCaptor<ComposeView> = argumentCaptor()
+            verify(mockViewGroup, times(1)).addView(composeViewCaptor.capture())
+
+            // verify that the listener, delegate, and state manager are notified of content show
+            verify(mockPresentationDelegate).onShow(aepPresentableWithGatedDisplay)
+            verify(mockPresentationListener).onShow(aepPresentableWithGatedDisplay)
+            assertTrue { presentationStateManager.presentableState.value == Presentable.State.VISIBLE }
+
+            // verify that the presentation observer is notified of the new presentation
+            verify(mockPresentationObserver).onPresentationVisible(aepPresentableWithGatedDisplay.getPresentation())
+
+            // We already asserted above the presentable has been attached. So return the captured ComposeView
+            `when`(mockActivity.findViewById<ComposeView?>(aepPresentableWithGatedDisplay.contentIdentifier)).thenReturn(
+                composeViewCaptor.firstValue
+            )
+
+            // Part-2: Simulate another activity resuming when presentable is already shown
+            // simulate another activity being the current activity
+            aepPresentableWithGatedDisplay.onActivityResumed(mockAnotherActivity)
+
+            // verify that the compose view is removed from the previous Activity view/group
+            verify(mockViewGroup, times(1)).removeView(composeViewCaptor.firstValue)
+
+            // verify that a new compose view is added to the new Activity view/group
+            verify(anotherViewGroup, times(1)).addView(any())
+            assertTrue { presentationStateManager.presentableState.value == Presentable.State.VISIBLE }
+
+            // verify that the listener, delegate are not re-notified because this is implicit
+            verifyNoMoreInteractions(mockPresentationDelegate)
+            verifyNoMoreInteractions(mockPresentationListener)
+        }
+    }
+
+    @Test
     fun `Test that AEPPresentable#onActivityResumed bails when presentable is HIDDEN`() {
         // setup
         val aepPresentableWithGatedDisplay = TestAEPPresentableGatedDisplay(
@@ -962,5 +1053,9 @@ internal class AEPPresentableTest {
         override fun hasConflicts(visiblePresentations: List<Presentation<*>>): Boolean {
             return conflictLogic(visiblePresentations)
         }
+    }
+
+    private class AnotherActivity : Activity() {
+        // no-op activity
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently, the `ComposeView` attached to the `Activity` when presentables are shown is not removed until the activity is destroyed. This is OK for most use-cases that follow the single window mode where the newly resumed activity obscures the previous one, and the presentable redraws on the new activity. 

However, this approach of waiting until the activity is destroyed may result in the presentables being shown on each activity in a multi-window side-by-side mode.
While we do not support multi-window mode, we should ensure that the experience does not deteriorate in such a case. As a solution, change the current detachment logic to to the following:

1.  Track the current activity that the presentable is attached to

2. When presentable is visible on `ActivityA` and another activity `ActivityB` resumes, use the Android activity co-ordination guarantees to detach presentable from Activity-A and re-attach to Activity B.
3. Reset the reference held to the activity that the presentable is attached to when the activity is destroyed.

See More here:
 -  [Configuration Changes](https://developer.android.com/guide/components/activities/state-changes#cco) call `onDestroy` of previous activity before `onResume` of newly created activity
 -  [New activity launches](https://developer.android.com/guide/components/activities/state-changes#covered) always result in `onResume` on new Activity. When the top-most activity is removed, `onResume` on previously paused activity is invoked.    
 -  [Activity co-ordination](https://developer.android.com/guide/components/activities/activity-lifecycle) if `ActivityA` starts `ActivityB`, then `ActivityB.onResume` is invoked before `ActivityA.onPause()`/ `ActivityA.onDestroy()`


<!--- Describe your changes in detail -->

## Related Issue
N/A
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Test app
- Scenario test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
**Before** 
![before](https://github.com/adobe/aepsdk-core-android/assets/96199823/83c6c8d0-8e05-485f-a046-96e159fddf2e)
**After**
![after](https://github.com/adobe/aepsdk-core-android/assets/96199823/c3b5df24-ade5-4061-94fe-7e08aad99c5e)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
