### PR TITLE
Do not initialize SDK in direct boot mode

### DIFF
--- a/code/core/build.gradle.kts
+++ b/code/core/build.gradle.kts
@@ -52,4 +52,5 @@ dependencies {
     androidTestImplementation("androidx.test.uiautomator:uiautomator:2.3.0")
     //TODO: Consider moving this to the aep-library plugin later
     androidTestImplementation("com.linkedin.dexmaker:dexmaker-mockito-inline:2.28.3")
+    testImplementation("org.robolectric:robolectric:4.7")
 }

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
@@ -13,9 +13,13 @@ package com.adobe.marketing.mobile;
 
 import android.app.Activity;
 import android.app.Application;
+import android.app.Application.ActivityLifecycleCallbacks;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+import androidx.core.os.UserManagerCompat;
 import com.adobe.marketing.mobile.internal.AppResourceStore;
 import com.adobe.marketing.mobile.internal.CoreConstants;
 import com.adobe.marketing.mobile.internal.DataMarshaller;
@@ -82,8 +86,8 @@ public final class MobileCore {
 
     /**
      * Set the Android {@link Application}, which enables the SDK get the app {@code Context},
-     * register a {@link Application.ActivityLifecycleCallbacks} to monitor the lifecycle of the app
-     * and get the {@link android.app.Activity} on top of the screen.
+     * register a {@link ActivityLifecycleCallbacks} to monitor the lifecycle of the app and get the
+     * {@link Activity} on top of the screen.
      *
      * <p>NOTE: This method should be called right after the app starts, so it gives the SDK all the
      * contexts it needed.
@@ -91,10 +95,24 @@ public final class MobileCore {
      * @param application the Android {@link Application} instance. It should not be null.
      */
     public static void setApplication(@NonNull final Application application) {
+
         if (application == null) {
             Log.error(
                     CoreConstants.LOG_TAG, LOG_TAG, "setApplication failed - application is null");
             return;
+        }
+
+        // Direct boot mode is supported on Android N and above
+        if (VERSION.SDK_INT >= VERSION_CODES.N) {
+            if (UserManagerCompat.isUserUnlocked(application)) {
+                Log.debug(CoreConstants.LOG_TAG, LOG_TAG, "Device is not in direct boot mode.");
+            } else {
+                Log.error(
+                        CoreConstants.LOG_TAG,
+                        LOG_TAG,
+                        "Device is in direct boot mode, SDK will not be initialized.");
+                return;
+            }
         }
 
         if (sdkInitializedWithContext.getAndSet(true)) {
@@ -105,8 +123,7 @@ public final class MobileCore {
             return;
         }
 
-        if (android.os.Build.VERSION.SDK_INT == android.os.Build.VERSION_CODES.O
-                || android.os.Build.VERSION.SDK_INT == android.os.Build.VERSION_CODES.O_MR1) {
+        if (VERSION.SDK_INT == VERSION_CODES.O || VERSION.SDK_INT == VERSION_CODES.O_MR1) {
             // AMSDK-8502
             // Workaround to prevent a crash happening on Android 8.0/8.1 related to
             // TimeZoneNamesImpl

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
@@ -105,12 +105,16 @@ public final class MobileCore {
         // Direct boot mode is supported on Android N and above
         if (VERSION.SDK_INT >= VERSION_CODES.N) {
             if (UserManagerCompat.isUserUnlocked(application)) {
-                Log.debug(CoreConstants.LOG_TAG, LOG_TAG, "Device is not in direct boot mode.");
+                Log.debug(
+                        CoreConstants.LOG_TAG,
+                        LOG_TAG,
+                        "setApplication failed - device is unlocked.");
             } else {
                 Log.error(
                         CoreConstants.LOG_TAG,
                         LOG_TAG,
-                        "Device is in direct boot mode, SDK will not be initialized.");
+                        "setApplication failed - device is in direct boot mode, SDK will not be"
+                                + " initialized.");
                 return;
             }
         }
@@ -119,7 +123,7 @@ public final class MobileCore {
             Log.debug(
                     CoreConstants.LOG_TAG,
                     LOG_TAG,
-                    "Ignoring as setApplication was already called.");
+                    "setApplication failed - ignoring as setApplication was already called.");
             return;
         }
 

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
@@ -108,7 +108,7 @@ public final class MobileCore {
                 Log.debug(
                         CoreConstants.LOG_TAG,
                         LOG_TAG,
-                        "setApplication - device is unlocked, initializing the SDK.");
+                        "setApplication - device is unlocked and not in direct boot mode, initializing the SDK.");
             } else {
                 Log.error(
                         CoreConstants.LOG_TAG,

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
@@ -108,7 +108,8 @@ public final class MobileCore {
                 Log.debug(
                         CoreConstants.LOG_TAG,
                         LOG_TAG,
-                        "setApplication - device is unlocked and not in direct boot mode, initializing the SDK.");
+                        "setApplication - device is unlocked and not in direct boot mode,"
+                                + " initializing the SDK.");
             } else {
                 Log.error(
                         CoreConstants.LOG_TAG,

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
@@ -108,7 +108,7 @@ public final class MobileCore {
                 Log.debug(
                         CoreConstants.LOG_TAG,
                         LOG_TAG,
-                        "setApplication failed - device is unlocked.");
+                        "setApplication - device is unlocked, initializing the SDK.");
             } else {
                 Log.error(
                         CoreConstants.LOG_TAG,

--- a/code/core/src/test/java/com/adobe/marketing/mobile/MobileCoreRobolectricTests.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/MobileCoreRobolectricTests.kt
@@ -1,0 +1,83 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile
+
+import android.app.Application
+import androidx.core.os.UserManagerCompat
+import com.adobe.marketing.mobile.internal.eventhub.EventHub
+import junit.framework.TestCase.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.assertFalse
+
+@RunWith(RobolectricTestRunner::class)
+class MobileCoreRobolectricTests {
+
+    @Before
+    fun setup() {
+        MobileCore.sdkInitializedWithContext = AtomicBoolean(false)
+    }
+
+    @Test
+    @Config(sdk = [23])
+    fun testA() {
+        val app = RuntimeEnvironment.application as Application
+        val mockedEventHub = Mockito.mock(EventHub::class.java)
+        Mockito.mockStatic(UserManagerCompat::class.java).use { mockedStaticUserManagerCompat ->
+            mockedStaticUserManagerCompat.`when`<Any> { UserManagerCompat.isUserUnlocked(Mockito.any()) }
+                .thenReturn(false)
+            MobileCore.setApplication(app)
+            mockedStaticUserManagerCompat.verify({ UserManagerCompat.isUserUnlocked(Mockito.any()) }, never())
+        }
+        verify(mockedEventHub, never()).executeInEventHubExecutor(any())
+        assertTrue(MobileCore.sdkInitializedWithContext.get())
+    }
+
+    @Test
+    @Config(sdk = [24])
+    fun testB() {
+        val app = RuntimeEnvironment.application as Application
+        val mockedEventHub = Mockito.mock(EventHub::class.java)
+        EventHub.shared = mockedEventHub
+        Mockito.mockStatic(UserManagerCompat::class.java).use { mockedStaticUserManagerCompat ->
+            mockedStaticUserManagerCompat.`when`<Any> { UserManagerCompat.isUserUnlocked(Mockito.any()) }.thenReturn(true)
+            MobileCore.setApplication(app)
+            mockedStaticUserManagerCompat.verify({ UserManagerCompat.isUserUnlocked(Mockito.any()) }, times(1))
+        }
+        verify(mockedEventHub, times(1)).executeInEventHubExecutor(any())
+        assertTrue(MobileCore.sdkInitializedWithContext.get())
+    }
+
+    @Test
+    @Config(sdk = [24])
+    fun testc() {
+        val app = RuntimeEnvironment.application as Application
+        val mockedEventHub = Mockito.mock(EventHub::class.java)
+        Mockito.mockStatic(UserManagerCompat::class.java).use { mockedStaticUserManagerCompat ->
+            mockedStaticUserManagerCompat.`when`<Any> { UserManagerCompat.isUserUnlocked(Mockito.any()) }.thenReturn(false)
+            MobileCore.setApplication(app)
+            mockedStaticUserManagerCompat.verify({ UserManagerCompat.isUserUnlocked(Mockito.any()) }, times(1))
+        }
+        verify(mockedEventHub, never()).executeInEventHubExecutor(any())
+        assertFalse(MobileCore.sdkInitializedWithContext.get())
+    }
+}

--- a/code/core/src/test/java/com/adobe/marketing/mobile/MobileCoreRobolectricTests.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/MobileCoreRobolectricTests.kt
@@ -39,7 +39,8 @@ class MobileCoreRobolectricTests {
 
     @Test
     @Config(sdk = [23])
-    fun testA() {
+    fun `test setApplication when the device doesn't support direct boot mode`() {
+        // Android supports direct boot mode on API level 24 and above
         val app = RuntimeEnvironment.application as Application
         val mockedEventHub = Mockito.mock(EventHub::class.java)
         Mockito.mockStatic(UserManagerCompat::class.java).use { mockedStaticUserManagerCompat ->
@@ -54,11 +55,12 @@ class MobileCoreRobolectricTests {
 
     @Test
     @Config(sdk = [24])
-    fun testB() {
+    fun `test setApplication when the app is not configured to run in direct boot mode`() {
         val app = RuntimeEnvironment.application as Application
         val mockedEventHub = Mockito.mock(EventHub::class.java)
         EventHub.shared = mockedEventHub
         Mockito.mockStatic(UserManagerCompat::class.java).use { mockedStaticUserManagerCompat ->
+            // when initializing SDK, the app is not in direct boot mode (device is unlocked)
             mockedStaticUserManagerCompat.`when`<Any> { UserManagerCompat.isUserUnlocked(Mockito.any()) }.thenReturn(true)
             MobileCore.setApplication(app)
             mockedStaticUserManagerCompat.verify({ UserManagerCompat.isUserUnlocked(Mockito.any()) }, times(1))
@@ -69,10 +71,11 @@ class MobileCoreRobolectricTests {
 
     @Test
     @Config(sdk = [24])
-    fun testc() {
+    fun `test setApplication when the app is launched in direct boot mode`() {
         val app = RuntimeEnvironment.application as Application
         val mockedEventHub = Mockito.mock(EventHub::class.java)
         Mockito.mockStatic(UserManagerCompat::class.java).use { mockedStaticUserManagerCompat ->
+            // when initializing SDK, the app is in direct boot mode (device is still locked)
             mockedStaticUserManagerCompat.`when`<Any> { UserManagerCompat.isUserUnlocked(Mockito.any()) }.thenReturn(false)
             MobileCore.setApplication(app)
             mockedStaticUserManagerCompat.verify({ UserManagerCompat.isUserUnlocked(Mockito.any()) }, times(1))

--- a/code/testapp/src/main/AndroidManifest.xml
+++ b/code/testapp/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
     <application
         android:name="com.adobe.marketing.mobile.core.testapp.MyApp"
         android:allowBackup="true"
@@ -10,9 +12,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.AEPSDKCoreAndroid">
-        <profileable
-            android:shell="true"
-            tools:targetApi="q" />
+<!--        <profileable-->
+<!--            android:shell="true"-->
+<!--            tools:targetApi="q" />-->
 
         <activity
             android:name="com.adobe.marketing.mobile.core.testapp.MainActivity"
@@ -24,6 +26,16 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <receiver android:name=".BootBroadcastReceiver"
+          android:exported="false"
+          android:directBootAware="true"
+          tools:targetApi="n">
+            <intent-filter>
+                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/core/testapp/BootBroadcastReceiver.java
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/core/testapp/BootBroadcastReceiver.java
@@ -1,0 +1,32 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+ */
+package com.adobe.marketing.mobile.core.testapp;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
+import android.util.Log;
+import androidx.core.os.BuildCompat;
+import androidx.core.os.UserManagerCompat;
+
+public class BootBroadcastReceiver extends BroadcastReceiver {
+
+    private static final String TAG = "BootBroadcastReceiver";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String action = intent.getAction();
+        Log.i(TAG, "Received action: " + action + ", isUserUnlocked(): " + UserManagerCompat
+                .isUserUnlocked(context));
+    }
+}

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/core/testapp/MyApp.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/core/testapp/MyApp.kt
@@ -11,10 +11,12 @@
 package com.adobe.marketing.mobile.core.testapp
 
 import android.app.Application
-import com.adobe.marketing.mobile.MobileCore
+import android.util.Log
+import androidx.core.os.UserManagerCompat
 import com.adobe.marketing.mobile.Identity
 import com.adobe.marketing.mobile.Lifecycle
 import com.adobe.marketing.mobile.LoggingMode
+import com.adobe.marketing.mobile.MobileCore
 import com.adobe.marketing.mobile.Signal
 import com.adobe.marketing.mobile.core.testapp.extension.PerfExtension
 
@@ -22,6 +24,7 @@ class MyApp : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        Log.i("MyApp", "Application.onCreate() - start to initialize Adobe SDK. UserManagerCompat.isUserUnlocked(): ${UserManagerCompat.isUserUnlocked(this)}")
         MobileCore.setApplication(this)
         MobileCore.setLogLevel(LoggingMode.VERBOSE)
 


### PR DESCRIPTION
## Features
- Added logic to prevent the SDK from initializing in Android direct boot mode to avoid app crashes. 
- Updated the test app to allow running in Android direct boot mode.

## Manual testing (test app)
- After rebooting the device, it is running in direct boot mode before unlocking the screen.
- SDK is not initialized and extensions are not registered.
- After the device is unlocked, the EventHub singleton is initialized. However, the API calls are dropped since extensions are not registered correctly. 

Device is locked:
<img width="1142" alt="Screenshot 2024-06-18 at 11 04 18 AM" src="https://github.com/adobe/aepsdk-core-android/assets/47394585/954eadf0-5d28-4428-8daa-cb7f09ff48c6">
Device is unlocked:
<img width="1155" alt="Screenshot 2024-06-18 at 11 05 33 AM" src="https://github.com/adobe/aepsdk-core-android/assets/47394585/ab98fe1f-27e5-4573-9661-3bc97bd9fc7c">
Calling public APIs will cause the MobileCore.dispatch() method to be triggered, which will subsequently [initiate](https://github.com/adobe/aepsdk-core-android/blob/main/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java#L282) the EventHub singleton. 
```
AdobeExperienceSDK      com...marketing.mobile.core.testapp  D  MobileCore/ExtensionContainer[com.adobe.module.eventhub(3.0.2)] - Extension registered
AdobeExperienceSDK      com...marketing.mobile.core.testapp  V  MobileCore/Extension[com.adobe.module.eventhub(3.0.2)] - Extension registered successfully.
AdobeExperienceSDK      com...marketing.mobile.core.testapp  D  MobileCore/EventHub - Dispatching Event #1 - ({
                                                                    class: Event,
                                                                    name: Configuration Update,
                                                                    uniqueIdentifier: aed9001e-4974-4dfa-92cb-30f3ffbec878,
                                                                    source: com.adobe.eventSource.requestContent,
                                                                    type: com.adobe.eventType.configuration,
                                                                    responseId: null,
                                                                    parentId: null,
                                                                    timestamp: 1718726746531,
                                                                    data: {
                                                                    "config.update": {
                                                                        "global.privacy": "optedout"
                                                                    }
                                                                },
                                                                    mask: null,
                                                                })
AdobeExperienceSDK      com...marketing.mobile.core.testapp  V  MobileCore/EventHub - Extension class com.adobe.marketing.mobile.internal.eventhub.EventHubPlaceholderExtension registered successfully
```

