### PR TITLE
Switch Event extension functions to properties

### DIFF
--- a/code/core/src/main/java/com/adobe/marketing/mobile/util/EventUtils.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/util/EventUtils.kt
@@ -38,7 +38,7 @@ val Event.debugEventSource: String?
  * @return the content of "debug" key within "Event.data" if present,
  *         null if the event is not a debug event or if the debug data does not exist
  */
-val Event.debugEventData: Map<String, Any?>?
+private val Event.debugEventData: Map<String, Any?>?
     get() {
         if (type != EventType.SYSTEM || source != EventSource.DEBUG) return null
 

--- a/code/core/src/main/java/com/adobe/marketing/mobile/util/EventUtils.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/util/EventUtils.kt
@@ -25,35 +25,24 @@ private const val KEY_DEBUG_EVENT_SOURCE = "eventSource"
  * The debug event type (identified by debug.eventType) from the event data if present, otherwise null
  */
 val Event.debugEventType: String?
-    get() {
-        val debugData = getDebugEventData() ?: return null
-        val eventType = debugData[KEY_DEBUG_EVENT_TYPE]
-        if (eventType !is String) return null
-
-        return eventType
-    }
+    get() = debugEventData?.get(KEY_DEBUG_EVENT_TYPE) as? String
 
 /**
  * The debug event source (identified by debug.eventSource) from the event data if present, otherwise null.
  */
 val Event.debugEventSource: String?
-    get() {
-        val debugData = getDebugEventData() ?: return null
-        val eventSource = debugData[KEY_DEBUG_EVENT_SOURCE]
-        if (eventSource !is String) return null
-
-        return eventSource
-    }
+    get() = debugEventData?.get(KEY_DEBUG_EVENT_SOURCE) as? String
 
 /**
  * Returns the debug event data (identified by data.debug) from the event if present, otherwise null.
  * @return the content of "debug" key within "Event.data" if present,
  *         null if the event is not a debug event or if the debug data does not exist
  */
-private fun Event.getDebugEventData(): Map<String, Any?>? {
-    if (type != EventType.SYSTEM || source != EventSource.DEBUG) return null
+val Event.debugEventData: Map<String, Any?>?
+    get() {
+        if (type != EventType.SYSTEM || source != EventSource.DEBUG) return null
 
-    if (eventData == null) return null
+        if (eventData == null) return null
 
-    return DataReader.optTypedMap(Any::class.java, eventData, KEY_EVENT_DATA_DEBUG, null) ?: null
-}
+        return DataReader.optTypedMap(Any::class.java, eventData, KEY_EVENT_DATA_DEBUG, null) ?: null
+    }

--- a/code/core/src/main/java/com/adobe/marketing/mobile/util/EventUtils.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/util/EventUtils.kt
@@ -22,28 +22,28 @@ private const val KEY_DEBUG_EVENT_TYPE = "eventType"
 private const val KEY_DEBUG_EVENT_SOURCE = "eventSource"
 
 /**
- * Returns the debug event type (identified by debug.eventType) from the event data if present, otherwise null.
- * @return the debug event type if present, otherwise null
+ * The debug event type (identified by debug.eventType) from the event data if present, otherwise null
  */
-fun Event.getDebugEventType(): String? {
-    val debugData = getDebugEventData() ?: return null
-    val debugEventType = debugData[KEY_DEBUG_EVENT_TYPE]
-    if (debugEventType !is String) return null
+val Event.debugEventType: String?
+    get() {
+        val debugData = getDebugEventData() ?: return null
+        val eventType = debugData[KEY_DEBUG_EVENT_TYPE]
+        if (eventType !is String) return null
 
-    return debugEventType
-}
+        return eventType
+    }
 
 /**
- * Returns the debug event source (identified by debug.eventSource) from the event data if present, otherwise null.
- * @return the debug event source if present, otherwise null
+ * The debug event source (identified by debug.eventSource) from the event data if present, otherwise null.
  */
-fun Event.getDebugEventSource(): String? {
-    val debugData = getDebugEventData() ?: return null
-    val debugEventSource = debugData[KEY_DEBUG_EVENT_SOURCE]
-    if (debugEventSource !is String) return null
+val Event.debugEventSource: String?
+    get() {
+        val debugData = getDebugEventData() ?: return null
+        val eventSource = debugData[KEY_DEBUG_EVENT_SOURCE]
+        if (eventSource !is String) return null
 
-    return debugEventSource
-}
+        return eventSource
+    }
 
 /**
  * Returns the debug event data (identified by data.debug) from the event if present, otherwise null.

--- a/code/core/src/test/java/com/adobe/marketing/mobile/util/EventUtilsTest.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/util/EventUtilsTest.kt
@@ -26,37 +26,37 @@ class EventUtilsTest {
     }
 
     @Test
-    fun `Test getDebugEventType returns null on non debug event`() {
+    fun `Test debugEventType returns null on non debug event`() {
         val event = Event.Builder(TEST_EVENT_NAME, EventType.HUB, EventSource.REQUEST_CONTENT).build()
 
-        assertNull(event.getDebugEventType())
+        assertNull(event.debugEventType)
     }
 
     @Test
-    fun `Test getDebugEventType returns null on no eventData`() {
+    fun `Test debugEventType returns null on no eventData`() {
         val event = Event.Builder(TEST_EVENT_NAME, TEST_EVENT_TYPE, TEST_EVENT_SOURCE).build()
 
-        assertNull(event.getDebugEventType())
+        assertNull(event.debugEventType)
     }
 
     @Test
-    fun `Test getDebugEventType returns null on no debug data`() {
+    fun `Test debugEventType returns null on no debug data`() {
         val event = Event.Builder(TEST_EVENT_NAME, TEST_EVENT_TYPE, TEST_EVENT_SOURCE)
             .setEventData(mapOf("key" to "value")).build()
 
-        assertNull(event.getDebugEventType())
+        assertNull(event.debugEventType)
     }
 
     @Test
-    fun `Test getDebugEventType returns null when debug is not a map`() {
+    fun `Test debugEventType returns null when debug is not a map`() {
         val event = Event.Builder(TEST_EVENT_NAME, TEST_EVENT_TYPE, TEST_EVENT_SOURCE)
             .setEventData(mapOf("debug" to "value")).build()
 
-        assertNull(event.getDebugEventType())
+        assertNull(event.debugEventType)
     }
 
     @Test
-    fun `Test getDebugEventType returns null on invalid debug key`() {
+    fun `Test debugEventType returns null on invalid debug key`() {
         val event = Event.Builder(TEST_EVENT_NAME, TEST_EVENT_TYPE, TEST_EVENT_SOURCE)
             .setEventData(
                 mapOf(
@@ -67,11 +67,11 @@ class EventUtilsTest {
                 )
             ).build()
 
-        assertNull(event.getDebugEventType())
+        assertNull(event.debugEventType)
     }
 
     @Test
-    fun `Test getDebugEventType returns null when key is absent`() {
+    fun `Test debugEventType returns null when key is absent`() {
         val event = Event.Builder(TEST_EVENT_NAME, TEST_EVENT_TYPE, TEST_EVENT_SOURCE)
             .setEventData(
                 mapOf(
@@ -81,11 +81,11 @@ class EventUtilsTest {
                 )
             ).build()
 
-        assertNull(event.getDebugEventType())
+        assertNull(event.debugEventType)
     }
 
     @Test
-    fun `Test getDebugEventType returns debug event type`() {
+    fun `Test debugEventType returns debug event type`() {
         val event = Event.Builder(TEST_EVENT_NAME, TEST_EVENT_TYPE, TEST_EVENT_SOURCE)
             .setEventData(
                 mapOf(
@@ -96,11 +96,11 @@ class EventUtilsTest {
                 )
             ).build()
 
-        assertEquals(EventType.RULES_ENGINE, event.getDebugEventType())
+        assertEquals(EventType.RULES_ENGINE, event.debugEventType)
     }
 
     @Test
-    fun `Test getDebugEventType returns null when debugEvent type is not a string`() {
+    fun `Test debugEventType returns null when debugEvent type is not a string`() {
         val event = Event.Builder(TEST_EVENT_NAME, TEST_EVENT_TYPE, TEST_EVENT_SOURCE)
             .setEventData(
                 mapOf(
@@ -111,41 +111,41 @@ class EventUtilsTest {
                 )
             ).build()
 
-        assertNull(event.getDebugEventType())
+        assertNull(event.debugEventType)
     }
 
     @Test
-    fun `Test getDebugEventSource returns null on non debug event`() {
+    fun `Test debugEventSource returns null on non debug event`() {
         val event = Event.Builder(TEST_EVENT_NAME, EventType.HUB, EventSource.REQUEST_CONTENT).build()
 
-        assertNull(event.getDebugEventSource())
+        assertNull(event.debugEventSource)
     }
 
     @Test
-    fun `Test getDebugEventSource returns null on no eventData`() {
+    fun `Test debugEventSource returns null on no eventData`() {
         val event = Event.Builder(TEST_EVENT_NAME, TEST_EVENT_TYPE, TEST_EVENT_SOURCE).build()
 
-        assertNull(event.getDebugEventSource())
+        assertNull(event.debugEventSource)
     }
 
     @Test
-    fun `Test getDebugEventSource returns null when debug is not a map`() {
+    fun `Test debugEventSource returns null when debug is not a map`() {
         val event = Event.Builder(TEST_EVENT_NAME, TEST_EVENT_TYPE, TEST_EVENT_SOURCE)
             .setEventData(mapOf("debug" to "value")).build()
 
-        assertNull(event.getDebugEventSource())
+        assertNull(event.debugEventSource)
     }
 
     @Test
-    fun `Test getDebugEventSource returns null on no debug data`() {
+    fun `Test debugEventSource returns null on no debug data`() {
         val event = Event.Builder(TEST_EVENT_NAME, TEST_EVENT_TYPE, TEST_EVENT_SOURCE)
             .setEventData(mapOf("key" to "value")).build()
 
-        assertNull(event.getDebugEventSource())
+        assertNull(event.debugEventSource)
     }
 
     @Test
-    fun `Test getDebugEventSource returns null on invalid debug key`() {
+    fun `Test debugEventSource returns null on invalid debug key`() {
         val event = Event.Builder(TEST_EVENT_NAME, TEST_EVENT_TYPE, TEST_EVENT_SOURCE)
             .setEventData(
                 mapOf(
@@ -156,11 +156,11 @@ class EventUtilsTest {
                 )
             ).build()
 
-        assertNull(event.getDebugEventSource())
+        assertNull(event.debugEventSource)
     }
 
     @Test
-    fun `Test getDebugEventSource returns debug event source`() {
+    fun `Test debugEventSource returns debug event source`() {
         val event = Event.Builder(TEST_EVENT_NAME, TEST_EVENT_TYPE, TEST_EVENT_SOURCE)
             .setEventData(
                 mapOf(
@@ -171,11 +171,11 @@ class EventUtilsTest {
                 )
             ).build()
 
-        assertEquals(EventSource.RESET_COMPLETE, event.getDebugEventSource())
+        assertEquals(EventSource.RESET_COMPLETE, event.debugEventSource)
     }
 
     @Test
-    fun `Test getDebugEventSource returns null when debugEvent source is not a string`() {
+    fun `Test debugEventSource returns null when debugEvent source is not a string`() {
         val event = Event.Builder(TEST_EVENT_NAME, TEST_EVENT_TYPE, TEST_EVENT_SOURCE)
             .setEventData(
                 mapOf(
@@ -186,11 +186,11 @@ class EventUtilsTest {
                 )
             ).build()
 
-        assertNull(event.getDebugEventSource())
+        assertNull(event.debugEventSource)
     }
 
     @Test
-    fun `Test getDebugEventSource returns null when key is absent`() {
+    fun `Test debugEventSource returns null when key is absent`() {
         val event = Event.Builder(TEST_EVENT_NAME, TEST_EVENT_TYPE, TEST_EVENT_SOURCE)
             .setEventData(
                 mapOf(
@@ -200,6 +200,6 @@ class EventUtilsTest {
                 )
             ).build()
 
-        assertNull(event.getDebugEventSource())
+        assertNull(event.debugEventSource)
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Switch Event extension functions to properties to be easier for access in Kotlin and parity with iOS. Java callers can still use
`EventUtils.getDebugEventSource(event)` , `EventUtils.getDebugEventType(event)`
