### PR TITLE
Apply .99 alpha to versions <=22 only

### DIFF
--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageFrame.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageFrame.kt
@@ -11,6 +11,7 @@
 
 package com.adobe.marketing.mobile.services.ui.message.views
 
+import android.os.Build
 import android.webkit.WebView
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.MutableTransitionState
@@ -80,6 +81,8 @@ internal fun MessageFrame(
     val offsetY = remember { mutableStateOf(0f) }
     val dragVelocity = remember { mutableStateOf(0f) }
 
+    val adjustAlphaForClipping = remember { Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP_MR1 }
+
     AnimatedVisibility(
         visibleState = visibility,
         enter = MessageAnimationMapper.getEnterTransitionFor(inAppMessageSettings.displayAnimation),
@@ -98,14 +101,16 @@ internal fun MessageFrame(
             ),
             verticalAlignment = MessageAlignmentMapper.getVerticalAlignment(inAppMessageSettings.verticalAlignment)
         ) {
-            // The content of the InAppMessage. This needs to be placed inside a Card with .99 alpha to ensure that
-            // the WebView message is clipped to the rounded corners for API versions 22 and below. This does not
-            // affect the appearance of the message on API versions 23 and above.
+            // The content of the InAppMessage.
             Card(
                 backgroundColor = Color.Transparent,
                 modifier = Modifier
                     .clip(RoundedCornerShape(inAppMessageSettings.cornerRadius.dp))
-                    .alpha(0.99f)
+                    .let {
+                        // Needs .99 alpha to ensure that the WebView message is clipped to
+                        // the rounded corners for API versions 22 and below.
+                        if (adjustAlphaForClipping) it.alpha(0.99f) else it
+                    }
                     .draggable(
                         enabled = allowGestures,
                         state = rememberDraggableState { delta ->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

**Needs PM approval. DO NOT MERGE**

## Description
Currently a hack to apply an alpha of .99 on the content view holding the in-app message to ensure that corner radius settings are honored for API <=22.
However this is applied to all api levels currently. A very keen look show a faint outline the contents underneath the in-app message. Restrict the hack to API <=22 only to ensure that the issue is not seen on devices where the hack is not needed.
**Note that the slight transparency due to .99 alpha will still exist in API <=22 to honor rounded corner settings.**

<!--- Describe your changes in detail -->

## Related Issue
Internal (MOB-21296)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Currently a hack to apply an alpha of .99 on the content view holding the in-app message to ensure that corner radius settings are honored for API <=22.
However this is applied to all api levels currently. A very keen look show a faint outline the contents underneath the in-app message. Restrict the hack to API <=22 only to ensure that the issue is not seen on devices where the hack is not needed.
**Note that the slight transparency due to .99 alpha will still exist in API <=22 to honor rounded corner settings.**
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Test app
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
- **API 21(No changes should still see slight transparency)**<img src="https://github.com/adobe/aepsdk-core-android/assets/96199823/586d04fa-6f00-45b4-b5ce-7574e00af00a" height=300 width=150>


- **API 33 ( API >=23)** <img src="https://github.com/adobe/aepsdk-core-android/assets/96199823/80900adb-e9da-49df-ba5c-a17d5de805be" height=300 width=150>


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
