### PR TITLE
[PLATIR-41103] Added dialog for correct screen reader case

### DIFF
--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/Message.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/Message.kt
@@ -78,7 +78,8 @@ internal fun MessageScreen(
             ),
             onDismissRequest = {
                 onBackPressed()
-            }) {
+            }
+        ) {
             Message(
                 isVisible = presentationStateManager.visibilityState,
                 inAppMessageSettings = inAppMessageSettings,

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/Message.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/Message.kt
@@ -11,12 +11,10 @@
 
 package com.adobe.marketing.mobile.services.ui.message.views
 
-import android.view.Window
 import android.webkit.WebView
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalView

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/Message.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/Message.kt
@@ -115,7 +115,8 @@ internal fun Message(
                Customer can set their own dim and animations if needed and those will be honoured in MessageBackdrop inside Message
              */
 
-            val dialogWindow = getDialogWindow()
+            val dialogWindow = (LocalView.current.parent as? DialogWindowProvider)?.window
+
             SideEffect {
                 dialogWindow?.let {
                     it.setDimAmount(0f)
@@ -150,7 +151,3 @@ internal fun Message(
         )
     }
 }
-
-@ReadOnlyComposable
-@Composable
-fun getDialogWindow(): Window? = (LocalView.current.parent as? DialogWindowProvider)?.window

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/Message.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/Message.kt
@@ -69,50 +69,14 @@ internal fun MessageScreen(
         onBackPressed()
     }
 
-    if (inAppMessageSettings.shouldTakeOverUi) {
-        /**
-         * Dialog is used to take over the UI when the InAppMessage is set to take over the UI.
-         * This is necessary to ensure that the InAppMessage is displayed on top of the UI.
-         * Which will ensure that ScreenReader can read the content of the InAppMessage only and not the underlying UI.
-         */
-        Dialog(
-            properties = DialogProperties(
-                usePlatformDefaultWidth = false,
-                dismissOnBackPress = true,
-                dismissOnClickOutside = false
-            ),
-            onDismissRequest = {
-                onBackPressed()
-            }
-        ) {
-            /** Remove the default dim and animations for the dialog window
-             * Customer can set their own dim and animations if needed and those will be honoured in MessageBackdrop inside Message
-             */
-            val dialogWindow = getDialogWindow()
-            SideEffect {
-                dialogWindow?.let {
-                    it.setDimAmount(0f)
-                    it.setWindowAnimations(-1)
-                }
-            }
-
-            Message(
-                isVisible = presentationStateManager.visibilityState,
-                inAppMessageSettings = inAppMessageSettings,
-                gestureTracker = gestureTracker,
-                onCreated = { onCreated(it) },
-                onDisposed = { onDisposed() }
-            )
-        }
-    } else {
-        Message(
-            isVisible = presentationStateManager.visibilityState,
-            inAppMessageSettings = inAppMessageSettings,
-            gestureTracker = gestureTracker,
-            onCreated = { onCreated(it) },
-            onDisposed = { onDisposed() }
-        )
-    }
+    Message(
+        isVisible = presentationStateManager.visibilityState,
+        inAppMessageSettings = inAppMessageSettings,
+        gestureTracker = gestureTracker,
+        onCreated = { onCreated(it) },
+        onDisposed = { onDisposed() },
+        onBackPressed = onBackPressed
+    )
 }
 
 /**
@@ -129,25 +93,62 @@ internal fun Message(
     inAppMessageSettings: InAppMessageSettings,
     gestureTracker: GestureTracker,
     onCreated: (WebView) -> Unit,
-    onDisposed: () -> Unit
+    onDisposed: () -> Unit,
+    onBackPressed: () -> Unit,
 ) {
-    // Backdrop for the InAppMessage only takes into effect if the InAppMessage is taking over the UI
     if (inAppMessageSettings.shouldTakeOverUi) {
-        MessageBackdrop(
+        /* Dialog is used to take over the UI when the InAppMessage is set to take over the UI.
+         This is necessary to ensure that the InAppMessage is displayed on top of the UI.
+         Which will ensure that ScreenReader can read the content of the InAppMessage only and not the underlying UI.
+         */
+        Dialog(
+            properties = DialogProperties(
+                usePlatformDefaultWidth = false,
+                dismissOnBackPress = true,
+                dismissOnClickOutside = false
+            ),
+            onDismissRequest = {
+                onBackPressed()
+            }
+        ) {
+            /* Remove the default dim and animations for the dialog window
+               Customer can set their own dim and animations if needed and those will be honoured in MessageBackdrop inside Message
+             */
+
+            val dialogWindow = getDialogWindow()
+            SideEffect {
+                dialogWindow?.let {
+                    it.setDimAmount(0f)
+                    it.setWindowAnimations(-1)
+                }
+            }
+
+            // Backdrop for the InAppMessage only takes into effect if the InAppMessage is taking over the UI
+            MessageBackdrop(
+                visibility = isVisible,
+                inAppMessageSettings = inAppMessageSettings,
+                gestureTracker = gestureTracker
+            )
+
+            // Frame that holds the InAppMessage
+            MessageFrame(
+                visibility = isVisible,
+                inAppMessageSettings = inAppMessageSettings,
+                gestureTracker = gestureTracker,
+                onCreated = onCreated,
+                onDisposed = onDisposed
+            )
+        }
+    } else {
+        // Frame that holds the InAppMessage
+        MessageFrame(
             visibility = isVisible,
             inAppMessageSettings = inAppMessageSettings,
-            gestureTracker = gestureTracker
+            gestureTracker = gestureTracker,
+            onCreated = onCreated,
+            onDisposed = onDisposed
         )
     }
-
-    // Frame that holds the InAppMessage
-    MessageFrame(
-        visibility = isVisible,
-        inAppMessageSettings = inAppMessageSettings,
-        gestureTracker = gestureTracker,
-        onCreated = onCreated,
-        onDisposed = onDisposed
-    )
 }
 
 @ReadOnlyComposable

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/Message.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/Message.kt
@@ -11,13 +11,18 @@
 
 package com.adobe.marketing.mobile.services.ui.message.views
 
+import android.view.Window
 import android.webkit.WebView
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.DialogWindowProvider
 import com.adobe.marketing.mobile.services.ui.Presentable
 import com.adobe.marketing.mobile.services.ui.common.PresentationStateManager
 import com.adobe.marketing.mobile.services.ui.message.GestureTracker
@@ -80,6 +85,17 @@ internal fun MessageScreen(
                 onBackPressed()
             }
         ) {
+            /** Remove the default dim and animations for the dialog window
+             * Customer can set their own dim and animations if needed and those will be honoured in MessageBackdrop inside Message
+            */
+            val dialogWindow = getDialogWindow()
+            SideEffect {
+                dialogWindow?.let {
+                    it.setDimAmount(0f)
+                    it.setWindowAnimations(-1)
+                }
+            }
+
             Message(
                 isVisible = presentationStateManager.visibilityState,
                 inAppMessageSettings = inAppMessageSettings,
@@ -133,3 +149,8 @@ internal fun Message(
         onDisposed = onDisposed
     )
 }
+
+
+@ReadOnlyComposable
+@Composable
+fun getDialogWindow(): Window? = (LocalView.current.parent as? DialogWindowProvider)?.window

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/Message.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/Message.kt
@@ -87,7 +87,7 @@ internal fun MessageScreen(
         ) {
             /** Remove the default dim and animations for the dialog window
              * Customer can set their own dim and animations if needed and those will be honoured in MessageBackdrop inside Message
-            */
+             */
             val dialogWindow = getDialogWindow()
             SideEffect {
                 dialogWindow?.let {
@@ -149,7 +149,6 @@ internal fun Message(
         onDisposed = onDisposed
     )
 }
-
 
 @ReadOnlyComposable
 @Composable

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/Message.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/Message.kt
@@ -16,6 +16,8 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.adobe.marketing.mobile.services.ui.Presentable
 import com.adobe.marketing.mobile.services.ui.common.PresentationStateManager
 import com.adobe.marketing.mobile.services.ui.message.GestureTracker
@@ -62,13 +64,38 @@ internal fun MessageScreen(
         onBackPressed()
     }
 
-    Message(
-        isVisible = presentationStateManager.visibilityState,
-        inAppMessageSettings = inAppMessageSettings,
-        gestureTracker = gestureTracker,
-        onCreated = { onCreated(it) },
-        onDisposed = { onDisposed() }
-    )
+    if (inAppMessageSettings.shouldTakeOverUi) {
+        /**
+         * Dialog is used to take over the UI when the InAppMessage is set to take over the UI.
+         * This is necessary to ensure that the InAppMessage is displayed on top of the UI.
+         * Which will ensure that ScreenReader can read the content of the InAppMessage only and not the underlying UI.
+         */
+        Dialog(
+            properties = DialogProperties(
+                usePlatformDefaultWidth = false,
+                dismissOnBackPress = true,
+                dismissOnClickOutside = false
+            ),
+            onDismissRequest = {
+                onBackPressed()
+            }) {
+            Message(
+                isVisible = presentationStateManager.visibilityState,
+                inAppMessageSettings = inAppMessageSettings,
+                gestureTracker = gestureTracker,
+                onCreated = { onCreated(it) },
+                onDisposed = { onDisposed() }
+            )
+        }
+    } else {
+        Message(
+            isVisible = presentationStateManager.visibilityState,
+            inAppMessageSettings = inAppMessageSettings,
+            gestureTracker = gestureTracker,
+            onCreated = { onCreated(it) },
+            onDisposed = { onDisposed() }
+        )
+    }
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added dialog in case of UI take over for IAM , for making screen reader only read the content of IAM and not the UI beneath it.

## Description
Previously we were adding IAM directly in the activity UI, which, for screen readers, was just another content on the screen. So screen reader always read from top to bottom, regardless of IAM was showing or not. 
To make IAM getting read only while it is showing, we need to put it in a component which is a layer above the existing UI. So we chose to go with dialog with this. Also we have kept this behavior only in case of UI takeover is true, else it will block the direct interaction to UI beneath it.

## Related Issue
https://jira.corp.adobe.com/browse/PLATIR-41103

## Motivation and Context
Same as mentioned in description.

## How Has This Been Tested?
Tested for all the existing templates.
Ensured that non-ui take over case also remains the same

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
