### PR TITLE
add `SuppressedByAppDeveloper` to `PresentationError` interface

### DIFF
--- a/code/core/api/core.api
+++ b/code/core/api/core.api
@@ -778,11 +778,6 @@ public final class com/adobe/marketing/mobile/services/ui/ConflictingPresentatio
 	public static final field INSTANCE Lcom/adobe/marketing/mobile/services/ui/ConflictingPresentation;
 }
 
-public final class com/adobe/marketing/mobile/services/ui/DelegateGateNotMet : com/adobe/marketing/mobile/services/ui/ShowFailed {
-	public static final field $stable I
-	public static final field INSTANCE Lcom/adobe/marketing/mobile/services/ui/DelegateGateNotMet;
-}
-
 public abstract class com/adobe/marketing/mobile/services/ui/DismissFailed : com/adobe/marketing/mobile/services/ui/PresentationError {
 	public static final field $stable I
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -889,6 +884,11 @@ public abstract class com/adobe/marketing/mobile/services/ui/ShowFailed : com/ad
 	public static final field $stable I
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getReason ()Ljava/lang/String;
+}
+
+public final class com/adobe/marketing/mobile/services/ui/SuppressedByAppDeveloper : com/adobe/marketing/mobile/services/ui/ShowFailed {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/adobe/marketing/mobile/services/ui/SuppressedByAppDeveloper;
 }
 
 public abstract interface class com/adobe/marketing/mobile/services/ui/UIService {

--- a/code/core/api/core.api
+++ b/code/core/api/core.api
@@ -778,6 +778,11 @@ public final class com/adobe/marketing/mobile/services/ui/ConflictingPresentatio
 	public static final field INSTANCE Lcom/adobe/marketing/mobile/services/ui/ConflictingPresentation;
 }
 
+public final class com/adobe/marketing/mobile/services/ui/DelegateGateNotMet : com/adobe/marketing/mobile/services/ui/ShowFailed {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/adobe/marketing/mobile/services/ui/DelegateGateNotMet;
+}
+
 public abstract class com/adobe/marketing/mobile/services/ui/DismissFailed : com/adobe/marketing/mobile/services/ui/PresentationError {
 	public static final field $stable I
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/Presentation.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/Presentation.kt
@@ -37,7 +37,7 @@ sealed class Presentation<T : Presentation<T>>(val listener: PresentationEventLi
 /**
  * Represents an InAppMessage presentation.
  * @param settings the settings for the InAppMessage
- * @param eventListener the listener for the getting notified about InAppMessage lifecycle events
+ * @param eventListener the listener for getting notifications about InAppMessage lifecycle events
  * @param eventHandler the event handler performing operations on the InAppMessage
  */
 class InAppMessage(
@@ -54,7 +54,7 @@ class InAppMessage(
 
 /**
  * Represents a FloatingButton presentation.
- * @param eventListener the listener for the getting notified about FloatingButton lifecycle events
+ * @param eventListener the listener for getting notifications about FloatingButton lifecycle events
  * @param settings the settings for the FloatingButton
  */
 class FloatingButton(
@@ -72,7 +72,7 @@ class FloatingButton(
 /**
  * Represents an Alert presentation.
  * @param settings the settings for the Alert
- * @param eventListener the listener for the getting notified about Alert lifecycle events
+ * @param eventListener the listener for getting notifications about Alert lifecycle events
  */
 class Alert(
     val settings: AlertSettings,

--- a/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/PresentationError.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/PresentationError.kt
@@ -35,6 +35,12 @@ object ConflictingPresentation : ShowFailed("Conflict")
 object NoAttachableActivity : ShowFailed("No attachable activity available.")
 
 /**
+ * Represents a failure to show a Presentable because the delegate gate was not met.
+ */
+@Deprecated("Use SuppressedByAppDeveloper instead", ReplaceWith("SuppressedByAppDeveloper"))
+object DelegateGateNotMet : ShowFailed("PresentationDelegate suppressed the presentation from being shown.")
+
+/**
  * Represents a failure to show a Presentable because the app developer has suppressed [Presentable]s.
  */
 object SuppressedByAppDeveloper : ShowFailed("SuppressedByAppDeveloper")

--- a/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/PresentationError.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/services/ui/PresentationError.kt
@@ -27,7 +27,7 @@ sealed class DismissFailed(val reason: String) : PresentationError
 /**
  * Represents a failure to show a Presentable because a conflicting presentation is already shown.
  */
-object ConflictingPresentation : ShowFailed("Conflicting presentation is visible.")
+object ConflictingPresentation : ShowFailed("Conflict")
 
 /**
  * Represents a failure to show a Presentable because there is no activity to show it on.
@@ -35,9 +35,9 @@ object ConflictingPresentation : ShowFailed("Conflicting presentation is visible
 object NoAttachableActivity : ShowFailed("No attachable activity available.")
 
 /**
- * Represents a failure to show a Presentable because the delegate gate was not met.
+ * Represents a failure to show a Presentable because the app developer has suppressed [Presentable]s.
  */
-object DelegateGateNotMet : ShowFailed("PresentationDelegate suppressed the presentation from being shown.")
+object SuppressedByAppDeveloper : ShowFailed("SuppressedByAppDeveloper")
 
 /**
  * Represents a failure to show a Presentable because it is already shown.

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/common/AEPPresentable.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/common/AEPPresentable.kt
@@ -25,13 +25,13 @@ import com.adobe.marketing.mobile.services.ui.AlreadyDismissed
 import com.adobe.marketing.mobile.services.ui.AlreadyHidden
 import com.adobe.marketing.mobile.services.ui.AlreadyShown
 import com.adobe.marketing.mobile.services.ui.ConflictingPresentation
-import com.adobe.marketing.mobile.services.ui.DelegateGateNotMet
 import com.adobe.marketing.mobile.services.ui.NoActivityToDetachFrom
 import com.adobe.marketing.mobile.services.ui.NoAttachableActivity
 import com.adobe.marketing.mobile.services.ui.Presentable
 import com.adobe.marketing.mobile.services.ui.Presentation
 import com.adobe.marketing.mobile.services.ui.PresentationDelegate
 import com.adobe.marketing.mobile.services.ui.PresentationUtilityProvider
+import com.adobe.marketing.mobile.services.ui.SuppressedByAppDeveloper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.lang.ref.WeakReference
@@ -158,7 +158,8 @@ internal abstract class AEPPresentable<T : Presentation<T>> :
             if (gateDisplay()) {
                 val canShow = (presentationDelegate?.canShow(this@AEPPresentable) ?: true)
                 if (!canShow) {
-                    presentation.listener.onError(this@AEPPresentable, DelegateGateNotMet)
+                    Log.debug(ServiceConstants.LOG_TAG, LOG_SOURCE, "Presentable couldn't be displayed, PresentationDelegate#canShow states the presentable should not be displayed.")
+                    presentation.listener.onError(this@AEPPresentable, SuppressedByAppDeveloper)
                     return@launch
                 }
             }

--- a/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/common/AEPPresentableTest.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/services/ui/common/AEPPresentableTest.kt
@@ -21,7 +21,6 @@ import com.adobe.marketing.mobile.services.ui.Alert
 import com.adobe.marketing.mobile.services.ui.AlreadyDismissed
 import com.adobe.marketing.mobile.services.ui.AlreadyHidden
 import com.adobe.marketing.mobile.services.ui.AlreadyShown
-import com.adobe.marketing.mobile.services.ui.DelegateGateNotMet
 import com.adobe.marketing.mobile.services.ui.FloatingButton
 import com.adobe.marketing.mobile.services.ui.InAppMessage
 import com.adobe.marketing.mobile.services.ui.NoActivityToDetachFrom
@@ -29,6 +28,7 @@ import com.adobe.marketing.mobile.services.ui.Presentable
 import com.adobe.marketing.mobile.services.ui.Presentation
 import com.adobe.marketing.mobile.services.ui.PresentationDelegate
 import com.adobe.marketing.mobile.services.ui.PresentationUtilityProvider
+import com.adobe.marketing.mobile.services.ui.SuppressedByAppDeveloper
 import com.adobe.marketing.mobile.services.ui.message.InAppMessageEventListener
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -175,7 +175,7 @@ internal class AEPPresentableTest {
             verify(mockPresentationDelegate).canShow(aepPresentableWithGatedDisplay)
 
             // verify that the listener is notified of the error
-            verify(mockPresentationListener).onError(aepPresentableWithGatedDisplay, DelegateGateNotMet)
+            verify(mockPresentationListener).onError(aepPresentableWithGatedDisplay, SuppressedByAppDeveloper)
 
             // verify that the lifecycle provider is called to register the listener
             verify(mockAppLifecycleProvider, never()).registerListener(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- rename `DelegateGateNotMet` to `SuppressedByAppDeveloper`.
- update conflict and suppressed by app developer error reasons to match the ones in-use on the iOS side
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
