### PR TITLE
Cleanup AndroidManifest.xml

### DIFF
--- a/code/core/src/androidTest/AndroidManifest.xml
+++ b/code/core/src/androidTest/AndroidManifest.xml
@@ -1,3 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2019 Adobe. All rights reserved.
+    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License. You may obtain a copy
+    of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under
+    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+    OF ANY KIND, either express or implied. See the License for the specific language
+    governing permissions and limitations under the License.
+-->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   android:versionCode="1010"
   android:versionCodeMajor="5">

--- a/code/core/src/main/AndroidManifest.xml
+++ b/code/core/src/main/AndroidManifest.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright 2019 Adobe. All rights reserved.
     This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -13,7 +14,8 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <application>
-        <service android:name="com.adobe.marketing.mobile.ExtensionDiscoveryService">
+        <service android:name="com.adobe.marketing.mobile.ExtensionDiscoveryService"
+            android:exported="false">
             <meta-data
                 android:name="com.adobe.marketing.mobile.internal.configuration.ConfigurationExtension"
                 android:value="Extension" />

--- a/code/core/src/main/java/com/adobe/marketing/mobile/ExtensionDiscovery.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/ExtensionDiscovery.kt
@@ -46,8 +46,8 @@ internal class ExtensionDiscovery {
                         } else {
                             Log.debug(CoreConstants.LOG_TAG, LOG_TAG, "Class $key is not a valid Extension.")
                         }
-                    } catch (e: ClassNotFoundException) {
-                        Log.error(CoreConstants.LOG_TAG, LOG_TAG, "Failed to load extension class $key - ${e.message}.")
+                    } catch (e: Exception) {
+                        Log.warning(CoreConstants.LOG_TAG, LOG_TAG, "Failed to load extension class $key - ${e.cause}")
                     }
                 }
             } ?: Log.debug(CoreConstants.LOG_TAG, LOG_TAG, "No metadata found for service $SERVICE_NAME.")

--- a/code/identity/src/main/AndroidManifest.xml
+++ b/code/identity/src/main/AndroidManifest.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright 2019 Adobe. All rights reserved.
     This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -11,7 +12,8 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
-        <service android:name="com.adobe.marketing.mobile.ExtensionDiscoveryService">
+        <service android:name="com.adobe.marketing.mobile.ExtensionDiscoveryService"
+            android:exported="false">
             <meta-data
                 android:name="com.adobe.marketing.mobile.identity.IdentityExtension"
                 android:value="Extension" />

--- a/code/integration-tests/src/main/AndroidManifest.xml
+++ b/code/integration-tests/src/main/AndroidManifest.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.adobe.marketing.mobile.integration">
+<!--
+    Copyright 2019 Adobe. All rights reserved.
+    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License. You may obtain a copy
+    of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-</manifest>
+    Unless required by applicable law or agreed to in writing, software distributed under
+    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+    OF ANY KIND, either express or implied. See the License for the specific language
+    governing permissions and limitations under the License.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/code/lifecycle/src/main/AndroidManifest.xml
+++ b/code/lifecycle/src/main/AndroidManifest.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright 2019 Adobe. All rights reserved.
     This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -11,7 +12,8 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
-        <service android:name="com.adobe.marketing.mobile.ExtensionDiscoveryService">
+        <service android:name="com.adobe.marketing.mobile.ExtensionDiscoveryService"
+            android:exported="false">
             <meta-data
                 android:name="com.adobe.marketing.mobile.lifecycle.LifecycleExtension"
                 android:value="Extension" />

--- a/code/macrobenchmark/src/main/AndroidManifest.xml
+++ b/code/macrobenchmark/src/main/AndroidManifest.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<!--
+    Copyright 2019 Adobe. All rights reserved.
+    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License. You may obtain a copy
+    of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+    Unless required by applicable law or agreed to in writing, software distributed under
+    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+    OF ANY KIND, either express or implied. See the License for the specific language
+    governing permissions and limitations under the License.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <queries>
         <package android:name="com.adobe.marketing.mobile.app.kotlin" />
     </queries>

--- a/code/microbenchmark/src/androidTest/AndroidManifest.xml
+++ b/code/microbenchmark/src/androidTest/AndroidManifest.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2019 Adobe. All rights reserved.
+    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License. You may obtain a copy
+    of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under
+    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+    OF ANY KIND, either express or implied. See the License for the specific language
+    governing permissions and limitations under the License.
+-->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 

--- a/code/microbenchmark/src/main/AndroidManifest.xml
+++ b/code/microbenchmark/src/main/AndroidManifest.xml
@@ -1,2 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest />
+<!--
+    Copyright 2019 Adobe. All rights reserved.
+    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License. You may obtain a copy
+    of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under
+    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+    OF ANY KIND, either express or implied. See the License for the specific language
+    governing permissions and limitations under the License.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/code/signal/src/main/AndroidManifest.xml
+++ b/code/signal/src/main/AndroidManifest.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright 2019 Adobe. All rights reserved.
     This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -11,7 +12,8 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
-        <service android:name="com.adobe.marketing.mobile.ExtensionDiscoveryService">
+        <service android:name="com.adobe.marketing.mobile.ExtensionDiscoveryService"
+            android:exported="false">
             <meta-data
                 android:name="com.adobe.marketing.mobile.signal.internal.SignalExtension"
                 android:value="Extension" />

--- a/code/test-third-party-extension/src/main/AndroidManifest.xml
+++ b/code/test-third-party-extension/src/main/AndroidManifest.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright 2019 Adobe. All rights reserved.
     This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -11,7 +12,8 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
-        <service android:name="com.adobe.marketing.mobile.ExtensionDiscoveryService">
+        <service android:name="com.adobe.marketing.mobile.ExtensionDiscoveryService"
+            android:exported="false">
             <meta-data
                 android:name="com.example.victory.VictoryExtension"
                 android:value="Extension" />

--- a/code/testapp/src/main/AndroidManifest.xml
+++ b/code/testapp/src/main/AndroidManifest.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2019 Adobe. All rights reserved.
+    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License. You may obtain a copy
+    of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under
+    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+    OF ANY KIND, either express or implied. See the License for the specific language
+    governing permissions and limitations under the License.
+-->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 

--- a/code/testutils/src/main/AndroidManifest.xml
+++ b/code/testutils/src/main/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <!--
-
     Copyright 2023 Adobe. All rights reserved.
     This file is licensed to you under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License. You may obtain a copy
@@ -11,9 +9,5 @@
     the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
     OF ANY KIND, either express or implied. See the License for the specific language
     governing permissions and limitations under the License.
-
 -->
-
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />


### PR DESCRIPTION
- Set android:exported=false for the `ExtensionDiscovery` service.
- Add license headers.







