### PR TITLE
Allow disabling timeout when registering response listener

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@ assemble-phone: core-assemble-phone signal-assemble-phone lifecycle-assemble-pho
 
 assemble-phone-release: core-assemble-phone-release signal-assemble-phone-release lifecycle-assemble-phone-release identity-assemble-phone-release
 
-unit-test: core-unit-test signal-unit-test lifecycle-unit-test testutils-unit-test
+unit-test: core-unit-test signal-unit-test lifecycle-unit-test identity-unit-test testutils-unit-test
 
-unit-test-coverage: core-unit-test-coverage signal-unit-test-coverage lifecycle-unit-test-coverage testutils-unit-test-coverage
+unit-test-coverage: core-unit-test-coverage signal-unit-test-coverage lifecycle-unit-test-coverage identity-unit-test-coverage testutils-unit-test-coverage
 
 functional-test: core-functional-test signal-functional-test lifecycle-functional-test identity-functional-test
 

--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/eventhub/EventHub.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/eventhub/EventHub.kt
@@ -378,10 +378,12 @@ internal class EventHub {
     }
 
     /**
-     * Registers an event listener which will be invoked when the response event to trigger event is dispatched
-     * @param triggerEvent An [Event] which will trigger a response event
-     * @param timeoutMS A timeout in milliseconds, if the response listener is not invoked within the timeout, then the `EventHub` invokes the fail method.
-     * @param listener An [AdobeCallbackWithError] which will be invoked whenever the `EventHub` receives the response event for trigger event
+     * Registers an event listener that will be invoked when the response event corresponding to the trigger event is dispatched.
+     * If the response listener is not invoked within the specified timeout, the `EventHub` triggers the fail method.
+     *
+     * @param triggerEvent An [Event] that triggers the response event.
+     * @param timeoutMS A timeout in milliseconds. Use `Long.MAX_DURATION` to wait indefinitely without triggering a timeout.
+     * @param listener An [AdobeCallbackWithError] that will be invoked when the `EventHub` receives the response event for the trigger event.
      */
     fun registerResponseListener(
         triggerEvent: Event,

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
@@ -275,7 +275,8 @@ public final class MobileCore {
      * event} processing timeout occurs.
      *
      * @param event the {@link Event} to be dispatched, used as a trigger. It should not be null.
-     * @param timeoutMS the timeout specified in milliseconds.
+     * @param timeoutMS the timeout specified in milliseconds. Use Long.MAX_DURATION to wait
+     *     indefinitely without triggering a timeout.
      * @param responseCallback the callback whose {@link AdobeCallbackWithError#call(Object)} will
      *     be called when the response event is heard. It should not be null.
      */

--- a/code/core/src/test/java/com/adobe/marketing/mobile/internal/eventhub/EventHubTests.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/internal/eventhub/EventHubTests.kt
@@ -1848,6 +1848,28 @@ internal class EventHubTests {
     }
 
     @Test
+    fun testResponseListener_InfiniteTimeout() {
+        val testEvent = Event.Builder("Test event", eventType, eventSource).build()
+        val responseCallback = object : AdobeCallbackWithError<Event> {
+            override fun call(value: Event?) {
+                assertTrue { false }
+            }
+
+            override fun fail(error: AdobeError?) {
+                assertTrue { false }
+            }
+        }
+
+        eventHub.registerResponseListener(testEvent, Long.MAX_VALUE, responseCallback)
+
+        Thread.sleep(100)
+
+        val responseListener = eventHub.responseEventListeners.first { it.triggerEventId == testEvent.uniqueIdentifier }
+        assertNotNull(responseListener)
+        assertNull(responseListener.timeoutTask)
+    }
+
+    @Test
     fun testListener_LongRunningListenerShouldNotBlockOthers() {
         class Extension1(api: ExtensionApi) : Extension(api) {
             override fun getName(): String {


### PR DESCRIPTION
Some extensions don't want the request listener to time out when they call the API. They can achieve this by setting a large timeout. This is just a minor optimization to prevent adding additional timeout tasks for such listeners.