### PR TITLE
Fix ordered search type lookup in event history

### DIFF
--- a/code/core/src/androidTest/java/com/adobe/marketing/mobile/internal/eventhub/history/AndroidEventHistoryTests.kt
+++ b/code/core/src/androidTest/java/com/adobe/marketing/mobile/internal/eventhub/history/AndroidEventHistoryTests.kt
@@ -88,6 +88,25 @@ class AndroidEventHistoryTests {
     }
 
     @Test
+    fun testGetEventsWithEnforceOrderWithMultipleIdenticalEvents() {
+        val data = mapOf("key" to "value")
+        assertTrue(record(data, 5000))
+
+        val data1 = mapOf("key1" to "value1")
+        assertTrue(record(data1, 10000))
+
+        assertTrue(record(data, 20000))
+
+        val requests = arrayOf(
+            EventHistoryRequest(data, 0, 0),
+            EventHistoryRequest(data1, 0, System.currentTimeMillis())
+        )
+
+        // if enforceOrder == true, 1 denotes success satisfying all event history requests
+        assertEquals(1, query(requests, true))
+    }
+
+    @Test
     fun testGetEventsWithEnforceOrderOverlappingTimestamp() {
         val data = mapOf("key" to "value")
         assertTrue(record(data, 10000))

--- a/code/core/src/androidTest/java/com/adobe/marketing/mobile/internal/eventhub/history/AndroidEventHistoryTests.kt
+++ b/code/core/src/androidTest/java/com/adobe/marketing/mobile/internal/eventhub/history/AndroidEventHistoryTests.kt
@@ -88,22 +88,52 @@ class AndroidEventHistoryTests {
     }
 
     @Test
-    fun testGetEventsWithEnforceOrderWithMultipleIdenticalEvents() {
+    fun testGetEventsWithEnforceOrderSuccessWithMultipleIdenticalEvents() {
         val data = mapOf("key" to "value")
         assertTrue(record(data, 5000))
 
         val data1 = mapOf("key1" to "value1")
         assertTrue(record(data1, 10000))
 
+        val data2 = mapOf("key2" to "value2")
+        assertTrue(record(data2, 15000))
+
         assertTrue(record(data, 20000))
+
+        assertTrue(record(data, 30000))
 
         val requests = arrayOf(
             EventHistoryRequest(data, 0, 0),
-            EventHistoryRequest(data1, 0, System.currentTimeMillis())
+            EventHistoryRequest(data1, 0, 0),
+            EventHistoryRequest(data2, 0, 0)
         )
 
         // if enforceOrder == true, 1 denotes success satisfying all event history requests
         assertEquals(1, query(requests, true))
+    }
+
+    @Test
+    fun testGetEventsWithEnforceOrderFailureWithMultipleIdenticalEvents() {
+        val data = mapOf("key" to "value")
+        assertTrue(record(data, 5000))
+
+        val data1 = mapOf("key1" to "value1")
+        assertTrue(record(data1, 10000))
+
+        val data2 = mapOf("key2" to "value2")
+
+        assertTrue(record(data, 20000))
+
+        assertTrue(record(data, 30000))
+
+        val requests = arrayOf(
+            EventHistoryRequest(data, 0, 0),
+            EventHistoryRequest(data1, 0, 0),
+            EventHistoryRequest(data2, 0, 0)
+        )
+
+        // if enforceOrder == true, 0 denotes failure looking all event history requests
+        assertEquals(0, query(requests, true))
     }
 
     @Test

--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/eventhub/history/AndroidEventHistory.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/eventhub/history/AndroidEventHistory.kt
@@ -80,10 +80,10 @@ internal class AndroidEventHistory : EventHistory {
         executor.submit {
             var dbError = false
             var count = 0
-            var latestEventOccurrence: Long? = null
+            var previousEventOldestOccurrence: Long? = null
             eventHistoryRequests.forEachIndexed { index, request ->
                 val eventHash = request.maskAsDecimalHash
-                val adjustedFromDate = if (enforceOrder) request.adjustedFromDate(latestEventOccurrence) else request.fromDate
+                val adjustedFromDate = if (enforceOrder) request.adjustedFromDate(previousEventOldestOccurrence) else request.fromDate
                 val res = androidEventHistoryDatabase.query(eventHash, adjustedFromDate, request.adjustedToDate)
 
                 Log.debug(
@@ -108,8 +108,12 @@ internal class AndroidEventHistory : EventHistory {
                     return@forEachIndexed
                 }
 
-                latestEventOccurrence = res.newestTimeStamp
-                count += res.count
+                previousEventOldestOccurrence = res.oldestTimestamp
+                if (enforceOrder) {
+                    count++
+                } else {
+                    count += res.count
+                }
             }
 
             val result = when {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The current ordered event history lookup logic uses newest timestamp of the previous event as the from value to search the existence of next event in the events array, instead of the oldest timestamp. Content card disqualification will be using ordered event look up and is failing because of the incorrect implementation.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/adobe/aepsdk-core-android/pull/749

## Motivation and Context

The `historical` rule condition allows checking if a series of events occurred in a specific order in the SDK event history by providing the `searchType` as `ordered` . As per the spec, for `ordered` search type, "_Each provided event will be queried in order.  As long as the count of an event is greater than one, the subsequent event will be queried for using the oldest timestamp of the previous event.  If the end of the events array is reached and each event has been found, the evaluation returns one (1)._"

This was implemented correctly in the [Java version](https://github.com/adobe/aepsdk-core-android/blame/0856ec47cf01a3650e48e7c170dd96ba3e80c2bd/code/android-core-library/src/main/java/com/adobe/marketing/mobile/internal/eventhub/history/AndroidEventHistory.java#L77-L124). However, when it was migrated to [Kotlin](https://github.com/adobe/aepsdk-core-android/blob/main/code/core/src/main/java/com/adobe/marketing/mobile/internal/eventhub/history/AndroidEventHistory.kt#L75-L123), we ended up using the [newest timestamp](https://github.com/adobe/aepsdk-core-android/blob/main/code/core/src/main/java/com/adobe/marketing/mobile/internal/eventhub/history/AndroidEventHistory.kt#L111) of the previous event as the from timestamp for the subsequent event. So the lookup would fail for the following case: [A, B, C, A] since we look for existence of B & C after the second occurrence of A, which is incorrect.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added a test for ordered event history look up with multiple identical events

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
