### PR TITLE
[bug fix] race condition: some events are evaluated twice

### DIFF
--- a/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesEngine.java
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesEngine.java
@@ -110,7 +110,7 @@ public class LaunchRulesEngine {
             return event;
         }
 
-        if (!cachedEvents.isEmpty() && isProcessCachedRulesEvent(event)) {
+        if (!cachedEvents.isEmpty() && shouldProcessCachedEvents(event)) {
             reprocessCachedEvents();
         }
 
@@ -119,7 +119,7 @@ public class LaunchRulesEngine {
         return launchRulesConsequence.process(event, matchedRules);
     }
 
-    private boolean isProcessCachedRulesEvent(final Event event) {
+    private boolean shouldProcessCachedEvents(final Event event) {
         return EventType.RULES_ENGINE.equals(event.getType())
                 && EventSource.REQUEST_RESET.equals(event.getSource())
                 && name.equals(DataReader.optString(event.getEventData(), RULES_ENGINE_NAME, ""));

--- a/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesEngine.java
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesEngine.java
@@ -110,7 +110,7 @@ public class LaunchRulesEngine {
             return event;
         }
 
-        if (!cachedEvents.isEmpty() && isReevaluateRulesEvent(event)) {
+        if (!cachedEvents.isEmpty() && isProcessCachedRulesEvent(event)) {
             reprocessCachedEvents();
         }
 
@@ -119,7 +119,7 @@ public class LaunchRulesEngine {
         return launchRulesConsequence.process(event, matchedRules);
     }
 
-    private boolean isReevaluateRulesEvent(final Event event) {
+    private boolean isProcessCachedRulesEvent(final Event event) {
         return EventType.RULES_ENGINE.equals(event.getType())
                 && EventSource.REQUEST_RESET.equals(event.getSource())
                 && name.equals(DataReader.optString(event.getEventData(), RULES_ENGINE_NAME, ""));


### PR DESCRIPTION
Fixed an issue (https://github.com/adobe/aepsdk-core-android/issues/678) in `LaunchRulesEngine` that could lead to certain events being evaluated twice.
