### PR TITLE
Stop migrating Mobile Services datastore from v4 SDK

### DIFF
--- a/code/core/src/androidTest/java/com/adobe/marketing/mobile/internal/migration/V4MigratorTests.kt
+++ b/code/core/src/androidTest/java/com/adobe/marketing/mobile/internal/migration/V4MigratorTests.kt
@@ -56,7 +56,6 @@ class V4MigratorTests {
             V5.Target.DATASTORE_NAME,
             V5.Identity.DATASTORE_NAME,
             V5.Configuration.DATASTORE_NAME,
-            V5.MobileServices.DATASTORE_NAME,
             V5.Lifecycle.DATASTORE_NAME
         )
         stores.forEach {
@@ -227,52 +226,7 @@ class V4MigratorTests {
             .getNamedCollection(V5.Target.DATASTORE_NAME)
         Assert.assertEquals("tntid", v5Target.getString(V5.Target.TNT_ID, null))
         Assert.assertEquals("3rdpartyid", v5Target.getString(V5.Target.THIRD_PARTY_ID, null))
-        val v5MobileServices = ServiceProvider.getInstance()
-            .dataStoreService
-            .getNamedCollection(V5.MobileServices.DATASTORE_NAME)
-        Assert.assertEquals(
-            "utm_source",
-            v5MobileServices.getString(
-                V5.MobileServices.DEFAULTS_KEY_REFERRER_UTM_SOURCE,
-                null
-            )
-        )
-        Assert.assertEquals(
-            "utm_medium",
-            v5MobileServices.getString(
-                V5.MobileServices.DEFAULTS_KEY_REFERRER_UTM_MEDIUM,
-                null
-            )
-        )
-        Assert.assertEquals(
-            "utm_term",
-            v5MobileServices.getString(V5.MobileServices.DEFAULTS_KEY_REFERRER_UTM_TERM, null)
-        )
-        Assert.assertEquals(
-            "utm_content",
-            v5MobileServices.getString(
-                V5.MobileServices.DEFAULTS_KEY_REFERRER_UTM_CONTENT,
-                null
-            )
-        )
-        Assert.assertEquals(
-            "utm_campaign",
-            v5MobileServices.getString(
-                V5.MobileServices.DEFAULTS_KEY_REFERRER_UTM_CAMPAIGN,
-                null
-            )
-        )
-        Assert.assertEquals(
-            "trackingcode",
-            v5MobileServices.getString(
-                V5.MobileServices.DEFAULTS_KEY_REFERRER_TRACKINGCODE,
-                null
-            )
-        )
-        Assert.assertEquals(
-            "blacklist",
-            v5MobileServices.getString(V5.MobileServices.SHARED_PREFERENCES_BLACK_LIST, null)
-        )
+
         val v5Configuration = ServiceProvider.getInstance()
             .dataStoreService
             .getNamedCollection(V5.Configuration.DATASTORE_NAME)

--- a/code/core/src/androidTest/java/com/adobe/marketing/mobile/internal/migration/V5LegacyCleanerTests.kt
+++ b/code/core/src/androidTest/java/com/adobe/marketing/mobile/internal/migration/V5LegacyCleanerTests.kt
@@ -1,0 +1,73 @@
+/*
+  Copyright 2025 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.internal.migration
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.adobe.marketing.mobile.internal.migration.MigrationConstants.V5
+import com.adobe.marketing.mobile.services.MockAppContextService
+import com.adobe.marketing.mobile.services.ServiceProvider
+import com.adobe.marketing.mobile.services.ServiceProviderModifier
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class V5LegacyCleanerTests {
+
+    @Before
+    fun setup() {
+        // Set up application context service
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val mockAppContextService = MockAppContextService().apply {
+            appContext = context
+        }
+        ServiceProviderModifier.setAppContextService(mockAppContextService)
+
+        // Clear any existing data
+        ServiceProvider.getInstance().dataStoreService.getNamedCollection(V5.MobileServices.DATASTORE_NAME)?.removeAll()
+    }
+
+    @After
+    fun tearDown() {
+        // Clean up test data
+        ServiceProvider.getInstance().dataStoreService.getNamedCollection(V5.MobileServices.DATASTORE_NAME)?.removeAll()
+    }
+
+    @Test
+    fun testCleanup_RemovesDataFromMobileServicesDataStore() {
+        // Setup - add some test data
+        val dataStore = ServiceProvider.getInstance().dataStoreService.getNamedCollection(V5.MobileServices.DATASTORE_NAME)
+        dataStore?.setString("testKey", "testValue")
+
+        // Verify data was set
+        Assert.assertEquals("testValue", dataStore?.getString("testKey", null))
+
+        // Test - invoke the cleanup method
+        V5LegacyCleaner.cleanup()
+
+        // Verify - data was removed
+        Assert.assertNull(dataStore?.getString("testKey", null))
+    }
+
+    @Test
+    fun testCleanup_HandlesEmptyDataStore() {
+        // Setup - ensure data store is empty
+        val dataStore = ServiceProvider.getInstance().dataStoreService.getNamedCollection(V5.MobileServices.DATASTORE_NAME)
+        dataStore?.removeAll()
+
+        // Test - invoke the cleanup method
+        V5LegacyCleaner.cleanup()
+
+        // Verify - no exceptions thrown
+    }
+}

--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/migration/MigrationConstants.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/migration/MigrationConstants.kt
@@ -136,15 +136,6 @@ internal object MigrationConstants {
 
         object MobileServices {
             const val DATASTORE_NAME = "ADBMobileServices"
-            const val DEFAULTS_KEY_INSTALLDATE = "ADMS_Legacy_InstallDate"
-            const val REFERRER_DATA_JSON_STRING = "ADMS_Referrer_ContextData_Json_String"
-            const val SHARED_PREFERENCES_BLACK_LIST = "messagesBlackList"
-            const val DEFAULTS_KEY_REFERRER_UTM_SOURCE = "utm_source"
-            const val DEFAULTS_KEY_REFERRER_UTM_MEDIUM = "utm_medium"
-            const val DEFAULTS_KEY_REFERRER_UTM_TERM = "utm_term"
-            const val DEFAULTS_KEY_REFERRER_UTM_CONTENT = "utm_content"
-            const val DEFAULTS_KEY_REFERRER_UTM_CAMPAIGN = "utm_campaign"
-            const val DEFAULTS_KEY_REFERRER_TRACKINGCODE = "trackingcode"
         }
 
         object Identity {

--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/migration/V4Migrator.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/migration/V4Migrator.kt
@@ -102,50 +102,7 @@ internal class V4Migrator {
     private fun migrateLocalStorage() {
         val v4DataStore = v4SharedPreferences ?: return
         val v4DataStoreEditor = v4DataStore.edit()
-
-        // mobile services
-        val mobileServicesV5DataStore =
-            ServiceProvider.getInstance().dataStoreService.getNamedCollection(V5.MobileServices.DATASTORE_NAME)
         val installDateMillis = v4DataStore.getLong(V4.Lifecycle.INSTALL_DATE, 0L)
-        if (installDateMillis > 0) {
-            // convert milliseconds to seconds as it is handled in v5
-            mobileServicesV5DataStore.setLong(
-                V5.MobileServices.DEFAULTS_KEY_INSTALLDATE,
-                convertMsToSec(installDateMillis)
-            )
-        }
-        mobileServicesV5DataStore.setString(
-            V5.MobileServices.REFERRER_DATA_JSON_STRING,
-            v4DataStore.getString(V4.Acquisition.REFERRER_DATA, null)
-        )
-        mobileServicesV5DataStore.setString(
-            V5.MobileServices.DEFAULTS_KEY_REFERRER_UTM_SOURCE,
-            v4DataStore.getString(V4.Acquisition.DEFAULTS_KEY_REFERRER_UTM_SOURCE, null)
-        )
-        mobileServicesV5DataStore.setString(
-            V5.MobileServices.DEFAULTS_KEY_REFERRER_UTM_MEDIUM,
-            v4DataStore.getString(V4.Acquisition.DEFAULTS_KEY_REFERRER_UTM_MEDIUM, null)
-        )
-        mobileServicesV5DataStore.setString(
-            V5.MobileServices.DEFAULTS_KEY_REFERRER_UTM_TERM,
-            v4DataStore.getString(V4.Acquisition.DEFAULTS_KEY_REFERRER_UTM_TERM, null)
-        )
-        mobileServicesV5DataStore.setString(
-            V5.MobileServices.DEFAULTS_KEY_REFERRER_UTM_CONTENT,
-            v4DataStore.getString(V4.Acquisition.DEFAULTS_KEY_REFERRER_UTM_CONTENT, null)
-        )
-        mobileServicesV5DataStore.setString(
-            V5.MobileServices.DEFAULTS_KEY_REFERRER_UTM_CAMPAIGN,
-            v4DataStore.getString(V4.Acquisition.DEFAULTS_KEY_REFERRER_UTM_CAMPAIGN, null)
-        )
-        mobileServicesV5DataStore.setString(
-            V5.MobileServices.DEFAULTS_KEY_REFERRER_TRACKINGCODE,
-            v4DataStore.getString(V4.Acquisition.DEFAULTS_KEY_REFERRER_TRACKINGCODE, null)
-        )
-        mobileServicesV5DataStore.setString(
-            V5.MobileServices.SHARED_PREFERENCES_BLACK_LIST,
-            v4DataStore.getString(V4.Messages.SHARED_PREFERENCES_BLACK_LIST, null)
-        )
 
         // don't remove V4.Acquisition.REFERRER_DATA at here, it will be removed by the acquisition
         // extension

--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/migration/V5LegacyCleaner.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/migration/V5LegacyCleaner.kt
@@ -1,0 +1,25 @@
+/*
+  Copyright 2025 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.internal.migration
+
+import com.adobe.marketing.mobile.internal.migration.MigrationConstants.V5
+import com.adobe.marketing.mobile.services.ServiceProvider
+
+/**
+ * Cleans up the V5 legacy data.
+ */
+internal object V5LegacyCleaner {
+    fun cleanup() {
+        ServiceProvider.getInstance().dataStoreService.getNamedCollection(V5.MobileServices.DATASTORE_NAME)
+            ?.removeAll()
+    }
+}

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCoreInitializer.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCoreInitializer.kt
@@ -25,6 +25,7 @@ import com.adobe.marketing.mobile.internal.CoreConstants
 import com.adobe.marketing.mobile.internal.configuration.ConfigurationExtension
 import com.adobe.marketing.mobile.internal.eventhub.EventHub
 import com.adobe.marketing.mobile.internal.migration.V4Migrator
+import com.adobe.marketing.mobile.internal.migration.V5LegacyCleaner
 import com.adobe.marketing.mobile.services.Log
 import com.adobe.marketing.mobile.services.ServiceProvider
 import com.adobe.marketing.mobile.services.internal.context.App
@@ -166,6 +167,11 @@ internal class MobileCoreInitializer(
                     v4Migrator.migrate()
                 } catch (e: Exception) {
                     Log.error(CoreConstants.LOG_TAG, LOG_TAG, "Migration from V4 SDK failed with error - ${e.localizedMessage}")
+                }
+                try {
+                    V5LegacyCleaner.cleanup()
+                } catch (e: Exception) {
+                    Log.error(CoreConstants.LOG_TAG, LOG_TAG, "Unable to clean the V5 legacy data due to an error - ${e.localizedMessage}")
                 }
 
                 EventHub.shared.initializeEventHistory()


### PR DESCRIPTION
- A new `V5LegacyCleaner` class was added to clean up legacy V5 Mobile Services data
- Mobile Services data migration code was removed from `V4Migrator.kt`