### PR TITLE
Do not enable WebSQL for InAppMessage presentables

### DIFF
--- a/code/core/src/androidTest/java/com/adobe/marketing/mobile/services/ui/message/views/InAppMessagePresentableTests.kt
+++ b/code/core/src/androidTest/java/com/adobe/marketing/mobile/services/ui/message/views/InAppMessagePresentableTests.kt
@@ -1,0 +1,90 @@
+/*
+  Copyright 2025 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.services.ui.message.views
+
+import android.content.Context
+import android.webkit.WebSettings
+import android.webkit.WebView
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.adobe.marketing.mobile.services.ui.InAppMessage
+import com.adobe.marketing.mobile.services.ui.PresentationDelegate
+import com.adobe.marketing.mobile.services.ui.PresentationUtilityProvider
+import com.adobe.marketing.mobile.services.ui.common.AppLifecycleProvider
+import com.adobe.marketing.mobile.services.ui.message.InAppMessagePresentable
+import com.adobe.marketing.mobile.services.ui.message.InAppMessageSettings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.anyBoolean
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import java.nio.charset.StandardCharsets
+
+/**
+ * Pseudo-unit tests for [InAppMessagePresentable] that rely on mocking Android framework
+ * components.
+ * See also [InAppMessagePresentableTest] for unit tests that do not rely on Android framework
+ */
+@RunWith(AndroidJUnit4::class)
+internal class InAppMessagePresentableTests {
+
+    @Mock
+    private lateinit var mockInAppMessage: InAppMessage
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        `when`(mockInAppMessage.settings).thenReturn(InAppMessageSettings.Builder().build())
+    }
+
+    @Test
+    fun testInAppMessagePresentableDefaultWebViewSettings() {
+        // setup
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val presentationDelegate = mock(PresentationDelegate::class.java)
+        val presentationUtilityProvider = mock(PresentationUtilityProvider::class.java)
+        val appLifecycleProvider = mock(AppLifecycleProvider::class.java)
+        val mainScope = CoroutineScope(Dispatchers.Main)
+
+        // Create a mock WebView
+        val webView = mock(WebView::class.java)
+        val webSettings = mock(WebSettings::class.java)
+        `when`(webView.settings).thenReturn(webSettings)
+
+        // Create an instance of InAppMessagePresentable
+        val presentable = InAppMessagePresentable(
+            inAppMessage = mockInAppMessage,
+            presentationDelegate = presentationDelegate,
+            presentationUtilityProvider = presentationUtilityProvider,
+            appLifecycleProvider = appLifecycleProvider,
+            mainScope = mainScope
+        )
+
+        presentable.applyWebViewSettings(webView)
+
+        // Verify that the default settings were applied to the WebView
+        verify(webSettings).javaScriptEnabled = true
+        verify(webSettings).allowFileAccess = false
+        verify(webSettings).domStorageEnabled = true
+        verify(webSettings).layoutAlgorithm = WebSettings.LayoutAlgorithm.NORMAL
+        verify(webSettings).defaultTextEncodingName = StandardCharsets.UTF_8.name()
+        verify(webSettings).mediaPlaybackRequiresUserGesture = false
+        verify(webSettings, times(0)).databaseEnabled = anyBoolean()
+    }
+}

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/InAppMessagePresentable.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/InAppMessagePresentable.kt
@@ -141,7 +141,8 @@ internal class InAppMessagePresentable(
      * @param webView the webview to apply the settings to
      * @return the webview with the settings applied
      */
-    private fun applyWebViewSettings(webView: WebView): WebView {
+    @VisibleForTesting
+    internal fun applyWebViewSettings(webView: WebView): WebView {
         webView.settings.apply {
             // base settings
             javaScriptEnabled = true
@@ -150,7 +151,6 @@ internal class InAppMessagePresentable(
             layoutAlgorithm = WebSettings.LayoutAlgorithm.NORMAL
             defaultTextEncodingName = StandardCharsets.UTF_8.name()
             mediaPlaybackRequiresUserGesture = false
-            databaseEnabled = true
         }
 
         webView.apply {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
`setDatabaseEnabled` api has been deprecated recently in API 35. This method is automatically treated as no-op on all Android versions since being removed Chromium 119. Also, the in-app message HTML templates provided out of the box for in AJO UI do not use WebSQL. If the customer does not WebSQL in their webpages, this should not affect them. Additionally this technology is not supported since 2010.
Remove this flag and add a test to validate current default settings applied to in-app webviews.
<!--- Describe your changes in detail -->

## Related Issue
MOB-23386

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
`setDatabaseEnabled` api has been deprecated recently in API 35. This method is automatically treated as no-op on all Android versions since being removed Chromium 119. Also, the in-app message HTML templates provided out of the box for in AJO UI do not use WebSQL. If the customer does not WebSQL in their webpages, this should not affect them. Additionally this technology is not supported since 2010.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Manual tests to verify in-app message rendering.
- New instrumentation test for validating setting
- Existing instrumentation tests for IAM.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
