### PR TITLE
Dispatch consequence in an rules consequence event if schema type is not eventHistory

### DIFF
--- a/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesConsequence.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesConsequence.kt
@@ -405,11 +405,14 @@ internal class LaunchRulesConsequence(
         if (consequence.schema == CONSEQUENCE_SCHEMA_EVENT_HISTORY) {
             processEventHistoryOperation(consequence, parentEvent)
         } else {
-            Log.warning(
+            val consequenceEvent =
+                generateConsequenceEvent(consequence, parentEvent)
+            Log.trace(
                 LaunchRulesEngineConstants.LOG_TAG,
                 logTag,
-                "Unable to process Schema Consequence for consequence ${consequence.id}, unsupported schema type ${consequence.schema}"
+                "evaluateRulesConsequence - Dispatching consequence event ${consequenceEvent.uniqueIdentifier}"
             )
+            extensionApi.dispatch(consequenceEvent)
         }
     }
 

--- a/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesConsequenceTests.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesConsequenceTests.kt
@@ -1320,7 +1320,7 @@ class LaunchRulesConsequenceTests {
     }
 
     @Test
-    fun `Test Schema Event History Insert Operation When detail schema Is Empty`() {
+    fun `Test Schema When detail schema Is Empty`() {
         // Given: a launch rule with an invalid event history operation
         //    ---------- schema event rule ----------
         //        "detail": {
@@ -1346,13 +1346,16 @@ class LaunchRulesConsequenceTests {
         val matchedRules = rulesEngine.evaluate(LaunchTokenFinder(event, extensionApi))
         launchRulesConsequence.process(event, matchedRules)
 
-        // Then: Event should not be recorded or dispatched
+        // Then: Event should not be recorded but consequence should be dispatched
         verify(extensionApi, never()).recordHistoricalEvent(any(), any())
-        verify(extensionApi, never()).dispatch(any())
+        val dispatchedConsequenceEventCaptor = ArgumentCaptor.forClass(Event::class.java)
+        verify(extensionApi, times(1)).dispatch(dispatchedConsequenceEventCaptor.capture())
+        val dispatchedEventConsequence = dispatchedConsequenceEventCaptor.value.eventData["triggeredconsequence"] as Map<String, Any?>?
+        assertEquals(dispatchedEventConsequence?.get("detail"), matchedRules[0].consequenceList[0].detail)
     }
 
     @Test
-    fun `Test Schema Event History Insert Operation When detail schema Is Invalid`() {
+    fun `Test Schema Event History Insert Operation When detail schema Is not eventHistoryOperation`() {
         // Given: a launch rule with an invalid event history operation
         //    ---------- schema event rule ----------
         //        "detail": {
@@ -1366,7 +1369,7 @@ class LaunchRulesConsequenceTests {
         //          }
         //        }
         //    --------------------------------------
-        resetRulesEngine("rules_module_tests/consequence_rules_testSchemaInvalidDetailSchema.json")
+        resetRulesEngine("rules_module_tests/consequence_rules_testSchemaInAppDetailSchema.json")
 
         val event = Event.Builder(
             "Test Event",
@@ -1378,9 +1381,12 @@ class LaunchRulesConsequenceTests {
         val matchedRules = rulesEngine.evaluate(LaunchTokenFinder(event, extensionApi))
         launchRulesConsequence.process(event, matchedRules)
 
-        // Then: Event should not be recorded or dispatched
+        // Then: Event should not be recorded or dispatched but consequence should be dispatched
         verify(extensionApi, never()).recordHistoricalEvent(any(), any())
-        verify(extensionApi, never()).dispatch(any())
+        val dispatchedConsequenceEventCaptor = ArgumentCaptor.forClass(Event::class.java)
+        verify(extensionApi, times(1)).dispatch(dispatchedConsequenceEventCaptor.capture())
+        val dispatchedEventConsequence = dispatchedConsequenceEventCaptor.value.eventData["triggeredconsequence"] as Map<String, Any?>?
+        assertEquals(dispatchedEventConsequence?.get("detail"), matchedRules[0].consequenceList[0].detail)
     }
 
     @Test

--- a/code/core/src/test/resources/rules_module_tests/consequence_rules_testSchemaInAppDetailSchema.json
+++ b/code/core/src/test/resources/rules_module_tests/consequence_rules_testSchemaInAppDetailSchema.json
@@ -26,7 +26,7 @@
           "type": "schema",
           "detail": {
             "id": "test-id",
-            "schema": "https://ns.adobe.com/personalization/invalidSchema",
+            "schema": "https://ns.adobe.com/personalization/message/in-app",
             "data": {
               "operation": "insert",
               "content": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Restore existing behavior of dispatching consequence in a rules response content event for `schema` type if the `detail` is not of type `https://ns.adobe.com/personalization/eventHistoryOperation`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
For non event history write cases, we still need to dispatch the consequence so Messaging SDK can use it to display in-app message or content card

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
