### PR TITLE
Rules : Fix logical operation for negative matchers with multiple values #1147

### DIFF
--- a/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/json/MatcherCondition.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/json/MatcherCondition.kt
@@ -43,7 +43,7 @@ internal class MatcherCondition(private val definition: JSONDefinition) : JSONCo
             "ex" to "exists",
             "nx" to "notExist"
         )
-        
+
         // Negative matchers that should use AND logic for multiple values
         private val NEGATIVE_MATCHERS = setOf("ne", "nc")
     }

--- a/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesEngineModuleTests.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesEngineModuleTests.kt
@@ -437,7 +437,7 @@ class LaunchRulesEngineModuleTests {
     }
 
     @Test
-    fun `Test matcher condition multiple Values (ne) - negative ` () {
+    fun `Test matcher condition multiple Values (ne) - negative `() {
         val json = readTestResources("rules_module_tests/rules_testMatcherNe_multipleValues.json")
         assertNotNull(json)
         val rules = JSONRulesParser.parse(json, extensionApi)
@@ -458,7 +458,7 @@ class LaunchRulesEngineModuleTests {
     }
 
     @Test
-    fun `Test matcher condition multiple Values (ne) - positive ` () {
+    fun `Test matcher condition multiple Values (ne) - positive `() {
         val json = readTestResources("rules_module_tests/rules_testMatcherNe_multipleValues.json")
         assertNotNull(json)
         val rules = JSONRulesParser.parse(json, extensionApi)
@@ -767,7 +767,7 @@ class LaunchRulesEngineModuleTests {
     }
 
     @Test
-    fun `Test matcher condition multiple Values (nc) - negative ` () {
+    fun `Test matcher condition multiple Values (nc) - negative `() {
         val json = readTestResources("rules_module_tests/rules_testMatcherNc_multipleValues.json")
         assertNotNull(json)
         val rules = JSONRulesParser.parse(json, extensionApi)
@@ -788,7 +788,7 @@ class LaunchRulesEngineModuleTests {
     }
 
     @Test
-    fun `Test matcher condition multiple Values (nc) - positive ` () {
+    fun `Test matcher condition multiple Values (nc) - positive `() {
         val json = readTestResources("rules_module_tests/rules_testMatcherNc_multipleValues.json")
         assertNotNull(json)
         val rules = JSONRulesParser.parse(json, extensionApi)

--- a/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesEngineModuleTests.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesEngineModuleTests.kt
@@ -437,6 +437,50 @@ class LaunchRulesEngineModuleTests {
     }
 
     @Test
+    fun `Test matcher condition multiple Values (ne) - negative ` () {
+        val json = readTestResources("rules_module_tests/rules_testMatcherNe_multipleValues.json")
+        assertNotNull(json)
+        val rules = JSONRulesParser.parse(json, extensionApi)
+        assertNotNull(rules)
+        launchRulesEngine.replaceRules(rules)
+        Mockito.`when`(extensionApi.getSharedState(anyString(), any(), Mockito.anyBoolean(), any()))
+            .thenReturn(
+                SharedStateResult(
+                    SharedStateStatus.SET,
+                    mapOf(
+                        "lifecyclecontextdata" to mapOf(
+                            "carriername" to "AT&T"
+                        )
+                    )
+                )
+            )
+        assertEquals(0, launchRulesEngine.evaluateEvent(defaultEvent).size)
+    }
+
+    @Test
+    fun `Test matcher condition multiple Values (ne) - positive ` () {
+        val json = readTestResources("rules_module_tests/rules_testMatcherNe_multipleValues.json")
+        assertNotNull(json)
+        val rules = JSONRulesParser.parse(json, extensionApi)
+        assertNotNull(rules)
+        launchRulesEngine.replaceRules(rules)
+        Mockito.`when`(extensionApi.getSharedState(anyString(), any(), Mockito.anyBoolean(), any()))
+            .thenReturn(
+                SharedStateResult(
+                    SharedStateStatus.SET,
+                    mapOf(
+                        "lifecyclecontextdata" to mapOf(
+                            "carriername" to "T-Mobile"
+                        )
+                    )
+                )
+            )
+        val matchedConsequences = launchRulesEngine.evaluateEvent(defaultEvent)
+        assertEquals(1, matchedConsequences.size)
+        assertEquals("pb", matchedConsequences[0].type)
+    }
+
+    @Test
     fun `Test matcher condition (nx) - negative `() {
         val json = readTestResources("rules_module_tests/rules_testMatcherNx.json")
         assertNotNull(json)
@@ -720,5 +764,49 @@ class LaunchRulesEngineModuleTests {
         launchRulesEngine.replaceRules(null)
         Mockito.verifyNoInteractions(extensionApi)
         assertEquals(10, launchRulesEngine.cachedEventCount)
+    }
+
+    @Test
+    fun `Test matcher condition multiple Values (nc) - negative ` () {
+        val json = readTestResources("rules_module_tests/rules_testMatcherNc_multipleValues.json")
+        assertNotNull(json)
+        val rules = JSONRulesParser.parse(json, extensionApi)
+        assertNotNull(rules)
+        launchRulesEngine.replaceRules(rules)
+        Mockito.`when`(extensionApi.getSharedState(anyString(), any(), Mockito.anyBoolean(), any()))
+            .thenReturn(
+                SharedStateResult(
+                    SharedStateStatus.SET,
+                    mapOf(
+                        "lifecyclecontextdata" to mapOf(
+                            "carriername" to "AT&T"
+                        )
+                    )
+                )
+            )
+        assertEquals(0, launchRulesEngine.evaluateEvent(defaultEvent).size)
+    }
+
+    @Test
+    fun `Test matcher condition multiple Values (nc) - positive ` () {
+        val json = readTestResources("rules_module_tests/rules_testMatcherNc_multipleValues.json")
+        assertNotNull(json)
+        val rules = JSONRulesParser.parse(json, extensionApi)
+        assertNotNull(rules)
+        launchRulesEngine.replaceRules(rules)
+        Mockito.`when`(extensionApi.getSharedState(anyString(), any(), Mockito.anyBoolean(), any()))
+            .thenReturn(
+                SharedStateResult(
+                    SharedStateStatus.SET,
+                    mapOf(
+                        "lifecyclecontextdata" to mapOf(
+                            "carriername" to "T-Mobile"
+                        )
+                    )
+                )
+            )
+        val matchedConsequences = launchRulesEngine.evaluateEvent(defaultEvent)
+        assertEquals(1, matchedConsequences.size)
+        assertEquals("pb", matchedConsequences[0].type)
     }
 }

--- a/code/core/src/test/resources/rules_module_tests/rules_testMatcherNc_multipleValues.json
+++ b/code/core/src/test/resources/rules_module_tests/rules_testMatcherNc_multipleValues.json
@@ -1,0 +1,89 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "condition": {
+        "type": "group",
+        "definition": {
+          "logic": "and",
+          "conditions": [
+            {
+              "type": "group",
+              "definition": {
+                "logic": "or",
+                "conditions": [
+                  {
+                    "type": "group",
+                    "definition": {
+                      "logic": "and",
+                      "conditions": [
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~type",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventType.lifecycle"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~source",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventSource.responseContent"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "lifecyclecontextdata.launchevent",
+                            "matcher": "ex",
+                            "values": []
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": "group",
+              "definition": {
+                "logic": "and",
+                "conditions": [
+                  {
+                    "type": "matcher",
+                    "definition": {
+                      "key": "~state.com.adobe.module.lifecycle/lifecyclecontextdata.carriername",
+                      "matcher": "nc",
+                      "values": [
+                        "AT",
+                        "Veri",
+                        "Cricket"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "consequences": [
+        {
+          "id": "RCc223ec648df44fbbaab737e6cc6da50e",
+          "type": "pb",
+          "detail": {
+            "timeout": 0,
+            "templateurl": "http://www.adobe.com"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/code/core/src/test/resources/rules_module_tests/rules_testMatcherNe_multipleValues.json
+++ b/code/core/src/test/resources/rules_module_tests/rules_testMatcherNe_multipleValues.json
@@ -1,0 +1,89 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "condition": {
+        "type": "group",
+        "definition": {
+          "logic": "and",
+          "conditions": [
+            {
+              "type": "group",
+              "definition": {
+                "logic": "or",
+                "conditions": [
+                  {
+                    "type": "group",
+                    "definition": {
+                      "logic": "and",
+                      "conditions": [
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~type",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventType.lifecycle"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "~source",
+                            "matcher": "eq",
+                            "values": [
+                              "com.adobe.eventSource.responseContent"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "matcher",
+                          "definition": {
+                            "key": "lifecyclecontextdata.launchevent",
+                            "matcher": "ex",
+                            "values": []
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": "group",
+              "definition": {
+                "logic": "and",
+                "conditions": [
+                  {
+                    "type": "matcher",
+                    "definition": {
+                      "key": "~state.com.adobe.module.lifecycle/lifecyclecontextdata.carriername",
+                      "matcher": "ne",
+                      "values": [
+                        "AT&T",
+                        "Verizon",
+                        "Cricket"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "consequences": [
+        {
+          "id": "RC2500e6b0140744d49e6fd503a55a66d4",
+          "type": "pb",
+          "detail": {
+            "timeout": 0,
+            "templateurl": "http://www.adobe.com"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### **Problem**
 When processing multiple values, the rules engine used OR logic for all matchers , which creates a logical flaw for negative 
conditions. For example 
```
carriername != "AT&T" OR  carriername != "Verizon" OR carriername != "Cricket"
```

```
                                    {
                                      "definition": {
                                          "type": "matcher",
                                          "matcher": "ne",
                                          "key": "xdm.carriername"
                                          "values": [
                                              "AT&T",
                                              "Verizon",
                                             "Cricket"
                                           ],
                                       },
                                    },
```


This is always true for negative matchers! If carriername = "AT&T", the condition carriername != "Verizon" makes the entire OR expression true, causing incorrect rule firing.



###  **Impact**
This was causing rules to fire when they shouldn't. (Customer issue : IAM was fired too often)


### **Solution**
Modified JSONRulesParser.swift to use AND logic for negative matchers like notContains (nc) and notExists (ne).

Correct evaluation
```
carriername != "AT&T" AND carriername != "Verizon" AND carriername != "Cricket"
```
