### PR TITLE
Update `RuleConsequence` `detail` to be non-optional

### DIFF
--- a/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesConsequence.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesConsequence.kt
@@ -195,12 +195,9 @@ internal class LaunchRulesConsequence(
     }
 
     private fun replaceToken(
-        detail: Map<String, Any?>?,
+        detail: Map<String, Any?>,
         tokenFinder: TokenFinder
-    ): Map<String, Any?>? {
-        if (detail.isNullOrEmpty()) {
-            return null
-        }
+    ): Map<String, Any?> {
         val mutableDetail = detail.toMutableMap()
         for ((key, value) in detail) {
             mutableDetail[key] = replaceToken(value, tokenFinder)
@@ -566,22 +563,22 @@ internal class LaunchRulesConsequence(
 
 // Extend RuleConsequence with helper methods for processing consequence events.
 private val RuleConsequence.eventData: Map<*, *>?
-    get() = detail?.get("eventdata") as? Map<*, *>
+    get() = detail["eventdata"] as? Map<*, *>
 
 private val RuleConsequence.eventSource: String?
-    get() = detail?.get("source") as? String
+    get() = detail["source"] as? String
 
 private val RuleConsequence.eventType: String?
-    get() = detail?.get("type") as? String
+    get() = detail["type"] as? String
 
 private val RuleConsequence.eventDataAction: String?
-    get() = detail?.get("eventdataaction") as? String
+    get() = detail["eventdataaction"] as? String
 
 private val RuleConsequence.detailId: String?
-    get() = detail?.get("id") as? String
+    get() = detail["id"] as? String
 
 private val RuleConsequence.schema: String?
-    get() = detail?.get("schema") as? String
+    get() = detail["schema"] as? String
 
 private val RuleConsequence.detailData: Map<String, Any>?
     get() = DataReader.optTypedMap(Any::class.java, detail, "data", null)

--- a/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/RuleConsequence.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/RuleConsequence.kt
@@ -23,5 +23,5 @@ package com.adobe.marketing.mobile.launch.rulesengine
 data class RuleConsequence(
     val id: String,
     val type: String,
-    val detail: Map<String, Any?>?
+    val detail: Map<String, Any?>
 )

--- a/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/json/JSONConsequence.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/json/JSONConsequence.kt
@@ -11,8 +11,10 @@
 
 package com.adobe.marketing.mobile.launch.rulesengine.json
 
+import com.adobe.marketing.mobile.internal.CoreConstants
 import com.adobe.marketing.mobile.internal.util.toMap
 import com.adobe.marketing.mobile.launch.rulesengine.RuleConsequence
+import com.adobe.marketing.mobile.services.Log
 import org.json.JSONObject
 
 /**
@@ -38,12 +40,28 @@ internal class JSONConsequence private constructor(
     }
 
     /**
-     * Converts itself to a [RuleConsequence] object
+     * Converts this object into a validated [RuleConsequence].
      *
-     * @return an object of [RuleConsequence]
+     * @return a valid [RuleConsequence] or `null` if any validation check fails
      */
     @JvmSynthetic
-    internal fun toRuleConsequence(): RuleConsequence {
-        return RuleConsequence(this.id, this.type, this.detail)
+    internal fun toRuleConsequence(): RuleConsequence? {
+        val LOG_SOURCE = "JSONConsequence"
+        if (id.isEmpty()) {
+            Log.warning(CoreConstants.LOG_TAG, LOG_SOURCE, "Unable to find required field \"id\" in rules consequence.")
+            return null
+        }
+
+        if (type.isEmpty()) {
+            Log.warning(CoreConstants.LOG_TAG, LOG_SOURCE, "Unable to find required field \"type\" in rules consequence.")
+            return null
+        }
+
+        if (detail.isNullOrEmpty()) {
+            Log.warning(CoreConstants.LOG_TAG, LOG_SOURCE, "Unable to find required field \"detail\" in rules consequence.")
+            return null
+        }
+
+        return RuleConsequence(id, type, detail)
     }
 }

--- a/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesEngineModuleTests.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesEngineModuleTests.kt
@@ -873,7 +873,7 @@ class LaunchRulesEngineModuleTests {
         assertEquals(3, matchedConsequences.size)
         for (consequence in matchedConsequences) {
             assertEquals("ajoInbound", consequence.type)
-            assertEquals("ajoFeedItem", consequence.detail?.get("type"))
+            assertEquals("ajoFeedItem", consequence.detail["type"])
         }
     }
 

--- a/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/json/JSONConsequenceTests.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/json/JSONConsequenceTests.kt
@@ -15,6 +15,7 @@ import com.adobe.marketing.mobile.test.util.buildJSONObject
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class JSONConsequenceTests {
     @Test
@@ -44,10 +45,197 @@ class JSONConsequenceTests {
         val eventdata = consequence?.detail?.get("eventdata") as? Map<*, *>
         assertNotNull(eventdata)
         assertEquals(1, eventdata.size)
-        val attachedData = eventdata.get("attached_data") as? Map<*, *>
+        val attachedData = eventdata["attached_data"] as? Map<*, *>
         assertNotNull(attachedData)
         assertEquals(2, attachedData.size)
         assertEquals("value1", attachedData["key1"] as? String)
         assertEquals("{%~state.com.adobe.module.lifecycle/lifecyclecontextdata.launches%}", attachedData["launches"] as? String)
+    }
+
+    @Test
+    fun testToRuleConsequence_NullId_ReturnsNull() {
+        val jsonString = """
+        {
+          "id": null,
+          "type": "add",
+          "detail": {
+            "eventdata": {
+              "key": "value"
+            }
+          }
+        }
+        """
+        val jsonObject = buildJSONObject(jsonString)
+        val consequence = JSONConsequence(jsonObject)?.toRuleConsequence()
+        assertNull(consequence)
+    }
+
+    @Test
+    fun testToRuleConsequence_MissingId_ReturnsNull() {
+        val jsonString = """
+        {
+          "type": "add",
+          "detail": {
+            "eventdata": {
+              "key": "value"
+            }
+          }
+        }
+        """
+        val jsonObject = buildJSONObject(jsonString)
+        val consequence = JSONConsequence(jsonObject)?.toRuleConsequence()
+        assertNull(consequence)
+    }
+
+    @Test
+    fun testToRuleConsequence_EmptyId_ReturnsNull() {
+        val jsonString = """
+        {
+          "id": "",
+          "type": "add",
+          "detail": {
+            "eventdata": {
+              "key": "value"
+            }
+          }
+        }
+        """
+        val jsonObject = buildJSONObject(jsonString)
+        val consequence = JSONConsequence(jsonObject)?.toRuleConsequence()
+        assertNull(consequence)
+    }
+
+    @Test
+    fun testToRuleConsequence_NullType_ReturnsNull() {
+        val jsonString = """
+        {
+          "id": "valid-id",
+          "type": null,
+          "detail": {
+            "eventdata": {
+              "key": "value"
+            }
+          }
+        }
+        """
+        val jsonObject = buildJSONObject(jsonString)
+        val consequence = JSONConsequence(jsonObject)?.toRuleConsequence()
+        assertNull(consequence)
+    }
+
+    @Test
+    fun testToRuleConsequence_MissingType_ReturnsNull() {
+        val jsonString = """
+        {
+          "id": "valid-id",
+          "detail": {
+            "eventdata": {
+              "key": "value"
+            }
+          }
+        }
+        """
+        val jsonObject = buildJSONObject(jsonString)
+        val consequence = JSONConsequence(jsonObject)?.toRuleConsequence()
+        assertNull(consequence)
+    }
+
+    @Test
+    fun testToRuleConsequence_EmptyType_ReturnsNull() {
+        val jsonString = """
+        {
+          "id": "valid-id",
+          "type": "",
+          "detail": {
+            "eventdata": {
+              "key": "value"
+            }
+          }
+        }
+        """
+        val jsonObject = buildJSONObject(jsonString)
+        val consequence = JSONConsequence(jsonObject)?.toRuleConsequence()
+        assertNull(consequence)
+    }
+
+    @Test
+    fun testToRuleConsequence_NullDetail_ReturnsNull() {
+        val jsonString = """
+        {
+          "id": "valid-id",
+          "type": "add",
+          "detail": null
+        }
+        """
+        val jsonObject = buildJSONObject(jsonString)
+        val consequence = JSONConsequence(jsonObject)?.toRuleConsequence()
+        assertNull(consequence)
+    }
+
+    @Test
+    fun testToRuleConsequence_MissingDetail_ReturnsNull() {
+        val jsonString = """
+        {
+          "id": "valid-id",
+          "type": "add"
+        }
+        """
+        val jsonObject = buildJSONObject(jsonString)
+        val consequence = JSONConsequence(jsonObject)?.toRuleConsequence()
+        assertNull(consequence)
+    }
+
+    @Test
+    fun testToRuleConsequence_EmptyDetail_ReturnsNull() {
+        val jsonString = """
+        {
+          "id": "valid-id",
+          "type": "add",
+          "detail": {}
+        }
+        """
+        val jsonObject = buildJSONObject(jsonString)
+        val consequence = JSONConsequence(jsonObject)?.toRuleConsequence()
+        assertNull(consequence)
+    }
+
+    @Test
+    fun testToRuleConsequence_AllFieldsInvalid_ReturnsNull() {
+        val jsonString = """
+        {
+          "id": null,
+          "type": null,
+          "detail": null
+        }
+        """
+        val jsonObject = buildJSONObject(jsonString)
+        val consequence = JSONConsequence(jsonObject)?.toRuleConsequence()
+        assertNull(consequence)
+    }
+
+    @Test
+    fun testToRuleConsequence_ValidInputs_ReturnsRuleConsequence() {
+        val jsonString = """
+        {
+          "id": "test-consequence-id",
+          "type": "dispatch",
+          "detail": {
+            "type": "com.adobe.eventType.edge",
+            "source": "com.adobe.eventSource.requestContent",
+            "eventdataaction": "copy"
+          }
+        }
+        """
+        val jsonObject = buildJSONObject(jsonString)
+        val consequence = JSONConsequence(jsonObject)?.toRuleConsequence()
+
+        assertNotNull(consequence)
+        assertEquals("test-consequence-id", consequence.id)
+        assertEquals("dispatch", consequence.type)
+        assertNotNull(consequence.detail)
+        assertEquals(3, consequence.detail.size)
+        assertEquals("com.adobe.eventType.edge", consequence.detail["type"])
+        assertEquals("com.adobe.eventSource.requestContent", consequence.detail["source"])
+        assertEquals("copy", consequence.detail["eventdataaction"])
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR updates `RuleConsequence` `detail` to be a non-optional property. This is to: 
1. Re-align with the Java implementation before the Kotlin migration
    * Original Java implementation: https://github.com/adobe/aepsdk-core-android/blob/c012ca5e45d4f402bac14879ac62af02cd5529ab/code/android-core-library/src/main/java/com/adobe/marketing/mobile/RuleConsequence.java#L33-L75
    * PR implementing Kotlin version: 
        * https://github.com/adobe/aepsdk-core-android/pull/17
        * [JSONConsequence.kt](https://github.com/adobe/aepsdk-core-android/pull/17/files#diff-ab72670c6f6106e4d28836e44cb63486c6785ea88d4ae47cee79e4508eab144f)
        * [RuleConsequence.kt](https://github.com/adobe/aepsdk-core-android/pull/17/files#diff-04a61d2f18bfcab77163dfa2c1aa911df1699699ec0c9ba7ca739d654f8dc0d2)
    * Newly optional `RuleConsequence` `detail`: https://github.com/adobe/aepsdk-core-android/blob/9b70e820122440c723a6ab7c401c3145f75e6ce2/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/RuleConsequence.kt#L26
    * `JSONConsequence` -> `RuleConsequence` construction logic lacks the same validation as before: https://github.com/adobe/aepsdk-core-android/blob/9b70e820122440c723a6ab7c401c3145f75e6ce2/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/json/JSONConsequence.kt#L45-L48
3. Align with the iOS implementation which similarly defines RuleConsequence.detail to be non-optional

The benefits of this change are:
1. Simplifying usage throughout `LaunchRulesConsequence`, since the `detail` property doesn't need to be checked at every access. 
2. It also emits the granular reason for rules creation failure, at rules construction time, not evaluation
3. Prevents invalid rules from being loaded in to begin with, saving processing on guaranteed invalid rules

The PR also adds test cases to validate the behavior of the conversion of `JSONConsequence` -> `RuleConsequence` via `toRuleConsequence()`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
