### PR TITLE
Add support for nested lists to map flattening logic

### DIFF
--- a/code/core/src/androidTest/java/com/adobe/marketing/mobile/internal/eventhub/history/AndroidEventHistoryDatabaseTests.kt
+++ b/code/core/src/androidTest/java/com/adobe/marketing/mobile/internal/eventhub/history/AndroidEventHistoryDatabaseTests.kt
@@ -211,6 +211,19 @@ class AndroidEventHistoryDatabaseTests {
     }
 
     @Test
+    fun testQuery_noRecordExists() {
+        // create new event history database
+        val eventHistoryDatabase = AndroidEventHistoryDatabase()
+
+        // query for a record that does not exist
+        val res = eventHistoryDatabase.query(222222222, 0, System.currentTimeMillis())
+
+        assertNotNull(res)
+        assertEquals(0, res?.count)
+        assertEquals(null, res?.oldestOccurrence)
+        assertEquals(null, res?.newestOccurrence)
+    }
+    @Test
     fun testQuery_DatabasesDeleted() {
         // create new event history database
         val eventHistoryDatabase = AndroidEventHistoryDatabase()
@@ -222,6 +235,8 @@ class AndroidEventHistoryDatabaseTests {
         val res = eventHistoryDatabase.query(222222222, 0, System.currentTimeMillis())
         assertNotNull(res)
         assertEquals(-1, res?.count)
+        assertEquals(null, res?.oldestOccurrence)
+        assertEquals(null, res?.newestOccurrence)
     }
 
     @Test
@@ -236,6 +251,8 @@ class AndroidEventHistoryDatabaseTests {
         val res = eventHistoryDatabase.query(222222222, 0, System.currentTimeMillis())
         assertNotNull(res)
         assertEquals(-1, res?.count)
+        assertEquals(null, res?.oldestOccurrence)
+        assertEquals(null, res?.newestOccurrence)
     }
 
     @Test

--- a/code/core/src/androidTest/java/com/adobe/marketing/mobile/internal/eventhub/history/AndroidEventHistoryTests.kt
+++ b/code/core/src/androidTest/java/com/adobe/marketing/mobile/internal/eventhub/history/AndroidEventHistoryTests.kt
@@ -198,6 +198,8 @@ class AndroidEventHistoryTests {
         assertEquals(3, results[0].count)
         assertEquals(1, results[1].count)
         assertEquals(0, results[2].count)
+        assertEquals(null, results[2].oldestOccurrence)
+        assertEquals(null, results[2].newestOccurrence)
     }
 
     @Test
@@ -218,6 +220,8 @@ class AndroidEventHistoryTests {
         assertEquals(requests.size, results.size)
         assertEquals(1, results[0].count)
         assertEquals(0, results[1].count)
+        assertEquals(null, results[1].oldestOccurrence)
+        assertEquals(null, results[1].newestOccurrence)
     }
 
     @Test
@@ -321,6 +325,8 @@ class AndroidEventHistoryTests {
         assertEquals(requests.size, results.size)
         for (result in results) {
             assertEquals(0, result.count)
+            assertEquals(null, result.oldestOccurrence)
+            assertEquals(null, result.newestOccurrence)
         }
     }
 

--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/eventhub/history/AndroidEventHistoryDatabase.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/eventhub/history/AndroidEventHistoryDatabase.kt
@@ -137,9 +137,13 @@ internal class AndroidEventHistoryDatabase : EventHistoryDatabase {
                 cursor.use {
                     cursor.moveToFirst()
                     val count = cursor.getInt(QUERY_COUNT_INDEX)
-                    val oldest = cursor.getLong(QUERY_OLDEST_INDEX)
-                    val newest = cursor.getLong(QUERY_NEWEST_INDEX)
-                    return EventHistoryResult(count, oldest, newest)
+                    if (count == 0) {
+                        return EventHistoryResult(0)
+                    } else {
+                        val oldest = cursor.getLong(QUERY_OLDEST_INDEX)
+                        val newest = cursor.getLong(QUERY_NEWEST_INDEX)
+                        return EventHistoryResult(count, oldest, newest)
+                    }
                 }
             } catch (e: Exception) {
                 Log.warning(

--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/util/ListExtensions.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/util/ListExtensions.kt
@@ -1,0 +1,54 @@
+/*
+  Copyright 2025 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.internal.util
+
+/**
+ * Recursively flattens nested [Map]s, [List]s and [Array]s values inside a List<Any?> into a
+ * single-level Map<String, Any?> with dot-separated index.
+ * Other nested values are added as objects without any flattening.
+ * For example, an input [List] of:
+ *  `[["key": "value"],
+ *    [value0, value1]]`
+ * will return a [Map] represented as:
+ *  `{0.key: value, 1.0: value0, 1.1: value1}`
+ *
+ *  Key names are not escaped; if flattened keys collide, the last value written wins.
+ *  The resolution order in this case is undefined and may change.
+ *
+ * @param prefix a prefix to append to the front of the key
+ * @return flattened [Map]
+ */
+@JvmSynthetic
+internal fun List<Any?>.flattening(prefix: String = ""): Map<String, Any?> {
+    val flattenedMap = mutableMapOf<String, Any?>()
+    this.forEachIndexed { index, item ->
+        val expandedKey = if (prefix.isNotEmpty()) "$prefix.$index" else "$index"
+        if (item is Map<*, *> && item.keys.isAllString()) {
+            @Suppress("UNCHECKED_CAST")
+            flattenedMap.putAll((item as Map<String, Any?>).flattening(expandedKey))
+        } else if (item is List<*>) {
+            flattenedMap.putAll((item as List<Any?>).flattening(prefix = expandedKey))
+        } else if (item is Array<*>) {
+            flattenedMap.putAll((item as Array<out Any?>).flattening(prefix = expandedKey))
+        } else {
+            flattenedMap[expandedKey] = item
+        }
+    }
+    return flattenedMap
+}
+
+/**
+ * Recursively flattens nested [Map]s, [List]s and [Array]s values inside an Array<outAny?> into a
+ * single-level Map<String, Any?> with dot-separated index.
+ */
+@JvmSynthetic
+internal fun Array<out Any?>.flattening(prefix: String = ""): Map<String, Any?> = toList().flattening(prefix)

--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/util/MapExtensions.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/util/MapExtensions.kt
@@ -46,18 +46,21 @@ internal fun Map<String, Any?>.fnv1a32(masks: Array<String>? = null): Long {
  *  `{rootKey: {key1: value1, key2: value2}}`
  * will return a [Map] represented as:
  *  `{rootKey.key1: value1, rootKey.key2: value2}`
- * For an input [Map] with nested [List], by default shouldFlattenList is true:
+ * For an input [Map] with nested [List], by default when shouldFlattenList is true:
  * `{rootKey: {key1 : [value0, value1]}}`
  * will return a [Map] represented as:
  *  `{rootKey.key1.0.value0, rootKey.key1.1.value1}`
  *  Else, it will return:
  *  `{rootKey.key1: [value0, value1]}`
  *
+ *  Key names are not escaped; if flattened keys collide, the last value written wins.
+ *  The resolution order in this case is undefined and may change.
+ *
  * @param prefix a prefix to append to the front of the key
  * @return flattened [Map]
  */
 @JvmSynthetic
-internal fun Map<String, Any?>.flattening(prefix: String = "", shouldFlattenList: Boolean = true): Map<String, Any?> {
+internal fun Map<String, Any?>.flattening(prefix: String = "", shouldFlattenListAndArray: Boolean = true): Map<String, Any?> {
     val keyPrefix = if (prefix.isNotEmpty()) "$prefix." else prefix
     val flattenedMap = mutableMapOf<String, Any?>()
     this.forEach { entry ->
@@ -66,13 +69,13 @@ internal fun Map<String, Any?>.flattening(prefix: String = "", shouldFlattenList
             is Map<*, *> -> {
                 if (value.keys.isAllString()) {
                     @Suppress("UNCHECKED_CAST")
-                    flattenedMap.putAll((value as Map<String, Any?>).flattening(expandedKey, shouldFlattenList))
+                    flattenedMap.putAll((value as Map<String, Any?>).flattening(expandedKey, shouldFlattenListAndArray))
                 } else {
                     flattenedMap[expandedKey] = value
                 }
             }
             is List<*>, is Array<*> -> {
-                if (shouldFlattenList) {
+                if (shouldFlattenListAndArray) {
                     val items = if (value is List<*>) value else (value as Array<*>).toList()
                     items.forEachIndexed { index, item ->
                         val itemMap = mapOf("$index" to item)

--- a/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesConsequence.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesConsequence.kt
@@ -542,7 +542,8 @@ internal class LaunchRulesConsequence(
             object : AdobeCallbackWithError<Boolean> {
                 override fun call(result: Boolean) {
                     if (result) {
-                        extensionApi.dispatch(eventToRecord)
+                        val consequenceEvent = generateConsequenceEvent(consequence, parentEvent)
+                        extensionApi.dispatch(consequenceEvent)
                     } else {
                         Log.warning(
                             LaunchRulesEngineConstants.LOG_TAG,

--- a/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchTokenFinder.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchTokenFinder.kt
@@ -77,7 +77,7 @@ internal class LaunchTokenFinder(val event: Event, val extensionApi: ExtensionAp
                     )
                     return EMPTY_STRING
                 }
-                val eventDataAsObjectMap = event.eventData.flattening(shouldFlattenListAndArray = false)
+                val eventDataAsObjectMap = event.eventData.flattening(flattenListAndArray = false)
                 eventDataAsObjectMap.serializeToQueryString()
             }
             KEY_ALL_JSON -> {

--- a/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchTokenFinder.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchTokenFinder.kt
@@ -77,7 +77,7 @@ internal class LaunchTokenFinder(val event: Event, val extensionApi: ExtensionAp
                     )
                     return EMPTY_STRING
                 }
-                val eventDataAsObjectMap = event.eventData.flattening(shouldFlattenList = false)
+                val eventDataAsObjectMap = event.eventData.flattening(shouldFlattenListAndArray = false)
                 eventDataAsObjectMap.serializeToQueryString()
             }
             KEY_ALL_JSON -> {

--- a/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchTokenFinder.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchTokenFinder.kt
@@ -77,7 +77,7 @@ internal class LaunchTokenFinder(val event: Event, val extensionApi: ExtensionAp
                     )
                     return EMPTY_STRING
                 }
-                val eventDataAsObjectMap = event.eventData.flattening()
+                val eventDataAsObjectMap = event.eventData.flattening(shouldFlattenList = false)
                 eventDataAsObjectMap.serializeToQueryString()
             }
             KEY_ALL_JSON -> {
@@ -147,6 +147,7 @@ internal class LaunchTokenFinder(val event: Event, val extensionApi: ExtensionAp
             return EMPTY_STRING
         }
         val eventDataMap = event.eventData.flattening()
-        return eventDataMap[key]
+        val value = eventDataMap[key]
+        return value
     }
 }

--- a/code/core/src/test/java/com/adobe/marketing/mobile/internal/util/ListExtensionsTests.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/internal/util/ListExtensionsTests.kt
@@ -1,0 +1,204 @@
+/*
+  Copyright 2025 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.internal.util
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class ListExtensionsTests {
+
+    @Test
+    fun testSimpleListFlattening() {
+        val list = listOf("a", "b", "c", "d")
+        val flattenedList = list.flattening()
+        val expectedMap = mapOf(
+            "0" to "a",
+            "1" to "b",
+            "2" to "c",
+            "3" to "d"
+        )
+        assertEquals(expectedMap, flattenedList)
+    }
+
+    @Test
+    fun testSimpleListFlatteningWithAllPrimitiveTypes() {
+        val list = listOf("string_Value", 1234, 45.67, false, null)
+        val flattenedList = list.flattening()
+        val expectedMap = mapOf(
+            "0" to "string_Value",
+            "1" to 1234,
+            "2" to 45.67,
+            "3" to false,
+            "4" to null
+        )
+        assertEquals(expectedMap, flattenedList)
+    }
+
+    @Test
+    fun testNestedListFlattening() {
+        val list = listOf(
+            "a",
+            listOf("b1", "b2"),
+        )
+        val flattenedList = list.flattening()
+        val expectedMap = mapOf(
+            "0" to "a",
+            "1.0" to "b1",
+            "1.1" to "b2",
+        )
+        assertEquals(expectedMap, flattenedList)
+    }
+
+    @Test
+    fun testListFlatteningWithArray() {
+        val list = listOf(
+            "a",
+            arrayOf("b1", "b2")
+        )
+        val flattenedList = list.flattening()
+        val expectedMap = mapOf(
+            "0" to "a",
+            "1.0" to "b1",
+            "1.1" to "b2"
+        )
+        assertEquals(expectedMap, flattenedList)
+    }
+
+    @Test
+    fun testListFlatteningWithMap() {
+        val list = listOf(
+            "a",
+            mapOf("key1" to "value1", "key2" to "value2")
+        )
+        val flattenedList = list.flattening()
+        val expectedMap = mapOf(
+            "0" to "a",
+            "1.key1" to "value1",
+            "1.key2" to "value2",
+        )
+        assertEquals(expectedMap, flattenedList)
+    }
+
+    @Test
+    fun testListFlatteningWithMixedTypes() {
+        val list = listOf(
+            "a",
+            listOf("b1", "b2"),
+            arrayOf("c1", "c2"),
+            mapOf("key1" to "value1")
+        )
+        val flattenedList = list.flattening()
+        val expectedMap = mapOf(
+            "0" to "a",
+            "1.0" to "b1",
+            "1.1" to "b2",
+            "2.0" to "c1",
+            "2.1" to "c2",
+            "3.key1" to "value1"
+        )
+        assertEquals(expectedMap, flattenedList)
+    }
+
+    @Test
+    fun testEmptyListFlattening() {
+        val list = emptyList<Any?>()
+        val flattenedList = list.flattening()
+        val expectedMap = emptyMap<String, Any?>()
+        assertEquals(expectedMap, flattenedList)
+    }
+
+    @Test
+    fun testSimpleArrayFlattening() {
+        val array = arrayOf("a", "b", "c", "d")
+        val flattenedArray = array.flattening()
+        val expectedMap = mapOf(
+            "0" to "a",
+            "1" to "b",
+            "2" to "c",
+            "3" to "d"
+        )
+        assertEquals(expectedMap, flattenedArray)
+    }
+
+    @Test
+    fun testNestedArrayFlattening() {
+        val array = arrayOf(
+            "a",
+            arrayOf("b1", "b2"),
+        )
+        val flattenedArray = array.flattening()
+        val expectedMap = mapOf(
+            "0" to "a",
+            "1.0" to "b1",
+            "1.1" to "b2",
+        )
+        assertEquals(expectedMap, flattenedArray)
+    }
+
+    @Test
+    fun testArrayFlatteningWithList() {
+        val array = arrayOf(
+            "a",
+            listOf("b1", "b2")
+        )
+        val flattenedArray = array.flattening()
+        val expectedMap = mapOf(
+            "0" to "a",
+            "1.0" to "b1",
+            "1.1" to "b2"
+        )
+        assertEquals(expectedMap, flattenedArray)
+    }
+
+    @Test
+    fun testArrayFlatteningWithMap() {
+        val array = arrayOf(
+            "a",
+            mapOf("key1" to "value1", "key2" to "value2")
+        )
+        val flattenedArray = array.flattening()
+        val expectedMap = mapOf(
+            "0" to "a",
+            "1.key1" to "value1",
+            "1.key2" to "value2",
+        )
+        assertEquals(expectedMap, flattenedArray)
+    }
+
+    @Test
+    fun testArrayFlatteningWithMixedTypes() {
+        val array = arrayOf(
+            "a",
+            listOf("b1", "b2"),
+            arrayOf("c1", "c2"),
+            mapOf("key1" to "value1")
+        )
+        val flattenedArray = array.flattening()
+        val expectedMap = mapOf(
+            "0" to "a",
+            "1.0" to "b1",
+            "1.1" to "b2",
+            "2.0" to "c1",
+            "2.1" to "c2",
+            "3.key1" to "value1"
+        )
+        assertEquals(expectedMap, flattenedArray)
+    }
+
+    @Test
+    fun testEmptyArrayFlattening() {
+        val array = emptyArray<Any?>()
+        val flattenedArray = array.flattening()
+        val expectedMap = emptyMap<String, Any?>()
+        assertEquals(expectedMap, flattenedArray)
+    }
+}

--- a/code/core/src/test/java/com/adobe/marketing/mobile/internal/util/MapExtensionsTests.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/internal/util/MapExtensionsTests.kt
@@ -38,6 +38,143 @@ class MapExtensionsTests {
     }
 
     @Test
+    fun testMapWithListFlattening() {
+        val map = mapOf(
+            "a" to mapOf(
+                "b" to mapOf(
+                    "c" to "a_b_c_value"
+                )
+            ),
+            "d" to mapOf(
+                "e" to listOf(
+                    mapOf(
+                        "value1" to "d_e_value1"
+                    ),
+                    mapOf(
+                        "value2" to "d_e_value2"
+                    )
+                ),
+            )
+        )
+        val flattenedMap = map.flattening()
+        val expectedMap = mapOf(
+            "a.b.c" to "a_b_c_value",
+            "d.e.0.value1" to "d_e_value1",
+            "d.e.1.value2" to "d_e_value2"
+        )
+        assertEquals(3, flattenedMap.size)
+        assertEquals(expectedMap, flattenedMap)
+    }
+
+    @Test
+    fun `test flattening with nested lists`() {
+        val map = mapOf(
+            "a" to listOf(
+                listOf("nested1", "nested2"),
+                listOf("nested3", "nested4")
+            )
+        )
+        val flattenedMap = map.flattening()
+        val expectedMap = mapOf(
+            "a.0.0" to "nested1",
+            "a.0.1" to "nested2",
+            "a.1.0" to "nested3",
+            "a.1.1" to "nested4"
+        )
+        assertEquals(expectedMap, flattenedMap)
+    }
+
+    @Test
+    fun `test flattening with maps inside lists`() {
+        val map = mapOf(
+            "a" to listOf(
+                mapOf("key1" to "value1", "key2" to "value2"),
+                mapOf("key3" to "value3", "key4" to "value4")
+            )
+        )
+        val flattenedMap = map.flattening()
+        val expectedMap = mapOf(
+            "a.0.key1" to "value1",
+            "a.0.key2" to "value2",
+            "a.1.key3" to "value3",
+            "a.1.key4" to "value4"
+        )
+        assertEquals(expectedMap, flattenedMap)
+    }
+
+    @Test
+    fun `test flattening with complex nested structures`() {
+        val map = mapOf(
+            "root" to mapOf(
+                "list1" to listOf(
+                    mapOf(
+                        "nestedList" to listOf("a", "b"),
+                        "nestedMap" to mapOf("x" to "y")
+                    ),
+                    mapOf(
+                        "nestedList" to listOf("c", "d"),
+                        "nestedMap" to mapOf("z" to "w")
+                    )
+                ),
+                "map1" to mapOf(
+                    "list2" to listOf(
+                        mapOf("p" to "q"),
+                        mapOf("r" to "s")
+                    )
+                )
+            )
+        )
+        val flattenedMap = map.flattening()
+        val expectedMap = mapOf(
+            "root.list1.0.nestedList.0" to "a",
+            "root.list1.0.nestedList.1" to "b",
+            "root.list1.0.nestedMap.x" to "y",
+            "root.list1.1.nestedList.0" to "c",
+            "root.list1.1.nestedList.1" to "d",
+            "root.list1.1.nestedMap.z" to "w",
+            "root.map1.list2.0.p" to "q",
+            "root.map1.list2.1.r" to "s"
+        )
+        assertEquals(expectedMap, flattenedMap)
+    }
+
+    @Test
+    fun `test flattening with arrays`() {
+        val map = mapOf(
+            "a" to arrayOf(
+                arrayOf("nested1", "nested2"),
+                arrayOf("nested3", "nested4")
+            )
+        )
+        val flattenedMap = map.flattening()
+        val expectedMap = mapOf(
+            "a.0.0" to "nested1",
+            "a.0.1" to "nested2",
+            "a.1.0" to "nested3",
+            "a.1.1" to "nested4"
+        )
+        assertEquals(expectedMap, flattenedMap)
+    }
+
+    @Test
+    fun `test flattening with mixed arrays and lists`() {
+        val map = mapOf(
+            "a" to listOf(
+                arrayOf("nested1", "nested2"),
+                listOf("nested3", "nested4")
+            )
+        )
+        val flattenedMap = map.flattening()
+        val expectedMap = mapOf(
+            "a.0.0" to "nested1",
+            "a.0.1" to "nested2",
+            "a.1.0" to "nested3",
+            "a.1.1" to "nested4"
+        )
+        assertEquals(expectedMap, flattenedMap)
+    }
+
+    @Test
     fun testNullValueMapFlattening() {
         val map = mapOf(
             "a" to mapOf(

--- a/code/core/src/test/java/com/adobe/marketing/mobile/internal/util/MapExtensionsTests.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/internal/util/MapExtensionsTests.kt
@@ -135,7 +135,7 @@ class MapExtensionsTests {
                 ),
             )
         )
-        val flattenedMap = map.flattening(shouldFlattenListAndArray = false)
+        val flattenedMap = map.flattening(flattenListAndArray = false)
         assertEquals(2, flattenedMap.size)
         assertEquals("a_b_c_value", flattenedMap["a.b.c"])
         assertTrue(flattenedMap["d.e"] is List<*>)
@@ -251,6 +251,31 @@ class MapExtensionsTests {
             "a.4" to null
         )
         assertEquals(expectedMap, flattenedMap)
+    }
+
+    @Test
+    fun testMapFlatteningWithArraysFlatteningDisabled() {
+        val map = mapOf(
+            "a" to mapOf(
+                "b" to mapOf(
+                    "c" to "a_b_c_value"
+                )
+            ),
+            "d" to mapOf(
+                "e" to arrayOf(
+                    mapOf(
+                        "value1" to "d_e_value1"
+                    ),
+                    mapOf(
+                        "value2" to "d_e_value2"
+                    )
+                ),
+            )
+        )
+        val flattenedMap = map.flattening(flattenListAndArray = false)
+        assertEquals(2, flattenedMap.size)
+        assertEquals("a_b_c_value", flattenedMap["a.b.c"])
+        assertTrue(flattenedMap["d.e"] is Array<*>)
     }
 
     @Test
@@ -386,10 +411,14 @@ class MapExtensionsTests {
         )
         val flattenedMap = map.flattening()
         assertEquals(1, flattenedMap.size)
-        val expectedMap = mapOf(
-            "a.b" to 2
-        )
-        assertEquals(expectedMap, flattenedMap)
+        assertEquals("a.b", flattenedMap.keys.first())
+    }
+
+    @Test
+    fun testFlatteningWithEmptyMap() {
+        val map = emptyMap<String, Any>()
+        val flattenedMap = map.flattening()
+        assertTrue(flattenedMap.isEmpty())
     }
 
     @Test

--- a/code/core/src/test/java/com/adobe/marketing/mobile/internal/util/MapExtensionsTests.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/internal/util/MapExtensionsTests.kt
@@ -38,7 +38,30 @@ class MapExtensionsTests {
     }
 
     @Test
-    fun testMapWithListFlattening() {
+    fun testSimpleMapFlatteningWithAllPrimitiveTypes() {
+        val map = mapOf(
+            "outerKey" to mapOf(
+                "a" to "string_value",
+                "b" to 123,
+                "c" to 45.67,
+                "d" to false,
+                "e" to null
+            )
+        )
+        val flattenedMap = map.flattening()
+        val expectedMap = mapOf(
+            "outerKey.a" to "string_value",
+            "outerKey.b" to 123,
+            "outerKey.c" to 45.67,
+            "outerKey.d" to false,
+            "outerKey.e" to null
+        )
+        assertEquals(5, flattenedMap.size)
+        assertEquals(expectedMap, flattenedMap)
+    }
+
+    @Test
+    fun testMapFlatteningWithList() {
         val map = mapOf(
             "a" to mapOf(
                 "b" to mapOf(
@@ -67,7 +90,34 @@ class MapExtensionsTests {
     }
 
     @Test
-    fun testMapWithListFlatteningDisabled() {
+    fun testMapFlatteningWithListOfAllPrimitiveTypes() {
+        val map = mapOf(
+            "a" to mapOf(
+                "b" to mapOf(
+                    "c" to "a_b_c_value"
+                )
+            ),
+            "d" to mapOf(
+                "e" to listOf(
+                    "stringInArray", 123, 4.56, false, null
+                )
+            )
+        )
+        val flattenedMap = map.flattening()
+        val expectedMap = mapOf(
+            "a.b.c" to "a_b_c_value",
+            "d.e.0" to "stringInArray",
+            "d.e.1" to 123,
+            "d.e.2" to 4.56,
+            "d.e.3" to false,
+            "d.e.4" to null
+        )
+        assertEquals(6, flattenedMap.size)
+        assertEquals(expectedMap, flattenedMap)
+    }
+
+    @Test
+    fun testMapFlatteningWithListFlatteningDisabled() {
         val map = mapOf(
             "a" to mapOf(
                 "b" to mapOf(
@@ -85,18 +135,14 @@ class MapExtensionsTests {
                 ),
             )
         )
-        val flattenedMap = map.flattening(shouldFlattenList = false)
-        val expectedMap = mapOf(
-            "a.b.c" to "a_b_c_value",
-            "d.e" to "[{value1=d_e_value1}, {value2=d_e_value2}]"
-        )
+        val flattenedMap = map.flattening(shouldFlattenListAndArray = false)
         assertEquals(2, flattenedMap.size)
         assertEquals("a_b_c_value", flattenedMap["a.b.c"])
         assertTrue(flattenedMap["d.e"] is List<*>)
     }
 
     @Test
-    fun `test flattening with nested lists`() {
+    fun testMapFlatteningWithNestedLists() {
         val map = mapOf(
             "a" to listOf(
                 listOf("nested1", "nested2"),
@@ -114,7 +160,7 @@ class MapExtensionsTests {
     }
 
     @Test
-    fun `test flattening with maps inside lists`() {
+    fun testMapFlatteningWithMapsInsideLists() {
         val map = mapOf(
             "a" to listOf(
                 mapOf("key1" to "value1", "key2" to "value2"),
@@ -132,7 +178,7 @@ class MapExtensionsTests {
     }
 
     @Test
-    fun `test flattening with complex nested structures`() {
+    fun testMapFlatteningWithComplexNestedStructures() {
         val map = mapOf(
             "root" to mapOf(
                 "list1" to listOf(
@@ -168,7 +214,7 @@ class MapExtensionsTests {
     }
 
     @Test
-    fun `test flattening with arrays`() {
+    fun testMapFlatteningWithArrays() {
         val map = mapOf(
             "a" to arrayOf(
                 arrayOf("nested1", "nested2"),
@@ -186,7 +232,47 @@ class MapExtensionsTests {
     }
 
     @Test
-    fun `test flattening with mixed arrays and lists`() {
+    fun testMapFlatteningWithArraysOfAllPrimitiveTypes() {
+        val map = mapOf(
+            "a" to arrayOf(
+                "string_value",
+                123,
+                45.67,
+                false,
+                null
+            )
+        )
+        val flattenedMap = map.flattening()
+        val expectedMap = mapOf(
+            "a.0" to "string_value",
+            "a.1" to 123,
+            "a.2" to 45.67,
+            "a.3" to false,
+            "a.4" to null
+        )
+        assertEquals(expectedMap, flattenedMap)
+    }
+
+    @Test
+    fun testMapFlatteningWithMapsInsideArrays() {
+        val map = mapOf(
+            "a" to arrayOf(
+                mapOf("key1" to "value1", "key2" to "value2"),
+                mapOf("key3" to "value3", "key4" to "value4")
+            )
+        )
+        val flattenedMap = map.flattening()
+        val expectedMap = mapOf(
+            "a.0.key1" to "value1",
+            "a.0.key2" to "value2",
+            "a.1.key3" to "value3",
+            "a.1.key4" to "value4"
+        )
+        assertEquals(expectedMap, flattenedMap)
+    }
+
+    @Test
+    fun testMapFlatteningWithMixedArraysAndLists() {
         val map = mapOf(
             "a" to listOf(
                 arrayOf("nested1", "nested2"),
@@ -204,7 +290,7 @@ class MapExtensionsTests {
     }
 
     @Test
-    fun testNullValueMapFlattening() {
+    fun testMapFlatteningNullValueMap() {
         val map = mapOf(
             "a" to mapOf(
                 "b1" to mapOf(
@@ -225,7 +311,7 @@ class MapExtensionsTests {
     }
 
     @Test
-    fun testMultipleNestedKeysMapFlattening() {
+    fun testMapFlatteningMultipleNestedKeys() {
         val map = mapOf(
             "a" to mapOf(
                 "b1" to mapOf(
@@ -256,7 +342,7 @@ class MapExtensionsTests {
     }
 
     @Test
-    fun testContainsNonStringKeysMapFlattening() {
+    fun testMapFlatteningContainsNonStringKeys() {
         val map = mapOf(
             "a" to mapOf(
                 "b1" to mapOf(
@@ -286,6 +372,22 @@ class MapExtensionsTests {
                 "2" to "a_b3_value"
             ),
             "d" to "d_value"
+        )
+        assertEquals(expectedMap, flattenedMap)
+    }
+
+    @Test
+    fun testMapFlatteningWithDotInKey() {
+        val map = mapOf(
+            "a.b" to 1,
+            "a" to mapOf(
+                "b" to 2
+            )
+        )
+        val flattenedMap = map.flattening()
+        assertEquals(1, flattenedMap.size)
+        val expectedMap = mapOf(
+            "a.b" to 2
         )
         assertEquals(expectedMap, flattenedMap)
     }

--- a/code/core/src/test/java/com/adobe/marketing/mobile/internal/util/MapExtensionsTests.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/internal/util/MapExtensionsTests.kt
@@ -67,6 +67,35 @@ class MapExtensionsTests {
     }
 
     @Test
+    fun testMapWithListFlatteningDisabled() {
+        val map = mapOf(
+            "a" to mapOf(
+                "b" to mapOf(
+                    "c" to "a_b_c_value"
+                )
+            ),
+            "d" to mapOf(
+                "e" to listOf(
+                    mapOf(
+                        "value1" to "d_e_value1"
+                    ),
+                    mapOf(
+                        "value2" to "d_e_value2"
+                    )
+                ),
+            )
+        )
+        val flattenedMap = map.flattening(shouldFlattenList = false)
+        val expectedMap = mapOf(
+            "a.b.c" to "a_b_c_value",
+            "d.e" to "[{value1=d_e_value1}, {value2=d_e_value2}]"
+        )
+        assertEquals(2, flattenedMap.size)
+        assertEquals("a_b_c_value", flattenedMap["a.b.c"])
+        assertTrue(flattenedMap["d.e"] is List<*>)
+    }
+
+    @Test
     fun `test flattening with nested lists`() {
         val map = mapOf(
             "a" to listOf(

--- a/code/core/src/test/java/com/adobe/marketing/mobile/internal/util/MapUtilsTests.java
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/internal/util/MapUtilsTests.java
@@ -156,8 +156,8 @@ public class MapUtilsTests {
                 };
         // test
         final long hash = MapUtilsKt.convertMapToFnv1aHash(map, null);
-        // verify flattened map string "key:[{aaa=1, zzz=true}, {number=123, double=1.5}]"
-        final long expectedHash = 2052811266L;
+        // verify flattened map string "key.0.aaa:1key.0.zzz:truekey.1.double:1.5key.1.number:123"
+        final long expectedHash = 2410759527L;
         assertEquals(expectedHash, hash);
     }
 
@@ -189,8 +189,8 @@ public class MapUtilsTests {
                 };
         // test
         final long hash = MapUtilsKt.convertMapToFnv1aHash(map, null);
-        // verify flattened map string "key:[[aaa, zzz, 111], [2]]"
-        final long expectedHash = 390515610L;
+        // verify flattened map string "key.0.0:aaakey.0.1:zzzkey.0.2:111key.1.0:2"
+        final long expectedHash = 2441202563L;
         assertEquals(expectedHash, hash);
     }
 

--- a/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesConsequenceTests.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesConsequenceTests.kt
@@ -1253,7 +1253,11 @@ class LaunchRulesConsequenceTests {
         val dispatchedEventCaptor: ArgumentCaptor<Event> =
             ArgumentCaptor.forClass(Event::class.java)
         verify(extensionApi, times(1)).dispatch(dispatchedEventCaptor.capture())
-        assertEquals(recordedEventCaptor.value, dispatchedEventCaptor.value)
+        val rulesConsequence = matchedRules?.get(0)?.consequenceList?.get(0)
+        val eventData = dispatchedEventCaptor.value.eventData?.get("triggeredconsequence") as Map<*, *>?
+        assertEquals(rulesConsequence?.id, eventData?.get("id"))
+        assertEquals(rulesConsequence?.type, eventData?.get("type"))
+        assertEquals(rulesConsequence?.detail, eventData?.get("detail"))
     }
 
     @Test
@@ -1739,7 +1743,11 @@ class LaunchRulesConsequenceTests {
         val dispatchedEventCaptor: ArgumentCaptor<Event> =
             ArgumentCaptor.forClass(Event::class.java)
         verify(extensionApi, times(1)).dispatch(dispatchedEventCaptor.capture())
-        assertEquals(recordedEventCaptor.value, dispatchedEventCaptor.value)
+        val rulesConsequence = matchedRules?.get(0)?.consequenceList?.get(0)
+        val eventData = dispatchedEventCaptor.value.eventData?.get("triggeredconsequence") as Map<*, *>?
+        assertEquals(rulesConsequence?.id, eventData?.get("id"))
+        assertEquals(rulesConsequence?.type, eventData?.get("type"))
+        assertEquals(rulesConsequence?.detail, eventData?.get("detail"))
     }
 
     @Test
@@ -1808,7 +1816,10 @@ class LaunchRulesConsequenceTests {
         val dispatchedEventCaptor: ArgumentCaptor<Event> =
             ArgumentCaptor.forClass(Event::class.java)
         verify(extensionApi, times(1)).dispatch(dispatchedEventCaptor.capture())
-        assertEquals(recordedEventCaptor.value, dispatchedEventCaptor.value)
+        val rulesConsequence = matchedRules?.get(0)?.consequenceList?.get(0)
+        val eventData = dispatchedEventCaptor.value.eventData?.get("triggeredconsequence") as Map<*, *>?
+        assertEquals(rulesConsequence?.id, eventData?.get("id"))
+        assertEquals(rulesConsequence?.type, eventData?.get("type"))
     }
 
     @Test
@@ -1876,7 +1887,11 @@ class LaunchRulesConsequenceTests {
         val dispatchedEventCaptor: ArgumentCaptor<Event> =
             ArgumentCaptor.forClass(Event::class.java)
         verify(extensionApi).dispatch(dispatchedEventCaptor.capture())
-        assertEquals(recordedEventCaptor.value, dispatchedEventCaptor.value)
+        val rulesConsequence = matchedRules?.get(0)?.consequenceList?.get(0)
+        val eventData = dispatchedEventCaptor.value.eventData?.get("triggeredconsequence") as Map<*, *>?
+        assertEquals(rulesConsequence?.id, eventData?.get("id"))
+        assertEquals(rulesConsequence?.type, eventData?.get("type"))
+        assertEquals(rulesConsequence?.detail, eventData?.get("detail"))
     }
 
     @Test

--- a/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesEngineModuleTests.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchRulesEngineModuleTests.kt
@@ -89,6 +89,43 @@ class LaunchRulesEngineModuleTests {
     }
 
     @Test
+    fun `Test group condition with key embedded inside list`() {
+        val json = readTestResources("rules_module_tests/rules_testGroupLogicalOperatorsWithKeysEmbeddedInList.json")
+        assertNotNull(json)
+        val rules = JSONRulesParser.parse(json, extensionApi)
+        assertNotNull(rules)
+        launchRulesEngine.replaceRules(rules)
+
+        val contentCardDismissEvent = Event.Builder(
+            "contentCardDismiss",
+            EventType.EDGE,
+            EventSource.REQUEST_CONTENT
+        ).setEventData(
+            mapOf(
+                "xdm" to mapOf(
+                    "eventType" to "decisioning.propositionDismiss",
+                    "_experience" to mapOf(
+                        "decisioning" to mapOf(
+                            "propositions" to listOf(
+                                mapOf(
+                                    "scopeDetails" to mapOf(
+                                        "activity" to mapOf(
+                                            "id" to "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        ).build()
+        val matchedConsequence = launchRulesEngine.evaluateEvent(contentCardDismissEvent)
+        assertEquals(1, matchedConsequence.size)
+        assertEquals("schema", matchedConsequence[0].type)
+    }
+
+    @Test
     fun `Test historical condition any search type success`() {
         val captor = argumentCaptor<AdobeCallbackWithError<Array<EventHistoryResult>>>()
         Mockito.`when`(extensionApi.getHistoricalEvents(any(), Mockito.anyBoolean(), captor.capture()))

--- a/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchTokenFinderTest.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchTokenFinderTest.kt
@@ -186,7 +186,7 @@ class LaunchTokenFinderTest {
         // test
         val result = launchTokenFinder.get("~all_url")
         // verify
-        assertEquals("key6.0=String1&key6.1=String2", result)
+        assertEquals("key6=String1%2CString2", result)
     }
 
     @Test

--- a/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchTokenFinderTest.kt
+++ b/code/core/src/test/java/com/adobe/marketing/mobile/launch/rulesengine/LaunchTokenFinderTest.kt
@@ -186,7 +186,7 @@ class LaunchTokenFinderTest {
         // test
         val result = launchTokenFinder.get("~all_url")
         // verify
-        assertEquals("key6=String1%2CString2", result)
+        assertEquals("key6.0=String1&key6.1=String2", result)
     }
 
     @Test
@@ -309,7 +309,7 @@ class LaunchTokenFinderTest {
     }
 
     @Test
-    fun `get should return shared state list of the module on valid event`() {
+    fun `get should return shared state string of the module on valid event`() {
         // setup
         val testEvent = getDefaultEvent(null)
         val lcData = mapOf("visitoridslist" to listOf("vid1", "vid2"))
@@ -328,10 +328,13 @@ class LaunchTokenFinderTest {
         )
         val launchTokenFinder = LaunchTokenFinder(testEvent, extensionApi)
         // test
-        val result =
-            launchTokenFinder.get("~state.com.adobe.marketing.mobile.identity/visitoridslist")
+        val result0 =
+            launchTokenFinder.get("~state.com.adobe.marketing.mobile.identity/visitoridslist.0")
+        val result1 =
+            launchTokenFinder.get("~state.com.adobe.marketing.mobile.identity/visitoridslist.1")
         // verify
-        assertEquals(listOf("vid1", "vid2"), result)
+        assertEquals("vid1", result0)
+        assertEquals("vid2", result1)
     }
 
     @Test
@@ -425,15 +428,17 @@ class LaunchTokenFinderTest {
     }
 
     @Test
-    fun `get should return list on list value`() {
+    fun `get should return string on list value`() {
         // setup
         val testEventData = mapOf("key6" to listOf("String1", "String2"))
         val testEvent = getDefaultEvent(testEventData)
         val launchTokenFinder = LaunchTokenFinder(testEvent, extensionApi)
         // test
-        val result = launchTokenFinder.get("key6")
+        val result0 = launchTokenFinder.get("key6.0")
+        val result1 = launchTokenFinder.get("key6.1")
         // verify
-        assertEquals(listOf("String1", "String2"), result)
+        assertEquals("String1", result0)
+        assertEquals("String2", result1)
     }
 
     @Test

--- a/code/core/src/test/resources/rules_module_tests/rules_testGroupLogicalOperatorsWithKeysEmbeddedInList.json
+++ b/code/core/src/test/resources/rules_module_tests/rules_testGroupLogicalOperatorsWithKeysEmbeddedInList.json
@@ -1,0 +1,90 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "condition": {
+        "type": "group",
+        "definition": {
+          "logic": "and",
+          "conditions": [
+            {
+              "type": "group",
+              "definition": {
+                "logic": "and",
+                "conditions": [
+                  {
+                    "definition": {
+                      "key": "~type",
+                      "matcher": "eq",
+                      "values": [
+                        "com.adobe.eventType.edge"
+                      ]
+                    },
+                    "type": "matcher"
+                  },
+                  {
+                    "definition": {
+                      "key": "~source",
+                      "matcher": "eq",
+                      "values": [
+                        "com.adobe.eventSource.requestContent"
+                      ]
+                    },
+                    "type": "matcher"
+                  },
+                  {
+                    "definition": {
+                      "key": "xdm.eventType",
+                      "matcher": "eq",
+                      "values": [
+                        "decisioning.propositionDismiss"
+                      ]
+                    },
+                    "type": "matcher"
+                  },
+                  {
+                    "definition": {
+                      "key": "xdm._experience.decisioning.propositions.0.scopeDetails.activity.id",
+                      "matcher": "eq",
+                      "values": [
+                        "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                      ]
+                    },
+                    "type": "matcher"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "matcher",
+              "definition": {
+                "key": "~timestampu",
+                "matcher": "lt",
+                "values": [
+                  2019715200
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "consequences": [
+        {
+          "id": "48181acd-22b3-edae-bc8a-447868a7df7c",
+          "type": "schema",
+          "detail": {
+            "id": "48181acd-22b3-edae-bc8a-447868a7df7c",
+            "schema": "https://ns.adobe.com/personalization/eventHistoryOperation",
+            "data": {
+              "operation": "insertIfNotExists",
+              "content": {
+                "iam.eventType": "disqualify",
+                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This PR enhances the map flattening logic to add support for nested lists and arrays.  The flattening logic in `MapExtensions.kt` has been updated to properly index list/array elements in the flattened keys and supports mixed data structures (maps containing lists, lists containing maps).

### Example
Before:
```kotlin
{rootKey: {key1: [value0, value1]}} -> {rootKey.key1: [value0, value1]}
```

After:
```kotlin
{rootKey: {key1: [value0, value1]}} -> {rootKey.key1.0: value0, rootKey.key1.1: value1}
```

### Impact

This change affects how event data map is flattened in:
- Event data key lookup for rules `matcher` condition: Since key lookup in nested lists was never supported, this is a net new feature for this case and shouldn't create any backwards compatibility issues.
- Event data hash generation for event history read and writes: Messaging SDK was the only extension to use event history and it never recorded maps with nested lists so this change should not have any impact.
- Converting event data to encoded URL format using `~all_url`: Since customers use this in their Launch rules with postback consequence, this change might impact their existing rules. A backwards compatible carve out for the token ~all_url` is needed so that arrays remain unflattened and preserve the existing behavior. This is achieved by implementing a flag in map flattening which controls whether or not to flatten inner arrays.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
With the existing logic, if a map contains a nested list, it is considered as unsupported for flattening and the resulting flattened map has the list added as an object, making it impossible to lookup for an element at a specific index in the list for rules matcher condition.

We need this ability to support content card disqualification when the card is dismissed. The rule condition in this case verifies that the dismiss event happened on the specific card we want to disqualify and writes a disqualify event to event history as a consequence. To verify this card association, we need to look up and match the activity id which is present inside the propositions array in the dismiss event data.

Disqualify rule example:
```

{
    "condition": {
        "type": "group",
        "definition": {
            "logic": "and",
            "conditions": [
                {
                    "type": "group",
                    "definition": {
                        "logic": "and",
                        "conditions": [
                             {
                                "definition": {
                                    "key": "~type",
                                    "matcher": "eq",
                                    "values": [
                                        "com.adobe.eventType.edge"
                                    ]
                                },
                                "type": "matcher"
                            },
                            {
                                "definition": {
                                    "key": "~source",
                                    "matcher": "eq",
                                    "values": [
                                        "com.adobe.eventSource.requestContent"
                                    ]
                                },
                                "type": "matcher"
                            },
                            {
                                "definition": {
                                    "key": "xdm.eventType",
                                    "matcher": "eq",
                                    "values": [
                                        "decisioning.propositionDismiss"
                                    ]
                                },
                                "type": "matcher"
                            },
                            {
                                "definition": {
                                    "key": "xdm._experience.decisioning.propositions.0.scopeDetails.activity.id",
                                    "matcher": "eq",
                                    "values": [
                                        "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
                                    ]
                                },
                                "type": "matcher"
                            }
                        ]
                    }
                },
                {
                    "type": "matcher",
                    "definition": {
                        "key": "~timestampu",
                        "matcher": "lt",
                        "values": [2019715200]
                    }
                }
            ]
        }
    },
    "consequences": [
        {
            "id": "48181acd-22b3-edae-bc8a-447868a7df7c",
            "type": "schema",
            "detail": {
                "id": "48181acd-22b3-edae-bc8a-447868a7df7c",
                "schema": "https://ns.adobe.com/personalization/eventHistoryOperation",
                "data": {
                    "operation": "insertIfNotExists",
                    "content": {
                        "iam.eventType": "disqualify",
                        "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
                    }
                }
            }
        }
    ]
}
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Updated related tests in `MapUtilsTests.java` and `LaunchTokenFinderTest.kt` to reflect the new flattening behavior

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
