### PR TITLE
Fix message inset calculation for InAppMessages

### DIFF
--- a/code/core/src/androidTest/java/com/adobe/marketing/mobile/services/ui/message/views/MessageScreenTests.kt
+++ b/code/core/src/androidTest/java/com/adobe/marketing/mobile/services/ui/message/views/MessageScreenTests.kt
@@ -647,7 +647,7 @@ class MessageScreenTests {
             validateViewSize(
                 contentBounds,
                 messageContentHeightDp,
-                contentViewWidthDp * (widthPercentage / 100f)
+                messageContentWidthDp
             )
         } else {
             validateViewSize(
@@ -1132,7 +1132,7 @@ class MessageScreenTests {
         val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
             .getUnclippedBoundsInRoot()
         val horizontalContentPaddingDp = (contentViewWidthDp * (100 - widthPercent).toFloat() / 100f) / 2
-        val offsetDp = messageContentHeightDp * offsetPercent.toFloat() / 100f
+        val offsetDp = contentViewHeightDp * offsetPercent.toFloat() / 100f
 
         // Frame top and bottom bounds are offset downwards by the inset value from the top
         validateBounds(
@@ -1204,7 +1204,7 @@ class MessageScreenTests {
         val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
             .getUnclippedBoundsInRoot()
         val horizontalContentPaddingDp = (contentViewWidthDp * (100 - widthPercent).toFloat() / 100f) / 2
-        val offsetDp = messageContentHeightDp * offsetPercent.toFloat() / 100f
+        val offsetDp = contentViewHeightDp * offsetPercent.toFloat() / 100f
 
         // Frame top and bottom bounds are offset upwards by the inset value from the top
         validateBounds(
@@ -1276,7 +1276,7 @@ class MessageScreenTests {
         val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
             .getUnclippedBoundsInRoot()
         val horizontalContentPaddingDp = (contentViewWidthDp * (100 - widthPercent).toFloat() / 100f) / 2
-        val offsetDp = messageContentHeightDp * offsetPercent.toFloat() / 100f
+        val offsetDp = contentViewHeightDp * offsetPercent.toFloat() / 100f
 
         // Frame top and bottom bounds are offset upwards by the inset value from the bottom
         validateBounds(
@@ -1348,7 +1348,7 @@ class MessageScreenTests {
         val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
             .getUnclippedBoundsInRoot()
         val horizontalContentPaddingDp = (contentViewWidthDp * (100 - widthPercent).toFloat() / 100f) / 2
-        val offsetDp = messageContentHeightDp * offsetPercent.toFloat() / 100f
+        val offsetDp = contentViewHeightDp * offsetPercent.toFloat() / 100f
 
         // Frame top and bottom bounds are offset downwards by the inset value from the bottom
         validateBounds(
@@ -1422,7 +1422,7 @@ class MessageScreenTests {
         val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
             .getUnclippedBoundsInRoot()
         val verticalContentPaddingDp = (contentViewHeightDp - messageContentHeightDp) / 2
-        val offsetDp = messageContentWidthDp * offsetPercent.toFloat() / 100f
+        val offsetDp = contentViewWidthDp * offsetPercent.toFloat() / 100f
 
         // Frame left and right bounds are offset leftwards by the inset value from the left
         validateBounds(
@@ -1496,7 +1496,7 @@ class MessageScreenTests {
         val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
             .getUnclippedBoundsInRoot()
         val verticalContentPaddingDp = (contentViewHeightDp - messageContentHeightDp) / 2
-        val offsetDp = messageContentWidthDp * offsetPercent.toFloat() / 100f
+        val offsetDp = contentViewWidthDp * offsetPercent.toFloat() / 100f
 
         // Frame left and right bounds are offset rightwards by the inset value from the left
         validateBounds(
@@ -1570,7 +1570,7 @@ class MessageScreenTests {
         val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
             .getUnclippedBoundsInRoot()
         val verticalContentPaddingDp = (contentViewHeightDp - messageContentHeightDp) / 2
-        val offsetDp = messageContentWidthDp * offsetPercent.toFloat() / 100f
+        val offsetDp = contentViewWidthDp * offsetPercent.toFloat() / 100f
 
         // Frame left and right bounds are offset leftwards by the inset value from the right
         validateBounds(
@@ -1644,7 +1644,7 @@ class MessageScreenTests {
         val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
             .getUnclippedBoundsInRoot()
         val verticalContentPaddingDp = (contentViewHeightDp - messageContentHeightDp) / 2
-        val offsetDp = messageContentWidthDp * offsetPercent.toFloat() / 100f
+        val offsetDp = contentViewWidthDp * offsetPercent.toFloat() / 100f
 
         // Frame left and right bounds are offset rightwards by the inset value from the right
         validateBounds(
@@ -1719,8 +1719,8 @@ class MessageScreenTests {
             composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
         val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
             .getUnclippedBoundsInRoot()
-        val heightOffsetDp = messageContentHeightDp * offsetPercent.toFloat() / 100f
-        val widthOffsetDp = messageContentWidthDp * offsetPercent.toFloat() / 100f
+        val heightOffsetDp = contentViewHeightDp * offsetPercent.toFloat() / 100f
+        val widthOffsetDp = contentViewWidthDp * offsetPercent.toFloat() / 100f
 
         // Frame top and bottom  bounds are offset upwards by the inset from the bottom
         // left and right bounds are offset rightwards by the inset value from the right
@@ -1760,12 +1760,14 @@ class MessageScreenTests {
             .build()
 
         var contentViewHeightDp = 0.dp
+        var contentViewWidthDp = 0.dp
         var messageContentHeightDp = 0.dp
         var messageContentWidthDp = 0.dp
         composeTestRule.setContent { // setting our composable as content for test
             val activity = LocalContext.current as Activity
             val contentView = activity.findViewById<View>(android.R.id.content)
             contentViewHeightDp = with(LocalDensity.current) { contentView.height.toDp() }
+            contentViewWidthDp = with(LocalDensity.current) { contentView.width.toDp() }
             messageContentHeightDp = ((contentViewHeightDp * settings.height) / 100)
             messageContentWidthDp = with(LocalDensity.current) { maxWidthPx.toDp() }
 
@@ -1796,8 +1798,8 @@ class MessageScreenTests {
             composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_FRAME).getUnclippedBoundsInRoot()
         val contentBounds = composeTestRule.onNodeWithTag(MessageTestTags.MESSAGE_CONTENT)
             .getUnclippedBoundsInRoot()
-        val heightOffsetDp = messageContentHeightDp * offsetPercent.toFloat() / 100f
-        val widthOffsetDp = messageContentWidthDp * offsetPercent.toFloat() / 100f
+        val heightOffsetDp = contentViewHeightDp * offsetPercent.toFloat() / 100f
+        val widthOffsetDp = contentViewWidthDp * offsetPercent.toFloat() / 100f
 
         // Frame top and bottom  bounds are offset upwards by the inset from the bottom
         // left and right bounds are offset rightwards by the inset value from the right

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageFrame.kt
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/ui/message/views/MessageFrame.kt
@@ -87,18 +87,19 @@ internal fun MessageFrame(
     val density = LocalDensity.current
     val contentView = currentActivity.findViewById<View>(android.R.id.content)
     val contentHeightDp = with(density) { contentView.height.toDp() }
+    val contentWidthDp = with(density) { contentView.width.toDp() }
     val heightDp = remember { mutableStateOf(((contentHeightDp * inAppMessageSettings.height) / 100)) }
     val widthDp = remember { mutableStateOf(getMessageFrameWidthInDp(density, contentView.width, inAppMessageSettings)) }
 
     val horizontalOffset = MessageOffsetMapper.getHorizontalOffset(
         inAppMessageSettings.horizontalAlignment,
         inAppMessageSettings.horizontalInset,
-        widthDp.value
+        contentWidthDp
     )
     val verticalOffset = MessageOffsetMapper.getVerticalOffset(
         inAppMessageSettings.verticalAlignment,
         inAppMessageSettings.verticalInset,
-        heightDp.value
+        contentHeightDp
     )
 
     val allowGestures = remember { inAppMessageSettings.gestureMap.isNotEmpty() }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
**Problem**
Inset calculation for in-app messages has regressed in `v3.1.1-core`.
The`MessageOffsetMapper` methods expect the full screen view dimensions as the third parameter to calculate the offset percentage correctly, but now being calculated incorrectly according to the dimensions of the in-app message rather than the dimensions of the view. 

```
val horizontalOffset = MessageOffsetMapper.getHorizontalOffset(
    inAppMessageSettings.horizontalAlignment,
    inAppMessageSettings.horizontalInset,
    widthDp.value  // ❌ This is the MESSAGE width, not content view/screen width
)
val verticalOffset = MessageOffsetMapper.getVerticalOffset(
    inAppMessageSettings.verticalAlignment,
    inAppMessageSettings.verticalInset,
    heightDp.value  // ❌ This is the MESSAGE height, not content view/screen height
)
```

This results in the following behavior:
- When inAppMessageSettings.height is 100: `heightDp.value equals contentHeightDp (full screen height)` the, offset calculation works correctly.
- When inAppMessageSettings.height is 30: `heightDp.value equals contentHeightDp * 30 / 100 (30% of screen height)` Offset percentage is calculated against this smaller value, making the actual offset much smaller than intended.

**Solution**
Ensure that verticalInset percentage is always calculated against the enclosing activity height (`contentHeightDp`) and horizontalInset against the enclosing activity width (`contentWidthDp`), regardless of the message's actual size.

## Related Issue
[PLATIR-51482](https://jira.corp.adobe.com/browse/PLATIR-51482)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## How Has This Been Tested?
- Fixed UI tests
- Manual verification

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
