### PR TITLE
Use AEP Gradle Plugin 3.4.1

### DIFF
--- a/code/build.gradle.kts
+++ b/code/build.gradle.kts
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.github.adobe:aepsdk-commons:gp-3.4.0")
+        classpath("com.github.adobe:aepsdk-commons:gp-3.4.1")
         classpath("org.jetbrains.kotlinx:binary-compatibility-validator:0.13.2")
         classpath("androidx.benchmark:benchmark-gradle-plugin:1.2.3")
     }


### PR DESCRIPTION
AEP Gradle Plugin fixes project version generation for bundles. This allows projects with multiple modules to set the right version tag without overwriting on publish.