### PR TITLE
Added plugin architecture base

### DIFF
--- a/code/core/api/core.api
+++ b/code/core/api/core.api
@@ -216,6 +216,7 @@ public final class com/adobe/marketing/mobile/LoggingMode : java/lang/Enum {
 }
 
 public final class com/adobe/marketing/mobile/MobileCore {
+	public static fun addPlugins ([Lcom/adobe/marketing/mobile/plugin/IAepPlugin;)V
 	public static fun clearUpdatedConfiguration ()V
 	public static fun collectMessageInfo (Ljava/util/Map;)V
 	public static fun collectPii (Ljava/util/Map;)V
@@ -228,6 +229,7 @@ public final class com/adobe/marketing/mobile/MobileCore {
 	public static fun getApplication ()Landroid/app/Application;
 	public static fun getLargeIconResourceID ()I
 	public static fun getLogLevel ()Lcom/adobe/marketing/mobile/LoggingMode;
+	public static fun getPlugin (Ljava/lang/Class;)Lcom/adobe/marketing/mobile/plugin/IAepPlugin;
 	public static fun getPrivacyStatus (Lcom/adobe/marketing/mobile/AdobeCallback;)V
 	public static fun getSdkIdentities (Lcom/adobe/marketing/mobile/AdobeCallback;)V
 	public static fun getSmallIconResourceID ()I
@@ -424,6 +426,16 @@ public final class com/adobe/marketing/mobile/launch/rulesengine/json/JSONRulesP
 	public static final field $stable I
 	public static final field INSTANCE Lcom/adobe/marketing/mobile/launch/rulesengine/json/JSONRulesParser;
 	public static final fun parse (Ljava/lang/String;Lcom/adobe/marketing/mobile/ExtensionApi;)Ljava/util/List;
+}
+
+public abstract interface class com/adobe/marketing/mobile/plugin/IAepPlugin {
+}
+
+public abstract interface class com/adobe/marketing/mobile/plugin/ILiveupdatePlugin : com/adobe/marketing/mobile/plugin/IAepPlugin {
+	public abstract fun handleLiveUpdatePush (Landroid/content/Context;Ljava/lang/Object;)V
+}
+
+public abstract interface class com/adobe/marketing/mobile/plugin/IUiTemplatePlugin : com/adobe/marketing/mobile/plugin/IAepPlugin {
 }
 
 public class com/adobe/marketing/mobile/rulesengine/ComparisonExpression : com/adobe/marketing/mobile/rulesengine/Evaluable {

--- a/code/core/api/core.api
+++ b/code/core/api/core.api
@@ -436,6 +436,7 @@ public abstract interface class com/adobe/marketing/mobile/plugin/ILiveupdatePlu
 }
 
 public abstract interface class com/adobe/marketing/mobile/plugin/IUiTemplatePlugin : com/adobe/marketing/mobile/plugin/IAepPlugin {
+	public abstract fun buildPushTemplateNotification (Landroid/content/Context;Ljava/util/Map;Ljava/lang/Class;Ljava/lang/Class;)Landroid/app/Notification;
 }
 
 public class com/adobe/marketing/mobile/rulesengine/ComparisonExpression : com/adobe/marketing/mobile/rulesengine/Evaluable {

--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/CoreConstants.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/CoreConstants.kt
@@ -13,7 +13,7 @@ package com.adobe.marketing.mobile.internal
 
 internal object CoreConstants {
     const val LOG_TAG = "MobileCore"
-    const val VERSION = "3.8.0"
+    const val VERSION = "3.8.1"
 
     object EventDataKeys {
         /**

--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/PluginRegistry.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/PluginRegistry.kt
@@ -1,0 +1,42 @@
+/*
+  Copyright 2026 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+package com.adobe.marketing.mobile.internal
+
+import com.adobe.marketing.mobile.plugin.IAepPlugin
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Process-wide holder for registered [IAepPlugin] implementations. Not public API - access goes
+ * through the [com.adobe.marketing.mobile.MobileCore] facade (`addPlugins` / `getPlugin`).
+ *
+ * Thread-safe: registration and resolution may race with inbound work such as push handling.
+ */
+object PluginRegistry {
+
+    private val plugins = CopyOnWriteArrayList<IAepPlugin>()
+
+    /** Registers a plugin. Idempotent per instance; registration order is preserved. */
+    fun addPlugin(plugin: IAepPlugin) {
+        plugins.addIfAbsent(plugin)
+    }
+
+    /**
+     * @return the first registered plugin assignable to [type], or `null` when none is registered.
+     */
+    fun <T : IAepPlugin> getPlugin(type: Class<T>): T? {
+        for (plugin in plugins) {
+            if (type.isInstance(plugin)) {
+                return type.cast(plugin)
+            }
+        }
+        return null
+    }
+}

--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/PluginRegistry.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/PluginRegistry.kt
@@ -8,6 +8,7 @@
   OF ANY KIND, either express or implied. See the License for the specific language
   governing permissions and limitations under the License.
 */
+
 package com.adobe.marketing.mobile.internal
 
 import com.adobe.marketing.mobile.plugin.IAepPlugin

--- a/code/core/src/main/java/com/adobe/marketing/mobile/plugin/IAepPlugin.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/plugin/IAepPlugin.kt
@@ -8,6 +8,7 @@
   OF ANY KIND, either express or implied. See the License for the specific language
   governing permissions and limitations under the License.
 */
+
 package com.adobe.marketing.mobile.plugin
 
 /**

--- a/code/core/src/main/java/com/adobe/marketing/mobile/plugin/IAepPlugin.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/plugin/IAepPlugin.kt
@@ -1,0 +1,19 @@
+/*
+  Copyright 2026 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+package com.adobe.marketing.mobile.plugin
+
+/**
+ * Marker interface for an AEP plugin: an optional capability implemented in a separate module and
+ * registered with the SDK via [com.adobe.marketing.mobile.MobileCore.addPlugins]. Specific plugin
+ * contracts (for example [ILiveupdatePlugin], [IUiTemplatePlugin]) extend this marker and declare
+ * meaningful, domain-specific methods.
+ */
+interface IAepPlugin

--- a/code/core/src/main/java/com/adobe/marketing/mobile/plugin/ILiveupdatePlugin.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/plugin/ILiveupdatePlugin.kt
@@ -1,0 +1,32 @@
+/*
+  Copyright 2026 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+package com.adobe.marketing.mobile.plugin
+
+import android.content.Context
+
+/**
+ * Plugin contract for handling a Live Update push.
+ *
+ * The push message is passed as [Any] so the platform push object (for example a Firebase
+ * `RemoteMessage`) can be forwarded from the host SDK through Core untouched - no bundling or
+ * unbundling into a map. The implementing add-on casts it back to the concrete type it expects.
+ */
+interface ILiveupdatePlugin : IAepPlugin {
+
+    /**
+     * Handles a Live Update push. Invoked by the host SDK when a Live Update payload is detected.
+     *
+     * @param context the application [Context]
+     * @param message the platform push message (for example a Firebase `RemoteMessage`), passed as
+     *     [Any] to avoid any conversion; the implementation casts it to the type it expects.
+     */
+    fun handleLiveUpdatePush(context: Context, message: Any)
+}

--- a/code/core/src/main/java/com/adobe/marketing/mobile/plugin/ILiveupdatePlugin.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/plugin/ILiveupdatePlugin.kt
@@ -8,6 +8,7 @@
   OF ANY KIND, either express or implied. See the License for the specific language
   governing permissions and limitations under the License.
 */
+
 package com.adobe.marketing.mobile.plugin
 
 import android.content.Context

--- a/code/core/src/main/java/com/adobe/marketing/mobile/plugin/IUiTemplatePlugin.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/plugin/IUiTemplatePlugin.kt
@@ -1,0 +1,19 @@
+/*
+  Copyright 2026 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+package com.adobe.marketing.mobile.plugin
+
+/**
+ * Plugin contract for UI template (push template) rendering.
+ *
+ * Intentionally empty for now; the required methods will be added in a later phase once the UI
+ * template capability is designed.
+ */
+interface IUiTemplatePlugin : IAepPlugin

--- a/code/core/src/main/java/com/adobe/marketing/mobile/plugin/IUiTemplatePlugin.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/plugin/IUiTemplatePlugin.kt
@@ -10,10 +10,41 @@
 */
 package com.adobe.marketing.mobile.plugin
 
+import android.app.Activity
+import android.app.Notification
+import android.content.BroadcastReceiver
+import android.content.Context
+
 /**
- * Plugin contract for UI template (push template) rendering.
+ * Plugin contract for rendering an out-of-the-box push-template notification (carousel, basic,
+ * input-box, timer, etc.).
  *
- * Intentionally empty for now; the required methods will be added in a later phase once the UI
- * template capability is designed.
+ * The contract uses only platform-framework types ([Context], [Notification], [Activity],
+ * [BroadcastReceiver], [Map]) so a host SDK on the floor toolchain can hold this reference while the
+ * implementing add-on (for example {@code aepsdk-ui-android}'s {@code notificationbuilder}) lives in
+ * its own module and depends only on Core. No androidx or Firebase type appears in Core's API.
+ *
+ * Unlike the live-activity plugin, the template plugin only **builds** the notification and returns
+ * it; the host SDK owns posting and tracking. This keeps the UI add-on free of any dependency on the
+ * host SDK.
  */
-interface IUiTemplatePlugin : IAepPlugin
+interface IUiTemplatePlugin : IAepPlugin {
+
+    /**
+     * Builds a push-template notification from the FCM data map.
+     *
+     * @param context the application [Context]
+     * @param messageData the push message data (from {@code RemoteMessage.getData()}); the template
+     *     type is read from the app-defined template-type key within it
+     * @param trackerActivityClass the host's tracker [Activity] used for tap/click intents, if any
+     * @param broadcastReceiverClass the host's [BroadcastReceiver] used for action/dismiss intents, if any
+     * @return the built [Notification], or {@code null} if the payload cannot be rendered (the caller
+     *     falls back to a basic notification)
+     */
+    fun buildPushTemplateNotification(
+        context: Context,
+        messageData: Map<String, String>,
+        trackerActivityClass: Class<out Activity>?,
+        broadcastReceiverClass: Class<out BroadcastReceiver>?
+    ): Notification?
+}

--- a/code/core/src/main/java/com/adobe/marketing/mobile/plugin/IUiTemplatePlugin.kt
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/plugin/IUiTemplatePlugin.kt
@@ -8,6 +8,7 @@
   OF ANY KIND, either express or implied. See the License for the specific language
   governing permissions and limitations under the License.
 */
+
 package com.adobe.marketing.mobile.plugin
 
 import android.app.Activity

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
@@ -1019,8 +1019,8 @@ public final class MobileCore {
     /**
      * Registers one or more {@link IAepPlugin} implementations with the SDK. Plugins are optional
      * capabilities (for example Live Updates) implemented in separate modules and resolved at
-     * runtime by type. Replaces capability-specific setters such as the former
-     * {@code Messaging.setLiveUpdateHandler(...)}.
+     * runtime by type. Replaces capability-specific setters such as the former {@code
+     * Messaging.setLiveUpdateHandler(...)}.
      *
      * @param plugins the plugins to register
      */

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/MobileCore.java
@@ -20,8 +20,10 @@ import androidx.annotation.VisibleForTesting;
 import com.adobe.marketing.mobile.internal.AppResourceStore;
 import com.adobe.marketing.mobile.internal.CoreConstants;
 import com.adobe.marketing.mobile.internal.DataMarshaller;
+import com.adobe.marketing.mobile.internal.PluginRegistry;
 import com.adobe.marketing.mobile.internal.eventhub.EventHub;
 import com.adobe.marketing.mobile.internal.eventhub.EventHubConstants;
+import com.adobe.marketing.mobile.plugin.IAepPlugin;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.services.ServiceProvider;
 import com.adobe.marketing.mobile.util.DataReader;
@@ -1008,6 +1010,44 @@ public final class MobileCore {
                         .setEventData(eventData)
                         .build();
         dispatchEvent(event);
+    }
+
+    // ========================================================
+    // Plugins
+    // ========================================================
+
+    /**
+     * Registers one or more {@link IAepPlugin} implementations with the SDK. Plugins are optional
+     * capabilities (for example Live Updates) implemented in separate modules and resolved at
+     * runtime by type. Replaces capability-specific setters such as the former
+     * {@code Messaging.setLiveUpdateHandler(...)}.
+     *
+     * @param plugins the plugins to register
+     */
+    public static void addPlugins(@NonNull final IAepPlugin... plugins) {
+        if (plugins == null) {
+            return;
+        }
+        for (final IAepPlugin plugin : plugins) {
+            if (plugin != null) {
+                PluginRegistry.INSTANCE.addPlugin(plugin);
+            }
+        }
+    }
+
+    /**
+     * Returns the registered plugin assignable to the given contract type, or {@code null} if none
+     * is registered.
+     *
+     * @param type the plugin contract type (for example {@code ILiveupdatePlugin.class})
+     * @param <T> the plugin contract type
+     * @return the registered plugin, or {@code null}
+     */
+    @Nullable public static <T extends IAepPlugin> T getPlugin(@NonNull final Class<T> type) {
+        if (type == null) {
+            return null;
+        }
+        return PluginRegistry.INSTANCE.getPlugin(type);
     }
 
     @VisibleForTesting

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -5,7 +5,7 @@ android.useAndroidX=true
 
 #Maven artifacts
 #Core extension
-coreExtensionVersion=3.8.0
+coreExtensionVersion=5.0.0-SNAPSHOT
 coreExtensionName=core
 coreMavenRepoName=AdobeMobileCoreSdk
 coreMavenRepoDescription=Android Core Extension for Adobe Mobile Marketing

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -5,7 +5,7 @@ android.useAndroidX=true
 
 #Maven artifacts
 #Core extension
-coreExtensionVersion=5.0.0-SNAPSHOT
+coreExtensionVersion=3.8.1
 coreExtensionName=core
 coreMavenRepoName=AdobeMobileCoreSdk
 coreMavenRepoDescription=Android Core Extension for Adobe Mobile Marketing


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Introduces a plugin mechanism in Core so optional capabilities can live in separate modules instead of being baked into Core or bundled through capability-specific setters.

- Adds `IAepPlugin`, a marker interface for an AEP plugin.
- Adds `ILiveupdatePlugin : IAepPlugin` with `handleLiveUpdatePush(Context, Any)`. The push message is passed as `Any` so the platform push object (for example a Firebase `RemoteMessage`) is forwarded from the host SDK through Core untouched, with no bundling or unbundling into a map.
- Adds `IUiTemplatePlugin : IAepPlugin` with `buildPushTemplateNotification(Context, Map<String, String>, Class<out Activity>?, Class<out BroadcastReceiver>?): Notification?` for rendering out-of-the-box push-template notifications (carousel, basic, input-box, timer, etc.). The contract only uses platform-framework types (`Context`, `Notification`, `Activity`, `BroadcastReceiver`, `Map`) so Core stays free of androidx and Firebase dependencies. The plugin only builds the notification; the host SDK owns posting and tracking.
- Adds an internal `PluginRegistry` (thread-safe via `CopyOnWriteArrayList`) that stores registered plugins and resolves them by type.
- Adds `MobileCore.addPlugins(IAepPlugin...)` and `MobileCore.getPlugin(Class<T>)` as the public entry points for registering and resolving plugins.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Downstream SDKs (starting with Messaging) currently expose capability-specific setters, such as the former `Messaging.setLiveUpdateHandler(...)`, to let host apps plug in UI or live-update behavior. A generic plugin registry in Core replaces that pattern with a single, extensible mechanism: any add-on module can implement a typed plugin contract and register it via `MobileCore.addPlugins`, and Core (or another SDK) can resolve it via `MobileCore.getPlugin(Class)` without Core taking a compile-time dependency on that module.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
