### PR TITLE
refactor: refactored log statements

### DIFF
--- a/code/core/src/main/java/com/adobe/marketing/mobile/internal/util/SQLiteDatabaseHelper.java
+++ b/code/core/src/main/java/com/adobe/marketing/mobile/internal/util/SQLiteDatabaseHelper.java
@@ -43,10 +43,10 @@ public class SQLiteDatabaseHelper {
             Log.warning(
                     CoreConstants.LOG_TAG,
                     LOG_PREFIX,
-                    String.format(
-                            "createTableIfNotExists - Error in creating/accessing database (%s)."
-                                    + "Error: (%s)",
-                            dbPath, e.getMessage()));
+                    "createTableIfNotExists - Error in creating/accessing database (%s)."
+                            + "Error: (%s)",
+                    dbPath,
+                    e.getMessage());
             return false;
         } finally {
             closeDatabase(database);
@@ -72,10 +72,11 @@ public class SQLiteDatabaseHelper {
             Log.warning(
                     CoreConstants.LOG_TAG,
                     LOG_PREFIX,
-                    String.format(
-                            "getTableSize - Error in querying table(%s) size from database(%s)."
-                                    + "Returning 0. Error: (%s)",
-                            tableName, dbPath, e.getMessage()));
+                    "getTableSize - Error in querying table(%s) size from database(%s)."
+                            + "Returning 0. Error: (%s)",
+                    tableName,
+                    dbPath,
+                    e.getMessage());
             return 0;
         } finally {
             closeDatabase(database);
@@ -100,10 +101,11 @@ public class SQLiteDatabaseHelper {
             Log.warning(
                     CoreConstants.LOG_TAG,
                     LOG_PREFIX,
-                    String.format(
-                            "clearTable - Error in clearing table(%s) from database(%s)."
-                                    + "Returning false. Error: (%s)",
-                            tableName, dbPath, e.getMessage()));
+                    "clearTable - Error in clearing table(%s) from database(%s)."
+                            + "Returning false. Error: (%s)",
+                    tableName,
+                    dbPath,
+                    e.getMessage());
             return false;
         } finally {
             closeDatabase(database);
@@ -161,8 +163,8 @@ public class SQLiteDatabaseHelper {
         Log.trace(
                 CoreConstants.LOG_TAG,
                 LOG_PREFIX,
-                String.format(
-                        "openDatabase - Successfully opened the database at path (%s)", filePath));
+                "openDatabase - Successfully opened the database at path (%s)",
+                filePath);
         return database;
     }
 

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/DeviceInfoService.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/DeviceInfoService.java
@@ -300,9 +300,9 @@ class DeviceInfoService implements DeviceInforming {
             Log.debug(
                     ServiceConstants.LOG_TAG,
                     LOG_TAG,
-                    String.format(
-                            "%s (Resources), unable to read (%s) from the the assets folder.",
-                            UNEXPECTED_NULL_VALUE, fileName));
+                    "%s (Resources), unable to read (%s) from the the assets folder.",
+                    UNEXPECTED_NULL_VALUE,
+                    fileName);
             return null;
         }
 
@@ -312,9 +312,9 @@ class DeviceInfoService implements DeviceInforming {
             Log.debug(
                     ServiceConstants.LOG_TAG,
                     LOG_TAG,
-                    String.format(
-                            "%s (AssetManager), unable to read (%s) from the the assets folder.",
-                            UNEXPECTED_NULL_VALUE, fileName));
+                    "%s (AssetManager), unable to read (%s) from the the assets folder.",
+                    UNEXPECTED_NULL_VALUE,
+                    fileName);
             return null;
         }
 
@@ -324,8 +324,9 @@ class DeviceInfoService implements DeviceInforming {
             Log.debug(
                     ServiceConstants.LOG_TAG,
                     LOG_TAG,
-                    String.format(
-                            "Unable to read (%s) from the the assets folder. (%s)", fileName, e));
+                    "Unable to read (%s) from the the assets folder. (%s)",
+                    fileName,
+                    e);
         }
 
         return inputStream;
@@ -347,9 +348,9 @@ class DeviceInfoService implements DeviceInforming {
             Log.debug(
                     ServiceConstants.LOG_TAG,
                     LOG_TAG,
-                    String.format(
-                            "%s (Package Manager), unable to read property for key (%s).",
-                            UNEXPECTED_NULL_VALUE, propertyKey));
+                    "%s (Package Manager), unable to read property for key (%s).",
+                    UNEXPECTED_NULL_VALUE,
+                    propertyKey);
             return null;
         }
 
@@ -362,9 +363,9 @@ class DeviceInfoService implements DeviceInforming {
                 Log.debug(
                         ServiceConstants.LOG_TAG,
                         LOG_TAG,
-                        String.format(
-                                "%s (Application info), unable to read property for key (%s).",
-                                UNEXPECTED_NULL_VALUE, propertyKey));
+                        "%s (Application info), unable to read property for key (%s).",
+                        UNEXPECTED_NULL_VALUE,
+                        propertyKey);
                 return null;
             }
 
@@ -374,10 +375,10 @@ class DeviceInfoService implements DeviceInforming {
                 Log.debug(
                         ServiceConstants.LOG_TAG,
                         LOG_TAG,
-                        String.format(
-                                "%s (ApplicationInfo's metaData), unable to read property for key"
-                                        + " (%s).",
-                                UNEXPECTED_NULL_VALUE, propertyKey));
+                        "%s (ApplicationInfo's metaData), unable to read property for key"
+                                + " (%s).",
+                        UNEXPECTED_NULL_VALUE,
+                        propertyKey);
                 return null;
             }
 
@@ -387,9 +388,9 @@ class DeviceInfoService implements DeviceInforming {
             Log.debug(
                     ServiceConstants.LOG_TAG,
                     LOG_TAG,
-                    String.format(
-                            "Unable to read property for key (%s). Exception - (%s)",
-                            propertyKey, e));
+                    "Unable to read property for key (%s). Exception - (%s)",
+                    propertyKey,
+                    e);
         }
 
         return propertyValue;
@@ -423,7 +424,8 @@ class DeviceInfoService implements DeviceInforming {
             Log.debug(
                     ServiceConstants.LOG_TAG,
                     LOG_TAG,
-                    String.format("PackageManager couldn't find application name (%s)", e));
+                    "PackageManager couldn't find application name (%s)",
+                    e);
         }
 
         return appName;
@@ -470,7 +472,8 @@ class DeviceInfoService implements DeviceInforming {
                 Log.debug(
                         ServiceConstants.LOG_TAG,
                         LOG_TAG,
-                        String.format("Failed to get app version code, (%s)", e));
+                        "Failed to get app version code, (%s)",
+                        e);
             }
         } else {
             versionCode = packageInfo.versionCode;
@@ -579,9 +582,8 @@ class DeviceInfoService implements DeviceInforming {
             Log.debug(
                     ServiceConstants.LOG_TAG,
                     LOG_TAG,
-                    String.format(
-                            "PackageManager couldn't find application version (%s)",
-                            e.getLocalizedMessage()));
+                    "PackageManager couldn't find application version (%s)",
+                    e.getLocalizedMessage());
             return null;
         }
     }

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/HttpConnection.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/HttpConnection.java
@@ -46,14 +46,10 @@ class HttpConnection implements HttpConnecting {
             Log.warning(
                     ServiceConstants.LOG_TAG,
                     TAG,
-                    String.format(
-                            "Could not get the input stream, protocol does not support input. (%s)",
-                            e));
+                    "Could not get the input stream, protocol does not support input. (%s)",
+                    e);
         } catch (final Exception | Error e) {
-            Log.warning(
-                    ServiceConstants.LOG_TAG,
-                    TAG,
-                    String.format("Could not get the input stream. (%s)", e));
+            Log.warning(ServiceConstants.LOG_TAG, TAG, "Could not get the input stream. (%s)", e);
         }
 
         return null;
@@ -70,10 +66,7 @@ class HttpConnection implements HttpConnecting {
         try {
             return httpUrlConnection.getErrorStream();
         } catch (final Exception | Error e) {
-            Log.warning(
-                    ServiceConstants.LOG_TAG,
-                    TAG,
-                    String.format("Could not get the input stream. (%s)", e));
+            Log.warning(ServiceConstants.LOG_TAG, TAG, "Could not get the input stream. (%s)", e);
         }
 
         return null;
@@ -92,10 +85,7 @@ class HttpConnection implements HttpConnecting {
         try {
             return httpUrlConnection.getResponseCode();
         } catch (final Exception | Error e) {
-            Log.warning(
-                    ServiceConstants.LOG_TAG,
-                    TAG,
-                    String.format("Could not get response code. (%s)", e));
+            Log.warning(ServiceConstants.LOG_TAG, TAG, "Could not get response code. (%s)", e);
         }
 
         return -1;
@@ -115,9 +105,7 @@ class HttpConnection implements HttpConnecting {
             return httpUrlConnection.getResponseMessage();
         } catch (final Exception | Error e) {
             Log.warning(
-                    ServiceConstants.LOG_TAG,
-                    TAG,
-                    String.format("Could not get the response message. (%s)", e));
+                    ServiceConstants.LOG_TAG, TAG, "Could not get the response message. (%s)", e);
         }
 
         return null;
@@ -155,9 +143,7 @@ class HttpConnection implements HttpConnecting {
                 inputStream.close();
             } catch (final Exception | Error e) {
                 Log.warning(
-                        ServiceConstants.LOG_TAG,
-                        TAG,
-                        String.format("Could not close the input stream. (%s)", e));
+                        ServiceConstants.LOG_TAG, TAG, "Could not close the input stream. (%s)", e);
             }
         }
         if (errorStream != null) {
@@ -165,9 +151,7 @@ class HttpConnection implements HttpConnecting {
                 errorStream.close();
             } catch (final Exception | Error e) {
                 Log.warning(
-                        ServiceConstants.LOG_TAG,
-                        TAG,
-                        String.format("Could not close the error stream. (%s)", e));
+                        ServiceConstants.LOG_TAG, TAG, "Could not close the error stream. (%s)", e);
             }
         }
 

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/HttpConnectionHandler.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/HttpConnectionHandler.java
@@ -107,22 +107,16 @@ class HttpConnectionHandler {
             Log.warning(
                     ServiceConstants.LOG_TAG,
                     TAG,
-                    String.format("%s is not a valid HTTP command (%s)!", command, e));
+                    "%s is not a valid HTTP command (%s)!",
+                    command,
+                    e);
         } catch (final IllegalStateException e) {
-            Log.warning(
-                    ServiceConstants.LOG_TAG,
-                    TAG,
-                    String.format("Cannot set command after connect (%s)!", e));
+            Log.warning(ServiceConstants.LOG_TAG, TAG, "Cannot set command after connect (%s)!", e);
         } catch (final IllegalArgumentException e) {
             Log.warning(
-                    ServiceConstants.LOG_TAG,
-                    TAG,
-                    String.format("%s command is not supported (%s)!", command, e));
+                    ServiceConstants.LOG_TAG, TAG, "%s command is not supported (%s)!", command, e);
         } catch (final Exception | Error e) {
-            Log.warning(
-                    ServiceConstants.LOG_TAG,
-                    TAG,
-                    String.format("Failed to set http command (%s)!", e));
+            Log.warning(ServiceConstants.LOG_TAG, TAG, "Failed to set http command (%s)!", e);
         }
 
         return false;
@@ -151,13 +145,12 @@ class HttpConnectionHandler {
                 Log.warning(
                         ServiceConstants.LOG_TAG,
                         TAG,
-                        String.format("Cannot set header field after connect (%s)!", e));
+                        "Cannot set header field after connect (%s)!",
+                        e);
                 return;
             } catch (final Exception | Error e) {
                 Log.warning(
-                        ServiceConstants.LOG_TAG,
-                        TAG,
-                        String.format("Failed to set request property (%s)!", e));
+                        ServiceConstants.LOG_TAG, TAG, "Failed to set request property (%s)!", e);
             }
         }
     }
@@ -175,12 +168,10 @@ class HttpConnectionHandler {
             Log.warning(
                     ServiceConstants.LOG_TAG,
                     TAG,
-                    String.format(connectTimeout + " is not valid timeout value (%s)", e));
+                    connectTimeout + " is not valid timeout value (%s)",
+                    e);
         } catch (final Exception | Error e) {
-            Log.warning(
-                    ServiceConstants.LOG_TAG,
-                    TAG,
-                    String.format("Failed to set connection timeout (%s)!", e));
+            Log.warning(ServiceConstants.LOG_TAG, TAG, "Failed to set connection timeout (%s)!", e);
         }
     }
 
@@ -197,12 +188,10 @@ class HttpConnectionHandler {
             Log.warning(
                     ServiceConstants.LOG_TAG,
                     TAG,
-                    String.format(readTimeout + " is not valid timeout value (%s)", e));
+                    readTimeout + " is not valid timeout value (%s)",
+                    e);
         } catch (final Exception | Error e) {
-            Log.warning(
-                    ServiceConstants.LOG_TAG,
-                    TAG,
-                    String.format("Failed to set read timeout (%s)!", e));
+            Log.warning(ServiceConstants.LOG_TAG, TAG, "Failed to set read timeout (%s)!", e);
         }
     }
 
@@ -220,12 +209,9 @@ class HttpConnectionHandler {
         Log.debug(
                 ServiceConstants.LOG_TAG,
                 TAG,
-                String.format(
-                        "Connecting to URL %s (%s)",
-                        (httpsUrlConnection.getURL() == null
-                                ? ""
-                                : httpsUrlConnection.getURL().toString()),
-                        command.toString()));
+                "Connecting to URL %s (%s)",
+                (httpsUrlConnection.getURL() == null ? "" : httpsUrlConnection.getURL().toString()),
+                command.toString());
 
         // If the command to be used is POST, set the length before connection
         if (command == Command.POST && payload != null) {
@@ -246,20 +232,15 @@ class HttpConnectionHandler {
             }
         } catch (final SocketTimeoutException e) {
             Log.warning(
-                    ServiceConstants.LOG_TAG,
-                    TAG,
-                    String.format("Connection failure, socket timeout (%s)", e));
+                    ServiceConstants.LOG_TAG, TAG, "Connection failure, socket timeout (%s)", e);
         } catch (final IOException e) {
             Log.warning(
                     ServiceConstants.LOG_TAG,
                     TAG,
-                    String.format(
-                            "Connection failure (%s)",
-                            (e.getLocalizedMessage() != null
-                                    ? e.getLocalizedMessage()
-                                    : e.getMessage())));
+                    "Connection failure (%s)",
+                    (e.getLocalizedMessage() != null ? e.getLocalizedMessage() : e.getMessage()));
         } catch (final Exception | Error e) {
-            Log.warning(ServiceConstants.LOG_TAG, TAG, String.format("Connection failure (%s)", e));
+            Log.warning(ServiceConstants.LOG_TAG, TAG, "Connection failure (%s)", e);
         }
 
         // Create a connection object here

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/LocalDataStoreService.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/LocalDataStoreService.java
@@ -25,10 +25,9 @@ class LocalDataStoreService implements DataStoring {
             Log.error(
                     ServiceConstants.LOG_TAG,
                     TAG,
-                    String.format(
-                            "Failed to create an instance of NamedCollection with name - %s: the"
-                                    + " collection name is null or empty.",
-                            collectionName));
+                    "Failed to create an instance of NamedCollection with name - %s: the"
+                            + " collection name is null or empty.",
+                    collectionName);
             return null;
         }
 
@@ -39,10 +38,9 @@ class LocalDataStoreService implements DataStoring {
             Log.error(
                     ServiceConstants.LOG_TAG,
                     TAG,
-                    String.format(
-                            "Failed to create an instance of NamedCollection with name - %s: the"
-                                    + " ApplicationContext is null",
-                            collectionName));
+                    "Failed to create an instance of NamedCollection with name - %s: the"
+                            + " ApplicationContext is null",
+                    collectionName);
             return null;
         }
 

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/NetworkService.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/NetworkService.java
@@ -90,12 +90,9 @@ class NetworkService implements Networking {
             Log.warning(
                     ServiceConstants.LOG_TAG,
                     TAG,
-                    String.format(
-                            "Failed to send request for (%s) [%s]",
-                            request.getUrl(),
-                            (e.getLocalizedMessage() != null
-                                    ? e.getLocalizedMessage()
-                                    : e.getMessage())));
+                    "Failed to send request for (%s) [%s]",
+                    request.getUrl(),
+                    (e.getLocalizedMessage() != null ? e.getLocalizedMessage() : e.getMessage()));
 
             if (callback != null) {
                 callback.call(null);
@@ -122,9 +119,8 @@ class NetworkService implements Networking {
             Log.warning(
                     ServiceConstants.LOG_TAG,
                     TAG,
-                    String.format(
-                            "Invalid URL (%s), only HTTPS protocol is supported",
-                            request.getUrl()));
+                    "Invalid URL (%s), only HTTPS protocol is supported",
+                    request.getUrl());
             return null;
         }
 
@@ -159,20 +155,20 @@ class NetworkService implements Networking {
                     Log.warning(
                             ServiceConstants.LOG_TAG,
                             TAG,
-                            String.format(
-                                    "Could not create a connection to URL (%s) [%s]",
-                                    request.getUrl(),
-                                    (e.getLocalizedMessage() != null
-                                            ? e.getLocalizedMessage()
-                                            : e.getMessage())));
+                            "Could not create a connection to URL (%s) [%s]",
+                            request.getUrl(),
+                            (e.getLocalizedMessage() != null
+                                    ? e.getLocalizedMessage()
+                                    : e.getMessage()));
                 }
             }
         } catch (final MalformedURLException e) {
             Log.warning(
                     ServiceConstants.LOG_TAG,
                     TAG,
-                    String.format(
-                            "Could not connect, invalid URL (%s) [%s]!!", request.getUrl(), e));
+                    "Could not connect, invalid URL (%s) [%s]!!",
+                    request.getUrl(),
+                    e);
         }
 
         return connection;

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/SQLiteDataQueue.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/SQLiteDataQueue.java
@@ -121,18 +121,15 @@ final class SQLiteDataQueue implements DataQueue {
                             Log.trace(
                                     ServiceConstants.LOG_TAG,
                                     LOG_PREFIX,
-                                    String.format(
-                                            "query - Successfully read %d rows from table.",
-                                            rows.size()));
+                                    "query - Successfully read %d rows from table.",
+                                    rows.size());
                             return true;
                         } catch (final SQLiteException e) {
                             Log.warning(
                                     ServiceConstants.LOG_TAG,
                                     LOG_PREFIX,
-                                    String.format(
-                                            "query - Error in querying database table. Error:"
-                                                    + " (%s)",
-                                            e.getLocalizedMessage()));
+                                    "query - Error in querying database table. Error:" + " (%s)",
+                                    e.getLocalizedMessage());
                             return false;
                         }
                     });
@@ -151,8 +148,8 @@ final class SQLiteDataQueue implements DataQueue {
         Log.trace(
                 ServiceConstants.LOG_TAG,
                 LOG_PREFIX,
-                String.format(
-                        "peek n - Successfully returned %d DataEntities", dataEntitiesList.size()));
+                "peek n - Successfully returned %d DataEntities",
+                dataEntitiesList.size());
         return dataEntitiesList;
     }
 
@@ -179,9 +176,8 @@ final class SQLiteDataQueue implements DataQueue {
         Log.trace(
                 ServiceConstants.LOG_TAG,
                 LOG_PREFIX,
-                String.format(
-                        "peek - Successfully returned DataEntity (%s)",
-                        dataEntities.get(0).toString()));
+                "peek - Successfully returned DataEntity (%s)",
+                dataEntities.get(0));
         return dataEntities.get(0);
     }
 
@@ -225,18 +221,16 @@ final class SQLiteDataQueue implements DataQueue {
                                     Log.trace(
                                             ServiceConstants.LOG_TAG,
                                             LOG_PREFIX,
-                                            String.format(
-                                                    "remove n - Removed %d DataEntities",
-                                                    deletedRowsCount));
+                                            "remove n - Removed %d DataEntities",
+                                            deletedRowsCount);
                                     return deletedRowsCount > -1;
                                 } catch (final SQLiteException e) {
                                     Log.warning(
                                             ServiceConstants.LOG_TAG,
                                             LOG_PREFIX,
-                                            String.format(
-                                                    "removeRows - Error in deleting rows from"
-                                                            + " table. Returning 0. Error: (%s)",
-                                                    e.getMessage()));
+                                            "removeRows - Error in deleting rows from"
+                                                    + " table. Returning 0. Error: (%s)",
+                                            e.getMessage());
                                     return false;
                                 }
                             });
@@ -269,8 +263,8 @@ final class SQLiteDataQueue implements DataQueue {
             Log.trace(
                     ServiceConstants.LOG_TAG,
                     LOG_PREFIX,
-                    String.format(
-                            "clear - %s in clearing table", (result ? "Successful" : "Failed")));
+                    "clear - %s in clearing table",
+                    (result ? "Successful" : "Failed"));
 
             if (!result) {
                 resetDatabase();

--- a/code/core/src/phone/java/com/adobe/marketing/mobile/services/SharedPreferencesNamedCollection.java
+++ b/code/core/src/phone/java/com/adobe/marketing/mobile/services/SharedPreferencesNamedCollection.java
@@ -139,18 +139,18 @@ class SharedPreferencesNamedCollection implements NamedCollection {
                     Log.error(
                             ServiceConstants.LOG_TAG,
                             TAG,
-                            String.format(
-                                    "Unable to convert jsonObject key %s into map, %s",
-                                    keyName, jsonException.getLocalizedMessage()));
+                            "Unable to convert jsonObject key %s into map, %s",
+                            keyName,
+                            jsonException.getLocalizedMessage());
                 }
             }
         } catch (Exception e) {
             Log.error(
                     ServiceConstants.LOG_TAG,
                     TAG,
-                    String.format(
-                            "Failed to convert [%s] to String Map, %s",
-                            mapJsonString, e.getLocalizedMessage()));
+                    "Failed to convert [%s] to String Map, %s",
+                    mapJsonString,
+                    e.getLocalizedMessage());
             map = null;
         }
 


### PR DESCRIPTION
While looking into https://github.com/adobe/aepsdk-core-android/issues/806, I noticed the same pattern all over the core services: log messages get built with String.format right at the call site, so the string (and any toString()) is created even when that log level is turned off.

This PR moves all of those calls to Log's varargs overload, so the format string and its arguments are passed straight through and only formatted if the log level is actually enabled. That covers the peek() case from the issue plus 50 other spots across 8 files.

It's a mechanical change, no behavior or log output change; just less wasted work on the hot path.

I ran spotlessCheck, compiled :core, and all 1143 core unit tests pass. Closes https://github.com/adobe/aepsdk-core-android/issues/806